### PR TITLE
fix: make hardcoded UI strings translatable

### DIFF
--- a/i18n/drift.ts
+++ b/i18n/drift.ts
@@ -1881,6 +1881,54 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Media</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stickers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shapes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scenes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Transitions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Audio FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Drop to import</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2112,6 +2160,10 @@
 </context>
 <context>
     <name>AudioInspector</name>
+    <message>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Recommended caption length</source>
         <translation type="unfinished"></translation>
@@ -3659,6 +3711,30 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Center X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Center Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Feather</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Mask changed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4238,6 +4314,58 @@ If playback stutters, try another.</source>
 </context>
 <context>
     <name>PropertiesPanel</name>
+    <message>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Transform</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Audio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blending</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Masks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Audio FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Transition</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>It&apos;s empty here</source>
         <translation type="unfinished"></translation>
@@ -6789,6 +6917,22 @@ If playback stutters, try another.</source>
 </context>
 <context>
     <name>TransformInspector</name>
+    <message>
+        <source>Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Video only</source>
         <translation type="unfinished"></translation>

--- a/i18n/drift_si.ts
+++ b/i18n/drift_si.ts
@@ -1881,6 +1881,54 @@
         <translation>මාධ්‍ය ආයාත කරන්න</translation>
     </message>
     <message>
+        <source>Media</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished">පෙළ</translation>
+    </message>
+    <message>
+        <source>Subtitles</source>
+        <translation type="unfinished">උපසිරැසි</translation>
+    </message>
+    <message>
+        <source>Stickers</source>
+        <translation type="unfinished">ස්ටිකර්</translation>
+    </message>
+    <message>
+        <source>Shapes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scenes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Effects</source>
+        <translation type="unfinished">ප්‍රයෝග</translation>
+    </message>
+    <message>
+        <source>Templates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Transitions</source>
+        <translation type="unfinished">සංක්‍රාන්ති</translation>
+    </message>
+    <message>
+        <source>Audio FX</source>
+        <translation type="unfinished">ශ්‍රව්‍ය ප්‍රයෝග</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Drop to import</source>
         <translation>ආයාත කිරීමට මෙතැනට දමන්න</translation>
     </message>
@@ -2112,6 +2160,10 @@
 </context>
 <context>
     <name>AudioInspector</name>
+    <message>
+        <source>Volume</source>
+        <translation type="unfinished">ශබ්ද මට්ටම</translation>
+    </message>
     <message>
         <source>Recommended caption length</source>
         <translation type="unfinished"></translation>
@@ -3659,6 +3711,30 @@
         <translation>Cutout ඉවත් කරන්න</translation>
     </message>
     <message>
+        <source>Center X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Center Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Width</source>
+        <translation type="unfinished">පළල</translation>
+    </message>
+    <message>
+        <source>Height</source>
+        <translation type="unfinished">උස</translation>
+    </message>
+    <message>
+        <source>Rotation</source>
+        <translation type="unfinished">භ්‍රමණය</translation>
+    </message>
+    <message>
+        <source>Feather</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Mask changed</source>
         <translation>ආවරණය (Mask) වෙනස් විය</translation>
     </message>
@@ -4240,6 +4316,58 @@ If playback stutters, try another.</source>
 </context>
 <context>
     <name>PropertiesPanel</name>
+    <message>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished">පෙළ</translation>
+    </message>
+    <message>
+        <source>Shape</source>
+        <translation type="unfinished">හැඩතලය</translation>
+    </message>
+    <message>
+        <source>Subtitles</source>
+        <translation type="unfinished">උපසිරැසි</translation>
+    </message>
+    <message>
+        <source>Transform</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animation</source>
+        <translation type="unfinished">සජීවිකරණය</translation>
+    </message>
+    <message>
+        <source>Audio</source>
+        <translation type="unfinished">ශ්‍රව්‍ය</translation>
+    </message>
+    <message>
+        <source>Speed</source>
+        <translation type="unfinished">වේගය</translation>
+    </message>
+    <message>
+        <source>Blending</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Masks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Effects</source>
+        <translation type="unfinished">ප්‍රයෝග</translation>
+    </message>
+    <message>
+        <source>Audio FX</source>
+        <translation type="unfinished">ශ්‍රව්‍ය ප්‍රයෝග</translation>
+    </message>
+    <message>
+        <source>Transition</source>
+        <translation type="unfinished">සංක්‍රාන්ති</translation>
+    </message>
     <message>
         <source>It&apos;s empty here</source>
         <translation>මෙහි කිසිවක් නැත</translation>
@@ -6792,6 +6920,22 @@ If playback stutters, try another.</source>
 </context>
 <context>
     <name>TransformInspector</name>
