### PR TITLE
Make NVIDIA/Wayland work without falling back to X11

### DIFF
--- a/src/engine/GlRuntime.cpp
+++ b/src/engine/GlRuntime.cpp
@@ -104,15 +104,32 @@ GlRuntime &runtime()
 
 bool GlRuntime::initGlObjects()
 {
-    QSurfaceFormat format;
-    format.setVersion(3, 3);
-    format.setProfile(QSurfaceFormat::CoreProfile);
-    format.setDepthBufferSize(0);
-    format.setStencilBufferSize(0);
+    QOpenGLContext *shared = QOpenGLContext::globalShareContext();
+    const bool sharingRequired = QCoreApplication::testAttribute(Qt::AA_ShareOpenGLContexts);
 
-    // Surface and context are both created here, on the GL thread, and never
-    // leave it. Creating the context on one thread and using it on another is
-    // what QOpenGLContext forbids ("cannot make current in a different thread").
+    // In the application, use the share context's realized format: EGL may
+    // adjust the requested format during creation. Command-line tools and
+    // tests have no Qt Quick share context, so retain an independent 3.3 Core
+    // context for those too.
+    if (shared && !shared->isValid())
+        shared = nullptr;
+
+    if (sharingRequired && !shared) {
+        qWarning("GlRuntime: required global OpenGL share context is unavailable");
+        return false;
+    }
+
+    QSurfaceFormat format;
+    if (shared) {
+        format = shared->format();
+    } else {
+        format.setRenderableType(QSurfaceFormat::OpenGL);
+        format.setVersion(3, 3);
+        format.setProfile(QSurfaceFormat::CoreProfile);
+        format.setDepthBufferSize(0);
+        format.setStencilBufferSize(0);
+    }
+
     surface = std::make_unique<QOffscreenSurface>();
     surface->setFormat(format);
     surface->create();
@@ -123,12 +140,9 @@ bool GlRuntime::initGlObjects()
     }
 
     context = std::make_unique<QOpenGLContext>();
-    context->setFormat(format);
-    // Share with the Qt Quick scene-graph context so composited textures can be
-    // handed to the preview item without a readback. Requires
-    // Qt::AA_ShareOpenGLContexts, set in main() before the QApplication.
-    if (QOpenGLContext *shared = QOpenGLContext::globalShareContext())
+    if (shared)
         context->setShareContext(shared);
+    context->setFormat(format);
     if (!context->create()) {
         qWarning("GlRuntime: failed to create OpenGL context");
         context.reset();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,21 +94,6 @@ int main(int argc, char *argv[])
 {
     applyLogLevel(verboseLoggingRequested(argc, argv));
 
-#ifdef Q_OS_LINUX
-    // NVIDIA proprietary driver on Wayland lacks EGL_EXT_platform_xcb support,
-    // causing QEGLPlatformContext::Failed to create context: 3009.
-    // Force XCB + GLX to work around this Qt/NVIDIA bug.
-    // If removed, it would break the app for most (if not all) users on Wayland with a Nvidia GPU
-    bool isWayland = qgetenv("XDG_SESSION_TYPE") == "wayland";
-    bool hasNvidiaDriver = QFile::exists("/proc/driver/nvidia/version");
-    bool hasNvidiaDevice = QFile::exists("/dev/nvidiactl");
-    
-    if (isWayland && hasNvidiaDriver && hasNvidiaDevice) {
-        qputenv("QT_QPA_PLATFORM", "xcb");
-        qputenv("QT_XCB_GL_INTEGRATION", "xcb_glx");
-    }
-#endif
-    
     for (int i = 1; i < argc; ++i) {
         if (qstrcmp(argv[i], "--mcp-stdio") == 0) {
             QCoreApplication app(argc, argv);
@@ -118,20 +103,17 @@ int main(int argc, char *argv[])
         }
     }
 
-#ifdef Q_OS_MACOS
-    // NSOpenGLContext will not share between the legacy 2.1 context Qt defaults to and the 3.3
-    // core one GlRuntime creates, and drops the share with only a warning, leaving the preview
-    // black. Match the default so both are core 3.3. X11 and WGL share across differing formats.
-    QSurfaceFormat macFormat = QSurfaceFormat::defaultFormat();
-    macFormat.setVersion(3, 3);
-    macFormat.setProfile(QSurfaceFormat::CoreProfile);
-    QSurfaceFormat::setDefaultFormat(macFormat);
-#endif
+    // On NVIDIA/Wayland, leaving the API unspecified makes EGL interpret 3.3
+    // as an invalid GLES version and fail with EGL_BAD_MATCH. Start from the
+    // default format to retain the platform-selected window-buffer attributes.
+    QSurfaceFormat format = QSurfaceFormat::defaultFormat();
+    format.setRenderableType(QSurfaceFormat::OpenGL);
+    format.setVersion(3, 3);
+    format.setProfile(QSurfaceFormat::CoreProfile);
+    QSurfaceFormat::setDefaultFormat(format);
 
-    // The compositor renders into an FBO on its own GL context and hands the
-    // texture to the scene graph without a readback. That requires both contexts
-    // to share objects, and the scene graph to actually be on OpenGL. Both must
-    // be set before the QApplication is constructed.
+    // Keep Qt Quick on OpenGL and create its global share context before the
+    // application, enabling zero-copy texture handoff from the compositor.
     QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
     QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
 


### PR DESCRIPTION
## Summary

Fixes #41

Fix OpenGL context creation on NVIDIA/Wayland without falling back to X11.

The previous workaround detected NVIDIA under Wayland and forced Qt to use XCB/GLX. This removes that workaround and fixes the underlying context incompatibility instead, making it work for Flatpak too.

Qt’s Wayland EGL integration could select OpenGL ES when the renderable API was unspecified. The requested 3.3 context was then interpreted as an invalid GLES version, causing EGL_BAD_MATCH (0x3009).

#### The changes:

  - Explicitly requests desktop OpenGL 3.3 Core before creating QApplication.
  - Ensures Qt Quick and the compositor use compatible contexts in the same share group.
  - Uses Qt’s realized share-context format for the compositor context.
  - Preserves the independent offscreen context used by tests and command-line tools.
  - Keeps the compositor on its dedicated GL thread.
  - Removes the NVIDIA/Wayland X11 fallback.

### Notes:
I don't have a Mac to test this on, could someone verify it still works there?

Compiling the project with GCC 16 causes a segfault at runtime, use an older version of GCC or Clang to compile the project. Even without the changes I did, it still segfaults. It is probably because of GCC 16 being too new for Qt 6.