### PR TITLE
feat: add timeline close-gap and per-clip split actions

### DIFF
--- a/i18n/drift.ts
+++ b/i18n/drift.ts
@@ -1595,6 +1595,10 @@
         <source>Export complete</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Close gap</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -5985,6 +5989,10 @@ Quality: renders and shows every single frame, silently and slower than real tim
         <source>Drag to trim the end</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Split item at current time</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TimelinePanel</name>
@@ -6050,6 +6058,10 @@ Quality: renders and shows every single frame, silently and slower than real tim
     </message>
     <message>
         <source>Clip name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close Gap</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/i18n/drift_si.ts
+++ b/i18n/drift_si.ts
@@ -1595,6 +1595,10 @@
         <source>Export complete</source>
         <translation>නිර්යාත කිරීම සම්පූර්ණයි</translation>
     </message>
+    <message>
+        <source>Close gap</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -5990,6 +5994,10 @@ Quality: තථ්‍ය කාලයට වඩා සෙමින්, ශබ්
         <source>Drag to trim the end</source>
         <translation>අවසානය කප්පාදු කිරීමට අදින්න</translation>
     </message>
+    <message>
+        <source>Split item at current time</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TimelinePanel</name>
@@ -6056,6 +6064,10 @@ Quality: තථ්‍ය කාලයට වඩා සෙමින්, ශබ්
     <message>
         <source>Clip name</source>
         <translation>ක්ලිප් නම</translation>
+    </message>
+    <message>
+        <source>Close Gap</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/scripts/sync-lucide-icons.sh
+++ b/scripts/sync-lucide-icons.sh
@@ -27,6 +27,8 @@ icons=(
   message-square moon sun grid-3x3 list arrow-down-a-z grip-vertical
   # Fit timeline in view (manual zoom calibration)
   chevrons-left-right-ellipsis
+  # Close a timeline gap (arrows collapsing toward each other)
+  chevrons-right-left
   save arrow-right-to-line arrow-left-to-line tags blend option square-dashed puzzle info
   # Project bundle: package/properties entries in the project menu
   package file-text

--- a/src/models/AppController.cpp
+++ b/src/models/AppController.cpp
@@ -2906,6 +2906,49 @@ void AppController::moveClip(int trackIndex, int clipIndex, double newStart)
     finishEdit(tr("Clip moved"));
 }
 