+    <message>
+        <source>Opacity</source>
+        <translation type="unfinished">පාරාන්ධතාව</translation>
+    </message>
+    <message>
+        <source>Width</source>
+        <translation type="unfinished">පළල</translation>
+    </message>
+    <message>
+        <source>Height</source>
+        <translation type="unfinished">උස</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <source>Video only</source>
         <translation>වීඩියෝ සඳහා පමණි</translation>

--- a/src/qml/AssetsPanel.qml
+++ b/src/qml/AssetsPanel.qml
@@ -217,23 +217,40 @@ PanelFrame {
         return kinds.length === 0 || kinds.indexOf(kind) >= 0
     }
 
+    // ListElement only accepts literal values; qsTr() calls are not
+    // evaluated. Labels are translated via tabLabels below.
+    property var tabLabels: ({
+        "media": qsTr("Media"),
+        "text": qsTr("Text"),
+        "subtitles": qsTr("Subtitles"),
+        "stickers": qsTr("Stickers"),
+        "shapes": qsTr("Shapes"),
+        "scenes": qsTr("Scenes"),
+        "effects": qsTr("Effects"),
+        "templates": qsTr("Templates"),
+        "transitions": qsTr("Transitions"),
+        "sounds": qsTr("Audio FX"),
+        "settings": qsTr("Settings"),
+        "shortcuts": qsTr("Shortcuts")
+    })
+
     // Rail order: project media → on-canvas graphics → processing → prefs.
     // `separatorAfter` draws a hairline under the tab so groups read as sections.
     // tabId "sounds" is kept for favorites persistence (settings key).
     ListModel {
         id: tabsModel
-        ListElement { tabId: "media"; icon: 0; label: "Media"; separatorAfter: true }
-        ListElement { tabId: "text"; icon: 1; label: "Text"; separatorAfter: false }
-        ListElement { tabId: "subtitles"; icon: 2; label: "Subtitles"; separatorAfter: false }
-        ListElement { tabId: "stickers"; icon: 3; label: "Stickers"; separatorAfter: false }
-        ListElement { tabId: "shapes"; icon: 4; label: "Shapes"; separatorAfter: true }
-        ListElement { tabId: "scenes"; icon: 11; label: "Scenes"; separatorAfter: true }
-        ListElement { tabId: "effects"; icon: 5; label: "Effects"; separatorAfter: false }
-        ListElement { tabId: "templates"; icon: 6; label: "Templates"; separatorAfter: false }
-        ListElement { tabId: "transitions"; icon: 7; label: "Transitions"; separatorAfter: false }
-        ListElement { tabId: "sounds"; icon: 8; label: "Audio FX"; separatorAfter: true }
-        ListElement { tabId: "settings"; icon: 9; label: "Settings"; separatorAfter: false }
-        ListElement { tabId: "shortcuts"; icon: 10; label: "Shortcuts"; separatorAfter: false }
+        ListElement { tabId: "media"; icon: 0; separatorAfter: true }
+        ListElement { tabId: "text"; icon: 1; separatorAfter: false }
+        ListElement { tabId: "subtitles"; icon: 2; separatorAfter: false }
+        ListElement { tabId: "stickers"; icon: 3; separatorAfter: false }
+        ListElement { tabId: "shapes"; icon: 4; separatorAfter: true }
+        ListElement { tabId: "scenes"; icon: 11; separatorAfter: true }
+        ListElement { tabId: "effects"; icon: 5; separatorAfter: false }
+        ListElement { tabId: "templates"; icon: 6; separatorAfter: false }
+        ListElement { tabId: "transitions"; icon: 7; separatorAfter: false }
+        ListElement { tabId: "sounds"; icon: 8; separatorAfter: true }
+        ListElement { tabId: "settings"; icon: 9; separatorAfter: false }
+        ListElement { tabId: "shortcuts"; icon: 10; separatorAfter: false }
     }
     property var tabIcons: [
         Theme.icons.film,
@@ -380,12 +397,12 @@ PanelFrame {
                             anchors.horizontalCenter: parent.horizontalCenter
                             glyph: root.tabIcons[model.icon]
                             variant: "ghost"
-                            tooltip: model.label
+                            tooltip: tabLabels[model.tabId]
                             active: root.activeTab === index
                             onClicked: root.activeTab = index
 
                             Accessible.role: Accessible.PageTab
-                            Accessible.name: model.label
+                            Accessible.name: tabLabels[model.tabId]
                             Accessible.checked: root.activeTab === index
                         }
 
@@ -442,7 +459,7 @@ PanelFrame {
                     anchors.left: parent.left
                     anchors.leftMargin: Theme.pagePadding
                     anchors.verticalCenter: parent.verticalCenter
-                    text: tabsModel.get(root.activeTab).label
+                    text: tabLabels[tabsModel.get(root.activeTab).tabId]
                     color: Theme.mutedForeground
                     font.family: Theme.fontFamily
                     font.pixelSize: Theme.fontSizeSm

--- a/src/qml/PropertiesPanel.qml
+++ b/src/qml/PropertiesPanel.qml
@@ -73,25 +73,43 @@ PanelFrame {
         root.syncSubtitlesTab()
     }
 
+    // ListElement only accepts literal values; qsTr() calls are not
+    // evaluated. Labels are translated via tabLabels below.
+    property var tabLabels: ({
+        "general": qsTr("General"),
+        "text": qsTr("Text"),
+        "shape": qsTr("Shape"),
+        "subtitles": qsTr("Subtitles"),
+        "transform": qsTr("Transform"),
+        "animation": qsTr("Animation"),
+        "audio": qsTr("Audio"),
+        "speed": qsTr("Speed"),
+        "blending": qsTr("Blending"),
+        "masks": qsTr("Masks"),
+        "effects": qsTr("Effects"),
+        "audioEffects": qsTr("Audio FX"),
+        "transition": qsTr("Transition")
+    })
+
     // Rail order: clip identity → geometry/timing → compositing / FX.
     // Contextual tabs (text / shape / captions) share the first group so a
     // separator still appears after General when they are hidden.
     // `group` drives hairlines between the next *visible* tab of a different group.
     ListModel {
         id: tabsModel
-        ListElement { tabId: "general"; icon: 0; label: "General"; group: 0 }
-        ListElement { tabId: "text"; icon: 1; label: "Text"; group: 0 }
-        ListElement { tabId: "shape"; icon: 2; label: "Shape"; group: 0 }
-        ListElement { tabId: "subtitles"; icon: 3; label: "Subtitles"; group: 0 }
-        ListElement { tabId: "transform"; icon: 4; label: "Transform"; group: 1 }
-        ListElement { tabId: "animation"; icon: 5; label: "Animation"; group: 1 }
-        ListElement { tabId: "audio"; icon: 6; label: "Audio"; group: 1 }
-        ListElement { tabId: "speed"; icon: 7; label: "Speed"; group: 1 }
-        ListElement { tabId: "blending"; icon: 8; label: "Blend"; group: 2 }
-        ListElement { tabId: "masks"; icon: 9; label: "Cutouts"; group: 2 }
-        ListElement { tabId: "effects"; icon: 10; label: "Effects"; group: 2 }
-        ListElement { tabId: "audioEffects"; icon: 11; label: "Audio FX"; group: 2 }
-        ListElement { tabId: "transition"; icon: 12; label: "Transition"; group: 2 }
+        ListElement { tabId: "general"; icon: 0; group: 0 }
+        ListElement { tabId: "text"; icon: 1; group: 0 }
+        ListElement { tabId: "shape"; icon: 2; group: 0 }
+        ListElement { tabId: "subtitles"; icon: 3; group: 0 }
+        ListElement { tabId: "transform"; icon: 4; group: 1 }
+        ListElement { tabId: "animation"; icon: 5; group: 1 }
+        ListElement { tabId: "audio"; icon: 6; group: 1 }
+        ListElement { tabId: "speed"; icon: 7; group: 1 }
+        ListElement { tabId: "blending"; icon: 8; group: 2 }
+        ListElement { tabId: "masks"; icon: 9; group: 2 }
+        ListElement { tabId: "effects"; icon: 10; group: 2 }
+        ListElement { tabId: "audioEffects"; icon: 11; group: 2 }
+        ListElement { tabId: "transition"; icon: 12; group: 2 }
     }
     property var tabIcons: [
         Theme.icons.info,
@@ -303,12 +321,12 @@ PanelFrame {
                                 anchors.horizontalCenter: parent.horizontalCenter
                                 glyph: root.tabIcons[model.icon]
                                 variant: "ghost"
-                                tooltip: model.label
+                                tooltip: tabLabels[model.tabId]
                                 active: root.activeTab === index
                                 onClicked: root.activeTab = index
 
                                 Accessible.role: Accessible.PageTab
-                                Accessible.name: model.label
+                                Accessible.name: tabLabels[model.tabId]
                                 Accessible.checked: root.activeTab === index
                             }
 
@@ -390,7 +408,7 @@ PanelFrame {
                     topPadding: Theme.pagePadding
 
                     Text {
-                        text: tabsModel.get(root.activeTab).label
+                        text: tabLabels[tabsModel.get(root.activeTab).tabId]
                         color: Theme.mutedForeground
                         font.family: Theme.fontFamily
                         font.pixelSize: Theme.fontSizeXs

--- a/src/qml/components/ThemedComboBox.qml
+++ b/src/qml/components/ThemedComboBox.qml
@@ -189,7 +189,7 @@ ComboBox {
             text: root.textRole ? (modelData[root.textRole] !== undefined
                                    ? modelData[root.textRole]
                                    : (model[root.textRole] !== undefined ? model[root.textRole] : modelData))
-                                : modelData
+                                : (root.labels ? (root.labels[modelData] || modelData) : modelData)
             color: Theme.panelForeground
             opacity: comboDelegate.enabled ? 1 : 0.4
             font: root.font

--- a/src/qml/components/properties/AudioInspector.qml
+++ b/src/qml/components/properties/AudioInspector.qml
@@ -14,7 +14,7 @@ Item {
     }
     readonly property bool hasSelection: !!clipData && Object.keys(clipData).length > 0
     readonly property string clipKind: hasSelection ? (clipData.kind || "") : ""
-    readonly property var propVolume: { "key": "volume", "label": "Volume", "def": 1.0, "decimals": 2 }
+    readonly property var propVolume: { "key": "volume", "label": qsTr("Volume"), "def": 1.0, "decimals": 2 }
 
     // "Recommended" packs by display width like openai-whisper does; the numbered entries cap
     // words per caption on top of that.

--- a/src/qml/components/properties/BlendingInspector.qml
+++ b/src/qml/components/properties/BlendingInspector.qml
@@ -66,7 +66,7 @@ Item {
             width: parent.width
             model: ["normal", "multiply", "screen", "overlay", "add", "darken", "lighten"]
             // Human labels — raw ids were shown to the user.
-            readonly property var labels: ({
+            property var labels: ({
                 "normal": qsTr("Normal"),
                 "multiply": qsTr("Multiply"),
                 "screen": qsTr("Screen"),

--- a/src/qml/components/properties/MasksInspector.qml
+++ b/src/qml/components/properties/MasksInspector.qml
@@ -170,12 +170,12 @@ Item {
 
         Repeater {
             model: [
-                { key: "x", label: "Center X", min: 0, max: 1 },
-                { key: "y", label: "Center Y", min: 0, max: 1 },
-                { key: "w", label: "Width", min: 0.05, max: 1 },
-                { key: "h", label: "Height", min: 0.05, max: 1 },
-                { key: "rotation", label: "Rotation", min: -180, max: 180 },
-                { key: "feather", label: "Feather", min: 0, max: 64 }
+                { key: "x", label: qsTr("Center X"), min: 0, max: 1 },
+                { key: "y", label: qsTr("Center Y"), min: 0, max: 1 },
+                { key: "w", label: qsTr("Width"), min: 0.05, max: 1 },
+                { key: "h", label: qsTr("Height"), min: 0.05, max: 1 },
+                { key: "rotation", label: qsTr("Rotation"), min: -180, max: 180 },
+                { key: "feather", label: qsTr("Feather"), min: 0, max: 64 }
             ]
             delegate: Column {
                 required property var modelData

--- a/src/qml/components/properties/TransformInspector.qml
+++ b/src/qml/components/properties/TransformInspector.qml
@@ -22,12 +22,12 @@ Item {
         return Math.max(1, EditorState.projectHeight())
     }
 
-    readonly property var propOpacity: { "key": "opacity", "label": "Opacity", "def": 1.0, "decimals": 2 }
+    readonly property var propOpacity: { "key": "opacity", "label": qsTr("Opacity"), "def": 1.0, "decimals": 2 }
     readonly property var propX: { "key": "x", "label": "X", "def": 0.0, "decimals": 0 }
     readonly property var propY: { "key": "y", "label": "Y", "def": 0.0, "decimals": 0 }
-    readonly property var propWidth: { "key": "width", "label": "Width", "def": root.canvasW, "decimals": 0 }
-    readonly property var propHeight: { "key": "height", "label": "Height", "def": root.canvasH, "decimals": 0 }
-    readonly property var propRotation: { "key": "rotation", "label": "Angle", "def": 0.0, "decimals": 1 }
+    readonly property var propWidth: { "key": "width", "label": qsTr("Width"), "def": root.canvasW, "decimals": 0 }
+    readonly property var propHeight: { "key": "height", "label": qsTr("Height"), "def": root.canvasH, "decimals": 0 }
+    readonly property var propRotation: { "key": "rotation", "label": qsTr("Angle"), "def": 0.0, "decimals": 1 }
 
     height: contentCol.height
     implicitHeight: contentCol.height


### PR DESCRIPTION
# Summary
1. Wrap certain strings with `qsTr()`.
2. Use a lookup table for `ListElement`, as it doesn't evaluate `qsTr()` calls.
3. Fix blend mode dropdown not translating

Once this is merged, I'll open a separate PR adding French Canadian translations. I've almost completed them in my fork. My father and I both prefer using software in French, so I'd be happy to contribute the full French localization.