### PR TITLE
fix: exiting preview fullscreen now restores maximized state on KDE

### DIFF
--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -236,7 +236,9 @@ ApplicationWindow {
     function togglePreviewFullscreen() {
         if (previewFullscreen) {
             previewFullscreen = false
-            visibility = _preFullscreenVisibility
+            // KDE Plasma doesn't handle Fullscreen -> Maximized for some reason
+            visibility = _preFullscreenVisibility // Fullscreen -> Windowed
+            visibility = _preFullscreenVisibility // Windowed -> Maximized (if it was previously maximized)
         } else {
             _preFullscreenVisibility = visibility
             previewFullscreen = true


### PR DESCRIPTION
# Summary
Closes #103 

Double assign previous state as KDE doesn't handle Fullscreen -> Maximized correctly. On systems which support the transition, the second assignment would simply get ignored.