+void AppController::closeGap(int trackIndex, double gapStartSeconds)
+{
+    if (trackIndex < 0 || trackIndex >= m_project.tracks().size())
+        return;
+
+    drift::Track &track = m_project.tracks()[trackIndex];
+    const drift::TimeUs gapStartUs = drift::secondsToUs(gapStartSeconds);
+
+    bool foundNext = false;
+    drift::TimeUs nextStart = 0;
+    for (const drift::Clip &clip : track.clips) {
+        if (clip.timelineStart < gapStartUs)
+            continue;
+        if (!foundNext || clip.timelineStart < nextStart) {
+            nextStart = clip.timelineStart;
+            foundNext = true;
+        }
+    }
+    if (!foundNext)
+        return;
+
+    const drift::TimeUs gapLength = nextStart - gapStartUs;
+    if (gapLength <= 0)
+        return;
+
+    const drift::Project before = m_project;
+    QSet<QString> movedIds;
+    for (drift::Clip &clip : track.clips) {
+        if (clip.timelineStart < gapStartUs)
+            continue;
+        clip.timelineStart -= gapLength;
+        movedIds.insert(clip.id);
+    }
+    for (const drift::Clip &clip : track.clips) {
+        if (!movedIds.contains(clip.id))
+            continue;
+        syncLinkedPartnersFrom(m_project, clip, movedIds);
+    }
+
+    pushProjectEdit(before, tr("Close gap"));
+    finishEdit(tr("Close gap"));
+}
+
 void AppController::splitAtPlayhead()
 {
     const drift::Project before = m_project;

--- a/src/models/AppController.cpp
+++ b/src/models/AppController.cpp
@@ -2911,6 +2911,10 @@ void AppController::closeGap(int trackIndex, double gapStartSeconds)
     if (trackIndex < 0 || trackIndex >= m_project.tracks().size())
         return;
 
+    // Snapshot before taking any non-const reference into m_project: QList is
+    // copy-on-write, and a reference grabbed first mutates the buffer the copy
+    // still shares, leaving `before` already rippled and undo a no-op.
+    const drift::Project before = m_project;
     drift::Track &track = m_project.tracks()[trackIndex];
     const drift::TimeUs gapStartUs = drift::secondsToUs(gapStartSeconds);
 
@@ -2931,7 +2935,6 @@ void AppController::closeGap(int trackIndex, double gapStartSeconds)
     if (gapLength <= 0)
         return;
 
-    const drift::Project before = m_project;
     QSet<QString> movedIds;
     for (drift::Clip &clip : track.clips) {
         if (clip.timelineStart < gapStartUs)

--- a/src/models/AppController.h
+++ b/src/models/AppController.h
@@ -635,6 +635,10 @@ public:
     Q_INVOKABLE void duplicateSelectedClip();
     Q_INVOKABLE void moveClip(int trackIndex, int clipIndex, double newStart);
     Q_INVOKABLE void moveClipToTrack(int trackIndex, int clipIndex, int newTrackIndex, double newStart);
+    // Shifts every clip on `trackIndex` starting at/after `gapStartSeconds` left by the
+    // width of the gap immediately following that position, closing it. Linked partner
+    // clips on other tracks (e.g. a companion audio clip) follow along to stay in sync.
+    Q_INVOKABLE void closeGap(int trackIndex, double gapStartSeconds);
     Q_INVOKABLE void alignSelectedClipLeft();
     Q_INVOKABLE void alignSelectedClipRight();
     Q_INVOKABLE void splitSelectedClipLeft();

--- a/src/qml/Theme.qml
+++ b/src/qml/Theme.qml
@@ -329,6 +329,7 @@ QtObject {
     readonly property var icons: ({
         scissors: "scissors",
         chevronsLeft: "chevrons-left",
+        chevronsRightLeft: "chevrons-right-left",
         undo: "undo",
         redo: "redo",
         clipboardPaste: "clipboard-paste",

--- a/src/qml/TimelinePanel.qml
+++ b/src/qml/TimelinePanel.qml
@@ -1375,7 +1375,7 @@ PanelFrame {
                                                 id: gapContextMenu
                                                 ThemedMenuItem {
                                                     text: qsTr("Close Gap")
-                                                    icon.name: Theme.icons.chevronsLeft
+                                                    icon.name: Theme.icons.chevronsRightLeft
                                                     onTriggered: EditorState.closeGap(trackRow.trackIndex,
                                                                                       gapItem.modelData.start)
                                                 }

--- a/src/qml/TimelinePanel.qml
+++ b/src/qml/TimelinePanel.qml
@@ -402,6 +402,25 @@ PanelFrame {
         return -1
     }
 
+    // Empty stretches on a track, sorted left-to-right. Gaps are never stored — they're
+    // just whatever time isn't covered by a clip — so this recomputes them from the
+    // current clip list on every call rather than caching anything.
+    function gapsForTrack(trackIndex) {
+        if (trackIndex < 0 || trackIndex >= tracks.length)
+            return []
+        const sorted = tracks[trackIndex].clips.slice().sort(function (a, b) {
+            return a.start - b.start
+        })
+        const gaps = []
+        for (var i = 0; i < sorted.length - 1; i++) {
+            const gapStart = sorted[i].start + sorted[i].duration
+            const gapEnd = sorted[i + 1].start
+            if (gapEnd > gapStart)
+                gaps.push({ start: gapStart, end: gapEnd })
+        }
+        return gaps
+    }
+
     function timelineHasClips() {
         for (var i = 0; i < tracks.length; i++) {
             if (tracks[i].clips.length > 0)
@@ -1323,6 +1342,45 @@ PanelFrame {
                                         panel: root
                                         timelineColumn: trackColumn
                                         trackIndex: trackRow.trackIndex
+                                    }
+                                }
+
+                                // Right-click a gap to ripple everything after it (and any
+                                // linked partner clips on other tracks) left to close it.
+                                Repeater {
+                                    model: root.gapsForTrack(trackRow.trackIndex)
+                                    delegate: Item {
+                                        id: gapItem
+                                        required property var modelData
+                                        x: modelData.start * root.pxPerSecond
+                                        width: (modelData.end - modelData.start) * root.pxPerSecond
+                                        height: trackRow.height
+                                        z: 1
+
+                                        Rectangle {
+                                            anchors.fill: parent
+                                            visible: gapMouse.containsMouse
+                                            color: Qt.rgba(Theme.panelAccent.r, Theme.panelAccent.g,
+                                                           Theme.panelAccent.b, 0.35)
+                                        }
+
+                                        MouseArea {
+                                            id: gapMouse
+                                            anchors.fill: parent
+                                            hoverEnabled: true
+                                            acceptedButtons: Qt.RightButton
+                                            onPressed: gapContextMenu.popup()
+
+                                            ThemedContextMenu {
+                                                id: gapContextMenu
+                                                ThemedMenuItem {
+                                                    text: qsTr("Close Gap")
+                                                    icon.name: Theme.icons.chevronsLeft
+                                                    onTriggered: EditorState.closeGap(trackRow.trackIndex,
+                                                                                      gapItem.modelData.start)
+                                                }
+                                            }
+                                        }
                                     }
                                 }
 

--- a/src/qml/components/timeline/TimelineClipItem.qml
+++ b/src/qml/components/timeline/TimelineClipItem.qml
@@ -591,6 +591,17 @@ Item {
                 onTriggered: EditorState.splitAtPlayhead()
             }
             ThemedMenuItem {
+                text: qsTr("Split item at current time")
+                icon.name: Theme.icons.scissors
+                // Scoped to just this clip (and its linked partner, e.g. companion
+                // audio) — splitAtPlayhead() above cuts every clip under the playhead
+                // across every track, which is surprising when picked from one clip's menu.
+                visible: EditorState.playheadSeconds > clipItem.clipData.start
+                        && EditorState.playheadSeconds < clipItem.clipData.start + clipItem.clipData.duration
+                onTriggered: EditorState.splitClipAt(clipItem.trackIndex, clipItem.clipIndex,
+                                                     EditorState.playheadSeconds)
+            }
+            ThemedMenuItem {
                 text: qsTr("Separate audio")
                 icon.name: Theme.icons.audioLines
                 // CapCut: only offer extract when the clip still has embedded audio.


### PR DESCRIPTION
## feat: add timeline close-gap and per-clip split actions

###  Problem
Closing a gap left on the timeline (e.g. after dragging a clip away from its neighbor) required manually dragging every following clip left by hand, and separately re-aligning any linked audio partner since it wasn't kept in sync automatically. Separately, a clip's right-click "Split at current time" split every clip under the playhead across all tracks, which was surprising to trigger from one specific clip's menu — there was no way to split just that clip.

###  Solution
Right-clicking an empty gap on a track now shows "Close Gap", which ripples every clip after the gap left to close it and shifts any linked partner clip on another track by the same amount, so linked video/audio pairs stay in sync. A new "Split item at current time" entry was added to the clip context menu — shown only when the playhead is over that clip — which splits just that clip (and its linked partner) via the existing splitClipAt path. The original "Split at current time" (all tracks at the playhead) is unchanged.

###  Testing
Built and ran the app locally on top of latest main: opened a gap between a linked video+audio pair, closed it via the gap's context menu, and checked that both clips shift left together with no gap left on either track, and that Ctrl+Z restores the original gap in one step. Also exercised "Split item at current time" to confirm it only appears/acts on the clip under the playhead, leaving other clips at that timestamp untouched.