### PR TITLE
feat: add folders to the media bin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,7 @@ add_library(driftcore STATIC
     src/core/Effect.h
     src/core/Effect.cpp
     src/core/EffectPreset.h
+    src/core/BinFolder.h
     src/core/MediaAsset.h
     src/core/MediaAsset.cpp
     src/core/Clip.h
@@ -580,6 +581,8 @@ qt_add_executable(drift
     src/models/Haptics.cpp
     src/models/AssetLibrary.h
     src/models/AssetLibrary.cpp
+    src/models/BinFolderListModel.h
+    src/models/BinFolderListModel.cpp
     src/models/TimelineModel.h
     src/models/TimelineModel.cpp
     src/models/ClipListModel.h
@@ -734,6 +737,7 @@ qt_add_qml_module(drift
         src/qml/components/assets/SettingsTab.qml
         src/qml/components/assets/ShortcutsTab.qml
         src/qml/components/assets/MediaAssetsTab.qml
+        src/qml/components/assets/BinBreadcrumb.qml
         src/qml/components/assets/AssetCategoryChips.qml
         src/qml/components/assets/EffectStacksSection.qml
         src/qml/components/assets/AssetFavoriteButton.qml

--- a/i18n/drift.ts
+++ b/i18n/drift.ts
@@ -2820,6 +2820,22 @@
         <source>Close gap</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Folder created</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder renamed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder deleted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Media moved</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -3097,6 +3113,34 @@
         <source>%1 — drag onto an overlap between two clips</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>New folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create a new folder here</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioEffectBrowser</name>
@@ -3318,6 +3362,13 @@
     </message>
     <message>
         <source>The audio device does not support playback of this project.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BinBreadcrumb</name>
+    <message>
+        <source>Media</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4931,6 +4982,26 @@
     </message>
     <message>
         <source>Import video, audio or images, then drag them onto the timeline. Right-click a clip to preview and trim it first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to folder…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This folder is empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag media here, or import more.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/i18n/drift_es.ts
+++ b/i18n/drift_es.ts
@@ -2820,6 +2820,22 @@
         <source>Close gap</source>
         <translation>Cerrar hueco</translation>
     </message>
+    <message>
+        <source>Folder created</source>
+        <translation>Carpeta creada</translation>
+    </message>
+    <message>
+        <source>Folder renamed</source>
+        <translation>Carpeta renombrada</translation>
+    </message>
+    <message>
+        <source>Folder deleted</source>
+        <translation>Carpeta eliminada</translation>
+    </message>
+    <message>
+        <source>Media moved</source>
+        <translation>Medio movido</translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -3097,6 +3113,34 @@
         <source>%1 — drag onto an overlap between two clips</source>
         <translation>%1 — arrastra sobre la superposición entre dos clips</translation>
     </message>
+    <message>
+        <source>New folder</source>
+        <translation>Nueva carpeta</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation>Crear</translation>
+    </message>
+    <message>
+        <source>Folder name</source>
+        <translation>Nombre de la carpeta</translation>
+    </message>
+    <message>
+        <source>Rename folder</source>
+        <translation>Cambiar nombre de la carpeta</translation>
+    </message>
+    <message>
+        <source>Move to folder</source>
+        <translation>Mover a la carpeta</translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation>Nueva carpeta</translation>
+    </message>
+    <message>
+        <source>Create a new folder here</source>
+        <translation>Crea una carpeta nueva aquí</translation>
+    </message>
 </context>
 <context>
     <name>AudioEffectBrowser</name>
@@ -3319,6 +3363,13 @@
     <message>
         <source>The audio device does not support playback of this project.</source>
         <translation>El dispositivo de audio no admite la reproducción de este proyecto.</translation>
+    </message>
+</context>
+<context>
+    <name>BinBreadcrumb</name>
+    <message>
+        <source>Media</source>
+        <translation>Medios</translation>
     </message>
 </context>
 <context>
@@ -4932,6 +4983,26 @@
     <message>
         <source>Import video, audio or images, then drag them onto the timeline. Right-click a clip to preview and trim it first.</source>
         <translation>Importa vídeo, audio o imágenes y arrástralos a la línea de tiempo. Haz clic derecho en un clip para previsualizarlo y recortarlo primero.</translation>
+    </message>
+    <message>
+        <source>Move to folder…</source>
+        <translation>Mover a la carpeta…</translation>
+    </message>
+    <message>
+        <source>This folder is empty</source>
+        <translation>Esta carpeta está vacía</translation>
+    </message>
+    <message>
+        <source>Drag media here, or import more.</source>
+        <translation>Arrastra medios aquí o importa más.</translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation>Abrir</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>Eliminar</translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_fr_CA.ts
+++ b/i18n/drift_fr_CA.ts
@@ -2822,6 +2822,22 @@
         <source>Export complete</source>
         <translation>Exportation terminée</translation>
     </message>
+    <message>
+        <source>Folder created</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder renamed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder deleted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Media moved</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -3099,6 +3115,34 @@
         <source>%1 — drag onto an overlap between two clips</source>
         <translation>%1 — faites glisser sur un chevauchement entre deux clips</translation>
     </message>
+    <message>
+        <source>New folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">Créer</translation>
+    </message>
+    <message>
+        <source>Folder name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create a new folder here</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioEffectBrowser</name>
@@ -3321,6 +3365,13 @@
     <message>
         <source>The audio device does not support playback of this project.</source>
         <translation>Le périphérique audio ne prend pas en charge la lecture de ce projet.</translation>
+    </message>
+</context>
+<context>
+    <name>BinBreadcrumb</name>
+    <message>
+        <source>Media</source>
+        <translation type="unfinished">Média</translation>
     </message>
 </context>
 <context>
@@ -4935,6 +4986,26 @@
     <message>
         <source>Import video, audio or images, then drag them onto the timeline. Right-click a clip to preview and trim it first.</source>
         <translation>Importez de la vidéo, de l’audio ou des images, puis faites-les glisser sur la timeline. Faites un clic droit sur un clip pour le prévisualiser et le découper au préalable.</translation>
+    </message>
+    <message>
+        <source>Move to folder…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This folder is empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag media here, or import more.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished">Ouvrir</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Supprimer</translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_it.ts
+++ b/i18n/drift_it.ts
@@ -2820,6 +2820,22 @@
         <source>Close gap</source>
         <translation>Chiudi spazio</translation>
     </message>
+    <message>
+        <source>Folder created</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder renamed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder deleted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Media moved</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -3097,6 +3113,34 @@
         <source>%1 — drag onto an overlap between two clips</source>
         <translation>%1 — trascina su una sovrapposizione tra due clip</translation>
     </message>
+    <message>
+        <source>New folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">Crea</translation>
+    </message>
+    <message>
+        <source>Folder name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create a new folder here</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioEffectBrowser</name>
@@ -3319,6 +3363,13 @@
     <message>
         <source>The audio device does not support playback of this project.</source>
         <translation>Il dispositivo audio non supporta la riproduzione di questo progetto.</translation>
+    </message>
+</context>
+<context>
+    <name>BinBreadcrumb</name>
+    <message>
+        <source>Media</source>
+        <translation type="unfinished">Elementi multimediali</translation>
     </message>
 </context>
 <context>
@@ -4932,6 +4983,26 @@
     <message>
         <source>Import video, audio or images, then drag them onto the timeline. Right-click a clip to preview and trim it first.</source>
         <translation>Importa video, audio o immagini, quindi trascinali sulla timeline. Fai clic destro su una clip per visualizzarla in anteprima e ritagliarla prima.</translation>
+    </message>
+    <message>
+        <source>Move to folder…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This folder is empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag media here, or import more.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished">Apri</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Elimina</translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_pt_BR.ts
+++ b/i18n/drift_pt_BR.ts
@@ -2820,6 +2820,22 @@
         <source>Close gap</source>
         <translation>Fechar lacuna</translation>
     </message>
+    <message>
+        <source>Folder created</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder renamed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder deleted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Media moved</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -3097,6 +3113,34 @@
         <source>%1 — drag onto an overlap between two clips</source>
         <translation>%1 — arraste para uma sobreposição entre dois clipes</translation>
     </message>
+    <message>
+        <source>New folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">Criar</translation>
+    </message>
+    <message>
+        <source>Folder name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create a new folder here</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioEffectBrowser</name>
@@ -3319,6 +3363,13 @@
     <message>
         <source>The audio device does not support playback of this project.</source>
         <translation>O dispositivo de áudio não é compatível com a reprodução deste projeto.</translation>
+    </message>
+</context>
+<context>
+    <name>BinBreadcrumb</name>
+    <message>
+        <source>Media</source>
+        <translation type="unfinished">Mídia</translation>
     </message>
 </context>
 <context>
@@ -4932,6 +4983,26 @@
     <message>
         <source>Import video, audio or images, then drag them onto the timeline. Right-click a clip to preview and trim it first.</source>
         <translation>Importe vídeo, áudio ou imagens e arraste-os para a linha do tempo. Clique com o botão direito em um clipe para pré-visualizar e aparar antes.</translation>
+    </message>
+    <message>
+        <source>Move to folder…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This folder is empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag media here, or import more.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished">Abrir</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Excluir</translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_si.ts
+++ b/i18n/drift_si.ts
@@ -2820,6 +2820,22 @@
         <source>Close gap</source>
         <translation>හිඩැස වසන්න</translation>
     </message>
+    <message>
+        <source>Folder created</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder renamed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder deleted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Media moved</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -3097,6 +3113,34 @@
         <source>%1 — drag onto an overlap between two clips</source>
         <translation>%1 — ක්ලිප් දෙකක් අතර අතිච්ඡාදනය වන තැනට අදින්න</translation>
     </message>
+    <message>
+        <source>New folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">සාදන්න</translation>
+    </message>
+    <message>
+        <source>Folder name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create a new folder here</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioEffectBrowser</name>
@@ -3319,6 +3363,13 @@
     <message>
         <source>The audio device does not support playback of this project.</source>
         <translation>මෙම ව්‍යාපෘතිය ධාවනය කිරීමට ශ්‍රව්‍ය උපාංගය සහාය නොදක්වයි.</translation>
+    </message>
+</context>
+<context>
+    <name>BinBreadcrumb</name>
+    <message>
+        <source>Media</source>
+        <translation type="unfinished">මාධ්‍ය</translation>
     </message>
 </context>
 <context>
@@ -4932,6 +4983,26 @@
     <message>
         <source>Import video, audio or images, then drag them onto the timeline. Right-click a clip to preview and trim it first.</source>
         <translation>වීඩියෝ, ශ්‍රව්‍ය හෝ පින්තූර ආයාත කර, පසුව ඒවා කාලරේඛාව වෙත අදින්න. ප්‍රථමයෙන් පෙරදසුන් කිරීමට සහ කප්පාදු කිරීමට ක්ලිප් එකක් මත දකුණු-ක්ලික් කරන්න.</translation>
+    </message>
+    <message>
+        <source>Move to folder…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This folder is empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag media here, or import more.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished">විවෘත කරන්න</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">මකන්න</translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_zh_Hans.ts
+++ b/i18n/drift_zh_Hans.ts
@@ -2815,6 +2815,22 @@
         <source>Close gap</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Folder created</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder renamed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder deleted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Media moved</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -3088,6 +3104,34 @@
         <source>%1 — drag onto an overlap between two clips</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>New folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Folder name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create a new folder here</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioEffectBrowser</name>
@@ -3310,6 +3354,13 @@
     <message>
         <source>The audio device does not support playback of this project.</source>
         <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BinBreadcrumb</name>
+    <message>
+        <source>Media</source>
+        <translation type="unfinished">媒体</translation>
     </message>
 </context>
 <context>
@@ -4921,6 +4972,26 @@
     </message>
     <message>
         <source>Import video, audio or images, then drag them onto the timeline. Right-click a clip to preview and trim it first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to folder…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This folder is empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag media here, or import more.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/core/BinFolder.h
+++ b/src/core/BinFolder.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <QString>
+
+namespace drift {
+
+// A folder in the media bin's hierarchy. Nesting is via parentId, like a filesystem —
+// empty parentId means the folder lives at bin root.
+struct BinFolder
+{
+    QString id;
+    QString name;
+    QString parentId;
+};
+
+} // namespace drift

--- a/src/core/MediaAsset.h
+++ b/src/core/MediaAsset.h
@@ -42,6 +42,11 @@ struct MediaAsset
     QString durationLabel;
     QString thumbnailPath;
     QString filmstripPath;
+
+    // Id of a BinFolder in Project::binFolders(). Empty = bin root. Purely an
+    // organizational attribute — clips address media through MediaAsset::id, so moving
+    // an asset between folders never touches anything on the timeline.
+    QString folderId;
 };
 
 } // namespace drift

--- a/src/core/Project.cpp
+++ b/src/core/Project.cpp
@@ -424,6 +424,8 @@ QJsonObject assetToJson(const MediaAsset &asset)
     // existed. Older builds ignore the key; a project without it simply reads back empty.
     if (!asset.sourceUri.isEmpty())
         object.insert(QStringLiteral("sourceUri"), asset.sourceUri);
+    if (!asset.folderId.isEmpty())
+        object.insert(QStringLiteral("folderId"), asset.folderId);
     return object;
 }
 
@@ -446,6 +448,7 @@ MediaAsset assetFromJsonV2(const QJsonObject &object)
     asset.codecName = object.value(QStringLiteral("codecName")).toString();
     asset.thumbnailPath = object.value(QStringLiteral("thumbnailPath")).toString();
     asset.filmstripPath = object.value(QStringLiteral("filmstripPath")).toString();
+    asset.folderId = object.value(QStringLiteral("folderId")).toString();
     if (object.contains(QStringLiteral("hasAudio"))) {
         asset.hasAudioKnown = true;
         asset.hasAudio = object.value(QStringLiteral("hasAudio")).toBool();
@@ -548,6 +551,8 @@ Project Project::detachedCopy() const
     out.m_bookmarks.detach();
     out.m_assetOrder.detach();
     out.m_assetsById.detach();
+    out.m_binFolderOrder.detach();
+    out.m_binFoldersById.detach();
     return out;
 }
 
@@ -584,6 +589,41 @@ QString Project::assetIdAt(int index) const
     if (index < 0 || index >= m_assetOrder.size())
         return {};
     return m_assetOrder.at(index);
+}
+
+QString Project::addBinFolder(BinFolder folder)
+{
+    if (folder.id.isEmpty())
+        folder.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+
+    m_binFoldersById.insert(folder.id, folder);
+    if (!m_binFolderOrder.contains(folder.id))
+        m_binFolderOrder.append(folder.id);
+    return folder.id;
+}
+
+BinFolder *Project::binFolder(const QString &id)
+{
+    auto it = m_binFoldersById.find(id);
+    return it == m_binFoldersById.end() ? nullptr : &it.value();
+}
+
+const BinFolder *Project::binFolder(const QString &id) const
+{
+    auto it = m_binFoldersById.constFind(id);
+    return it == m_binFoldersById.constEnd() ? nullptr : &it.value();
+}
+
+int Project::binFolderIndex(const QString &id) const
+{
+    return m_binFolderOrder.indexOf(id);
+}
+
+QString Project::binFolderIdAt(int index) const
+{
+    if (index < 0 || index >= m_binFolderOrder.size())
+        return {};
+    return m_binFolderOrder.at(index);
 }
 
 Project Project::fromJson(const QJsonObject &object, QString *errorOut)
@@ -631,6 +671,17 @@ Project Project::fromJson(const QJsonObject &object, QString *errorOut)
             project.addAsset(assetFromJsonV2(assetObject));
         else
             project.addAsset(assetFromJsonV1(assetObject));
+    }
+
+    const QJsonArray binFoldersArray = object.value(QStringLiteral("binFolders")).toArray();
+    for (const QJsonValue &value : binFoldersArray) {
+        const QJsonObject folderObject = value.toObject();
+        BinFolder folder;
+        folder.id = folderObject.value(QStringLiteral("id")).toString();
+        folder.name = folderObject.value(QStringLiteral("name")).toString();
+        folder.parentId = folderObject.value(QStringLiteral("parentId")).toString();
+        if (!folder.id.isEmpty())
+            project.addBinFolder(folder);
     }
 
     // Rebuild tracks from JSON. The Project ctor seeds a 1-track default, so
@@ -721,6 +772,18 @@ QJsonObject Project::toJson() const
             assetsArray.append(assetToJson(*assetPtr));
     }
 
+    QJsonArray binFoldersArray;
+    for (const QString &id : m_binFolderOrder) {
+        const BinFolder *folderPtr = binFolder(id);
+        if (folderPtr) {
+            binFoldersArray.append(QJsonObject{
+                {QStringLiteral("id"), folderPtr->id},
+                {QStringLiteral("name"), folderPtr->name},
+                {QStringLiteral("parentId"), folderPtr->parentId},
+            });
+        }
+    }
+
     QJsonArray tracksArray;
     for (const Track &track : m_tracks) {
         QJsonArray clipsArray;
@@ -764,6 +827,7 @@ QJsonObject Project::toJson() const
         {QStringLiteral("height"), m_height},
         {QStringLiteral("sampleRate"), m_sampleRate},
         {QStringLiteral("assets"), assetsArray},
+        {QStringLiteral("binFolders"), binFoldersArray},
         {QStringLiteral("tracks"), tracksArray},
         {QStringLiteral("bookmarks"), bookmarksArray},
         {QStringLiteral("background"), backgroundToJson(m_background)},

--- a/src/core/Project.h
+++ b/src/core/Project.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "BinFolder.h"
 #include "MediaAsset.h"
 #include "Track.h"
 #include "Time.h"
@@ -74,6 +75,11 @@ public:
     const QHash<QString, MediaAsset> &assets() const { return m_assetsById; }
     QHash<QString, MediaAsset> &assets() { return m_assetsById; }
 
+    const QList<QString> &binFolderOrder() const { return m_binFolderOrder; }
+    QList<QString> &binFolderOrder() { return m_binFolderOrder; }
+    const QHash<QString, BinFolder> &binFolders() const { return m_binFoldersById; }
+    QHash<QString, BinFolder> &binFolders() { return m_binFoldersById; }
+
     const QList<Bookmark> &bookmarks() const { return m_bookmarks; }
     QList<Bookmark> &bookmarks() { return m_bookmarks; }
 
@@ -106,6 +112,12 @@ public:
     int assetIndex(const QString &id) const;
     QString assetIdAt(int index) const;
 
+    QString addBinFolder(BinFolder folder);
+    BinFolder *binFolder(const QString &id);
+    const BinFolder *binFolder(const QString &id) const;
+    int binFolderIndex(const QString &id) const;
+    QString binFolderIdAt(int index) const;
+
     static Project fromJson(const QJsonObject &object, QString *errorOut = nullptr);
     QJsonObject toJson() const;
     // Compact JSON of toJson(); SHA-256 hex of those bytes. Undo history and on-disk
@@ -131,6 +143,8 @@ private:
     Background m_background;
     QList<QString> m_assetOrder;
     QHash<QString, MediaAsset> m_assetsById;
+    QList<QString> m_binFolderOrder;
+    QHash<QString, BinFolder> m_binFoldersById;
 };
 
 } // namespace drift

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -288,6 +288,7 @@ int main(int argc, char *argv[])
     static drift::Haptics haptics;
     editorState.setAddonManager(&addonManager);
     qmlRegisterSingletonInstance("Drift", 1, 0, "AssetLibrary", &assetLibrary);
+    qmlRegisterSingletonInstance("Drift", 1, 0, "BinFolderModel", editorState.binFolderModel());
     qmlRegisterSingletonInstance("Drift", 1, 0, "EditorState", &editorState);
     qmlRegisterSingletonInstance("Drift", 1, 0, "AppController", &editorState);
     qmlRegisterSingletonInstance("Drift", 1, 0, "FileDialogs", &fileDialogs);

--- a/src/models/AppController.cpp
+++ b/src/models/AppController.cpp
@@ -665,6 +665,7 @@ AppController::AppController(AssetLibrary *assetLibrary, QObject *parent)
     m_project.setAuthor(QSettings().value(QStringLiteral("authorName")).toString());
     if (m_assetLibrary)
         m_assetLibrary->setProject(&m_project);
+    m_binFolderModel.setProject(&m_project);
 
     m_timelineModel.setProject(&m_project);
     m_clipListModel.setProject(&m_project);
@@ -709,6 +710,12 @@ AppController::AppController(AssetLibrary *assetLibrary, QObject *parent)
         // model with a stale row count.
         if (m_assetLibrary)
             m_assetLibrary->syncToProject();
+        m_binFolderModel.syncToProject();
+        // An undo/redo can restore a project state where the folder currently being viewed no
+        // longer exists (its creation was undone) — back the viewer out to root rather than
+        // leaving it pointed at nothing.
+        if (!m_currentBinFolderId.isEmpty() && !m_project.binFolder(m_currentBinFolderId))
+            setCurrentBinFolderId(QString());
         normalizeSelection();
         setDirty(true);
         emit tracksChanged();
@@ -2272,6 +2279,87 @@ bool AppController::renameAsset(int assetIndex, const QString &name)
 
     pushProjectEdit(before, tr("Rename media"));
     finishEdit(tr("Media renamed"));
+    return true;
+}
+
+void AppController::setCurrentBinFolderId(const QString &folderId)
+{
+    if (m_currentBinFolderId == folderId)
+        return;
+    m_currentBinFolderId = folderId;
+    if (m_assetLibrary)
+        m_assetLibrary->setImportFolderId(folderId);
+    emit currentBinFolderIdChanged();
+}
+
+QString AppController::createBinFolder(const QString &name, const QString &parentId)
+{
+    const QString trimmed = name.trimmed();
+    if (trimmed.isEmpty())
+        return {};
+
+    // Plain copy, not detachedCopy(): nothing here runs off the GUI thread, so there's no
+    // concurrent reader to race — the same reasoning removeAsset already relies on. A full
+    // detach walks every clip's keyframes/masks/effects across the whole timeline, which is
+    // real, perceptible latency on a project of any size for an edit that touches none of it.
+    const drift::Project before = m_project;
+    const QString id = m_binFolderModel.createFolder(trimmed, parentId);
+    pushProjectEdit(before, tr("Folder created"));
+    return id;
+}
+
+bool AppController::renameBinFolder(const QString &folderId, const QString &name)
+{
+    const QString trimmed = name.trimmed();
+    if (trimmed.isEmpty())
+        return false;
+
+    // Plain copy, not detachedCopy(): nothing here runs off the GUI thread, so there's no
+    // concurrent reader to race — the same reasoning removeAsset already relies on. A full
+    // detach walks every clip's keyframes/masks/effects across the whole timeline, which is
+    // real, perceptible latency on a project of any size for an edit that touches none of it.
+    const drift::Project before = m_project;
+    if (!m_binFolderModel.renameFolder(folderId, trimmed))
+        return false;
+
+    pushProjectEdit(before, tr("Folder renamed"));
+    return true;
+}
+
+bool AppController::deleteBinFolder(const QString &folderId)
+{
+    // Plain copy, not detachedCopy(): nothing here runs off the GUI thread, so there's no
+    // concurrent reader to race — the same reasoning removeAsset already relies on. A full
+    // detach walks every clip's keyframes/masks/effects across the whole timeline, which is
+    // real, perceptible latency on a project of any size for an edit that touches none of it.
+    const drift::Project before = m_project;
+    const QString parentId = m_binFolderModel.parentIdOf(folderId);
+    if (!m_binFolderModel.deleteFolder(folderId))
+        return false;
+
+    if (m_assetLibrary)
+        m_assetLibrary->reparentAssetsInFolder(folderId, parentId);
+    if (m_currentBinFolderId == folderId)
+        setCurrentBinFolderId(parentId);
+
+    pushProjectEdit(before, tr("Folder deleted"));
+    return true;
+}
+
+bool AppController::moveAssetToFolder(int assetIndex, const QString &folderId)
+{
+    if (!m_assetLibrary)
+        return false;
+
+    // Plain copy, not detachedCopy(): nothing here runs off the GUI thread, so there's no
+    // concurrent reader to race — the same reasoning removeAsset already relies on. A full
+    // detach walks every clip's keyframes/masks/effects across the whole timeline, which is
+    // real, perceptible latency on a project of any size for an edit that touches none of it.
+    const drift::Project before = m_project;
+    if (!m_assetLibrary->moveAssetToFolder(assetIndex, folderId))
+        return false;
+
+    pushProjectEdit(before, tr("Media moved"));
     return true;
 }
 
@@ -13291,6 +13379,8 @@ bool AppController::applyProjectJson(const QByteArray &data, QString *error)
 
     if (m_assetLibrary)
         m_assetLibrary->setProject(&m_project);
+    m_binFolderModel.setProject(&m_project);
+    setCurrentBinFolderId(QString());
 
     rehydrateMissingSources();
 
@@ -13882,6 +13972,7 @@ void AppController::rehydrateMissingSources()
                 // to be told; a load has already cleared undo, and a restored file is not an edit.
                 if (m_assetLibrary)
                     m_assetLibrary->setProject(&m_project);
+                m_binFolderModel.setProject(&m_project);
                 restoreFilmstripsAfterLoad();
                 emit tracksChanged();
             });
@@ -13912,6 +14003,8 @@ void AppController::newProject()
     m_embeddedSources.clear();
     if (m_assetLibrary)
         m_assetLibrary->setProject(&m_project);
+    m_binFolderModel.setProject(&m_project);
+    setCurrentBinFolderId(QString());
     m_playback.setProject(&m_project);
     m_undoStack.clear();
     clearSelection();

--- a/src/models/AppController.h
+++ b/src/models/AppController.h
@@ -14,6 +14,7 @@
 #include "ClipListModel.h"
 #include "TimelineModel.h"
 #include "models/AssetLibrary.h"
+#include "models/BinFolderListModel.h"
 
 #include <QAtomicInt>
 #include <QFuture>
@@ -54,6 +55,11 @@ class AppController : public QObject
     Q_OBJECT
 
     Q_PROPERTY(AssetLibrary *assetLibrary READ assetLibrary CONSTANT)
+    Q_PROPERTY(BinFolderListModel *binFolderModel READ binFolderModel CONSTANT)
+    // Which bin folder is currently being viewed; empty = bin root. Transient navigation state —
+    // not persisted, not undoable, same treatment as mediaGridMode's touch-only sibling.
+    Q_PROPERTY(QString currentBinFolderId READ currentBinFolderId WRITE setCurrentBinFolderId
+                   NOTIFY currentBinFolderIdChanged)
     Q_PROPERTY(TimelineModel *timelineModel READ timelineModel CONSTANT)
     Q_PROPERTY(ClipListModel *clipListModel READ clipListModel CONSTANT)
     Q_PROPERTY(PlaybackEngine *playback READ playback CONSTANT)
@@ -280,6 +286,9 @@ public:
     ~AppController() override;
 
     AssetLibrary *assetLibrary() const { return m_assetLibrary; }
+    BinFolderListModel *binFolderModel() { return &m_binFolderModel; }
+    QString currentBinFolderId() const { return m_currentBinFolderId; }
+    void setCurrentBinFolderId(const QString &folderId);
     TimelineModel *timelineModel() { return &m_timelineModel; }
     ClipListModel *clipListModel() { return &m_clipListModel; }
     PlaybackEngine *playback() { return &m_playback; }
@@ -521,6 +530,13 @@ public:
     Q_INVOKABLE bool removeAsset(int assetIndex);
     // Bin label only — does not rename the file on disk or rewrite clip names.
     Q_INVOKABLE bool renameAsset(int assetIndex, const QString &name);
+    // Bin folder CRUD. parentId empty = bin root; nesting is arbitrary depth.
+    Q_INVOKABLE QString createBinFolder(const QString &name, const QString &parentId);
+    Q_INVOKABLE bool renameBinFolder(const QString &folderId, const QString &name);
+    // Moves the folder's direct children (assets and subfolders) up to its own parent, then
+    // removes it. Never blocks and never recurses into deleting contents.
+    Q_INVOKABLE bool deleteBinFolder(const QString &folderId);
+    Q_INVOKABLE bool moveAssetToFolder(int assetIndex, const QString &folderId);
     // Points an existing bin row at a different file, keeping every clip that uses it where it
     // is — its position, trim, effects and transitions all survive. Asynchronous: true only means
     // the probe started, and the outcome arrives as assetReplaceFinished.
@@ -1178,6 +1194,7 @@ signals:
     void sceneDetectProgressChanged();
     void sceneDetectStatusChanged();
     void sceneDetectionFinished(bool ok, const QString &message);
+    void currentBinFolderIdChanged();
     void selectionChanged();
     void editCapabilitiesChanged();
     void selectedClipDataChanged();
@@ -1394,6 +1411,8 @@ protected:
 
     AssetLibrary *m_assetLibrary = nullptr;
     AddonManager *m_addonManager = nullptr;
+    BinFolderListModel m_binFolderModel;
+    QString m_currentBinFolderId;
     TimelineModel m_timelineModel;
     ClipListModel m_clipListModel;
     // These trees must outlive m_playback: the compositor thread holds a bare

--- a/src/models/AssetLibrary.cpp
+++ b/src/models/AssetLibrary.cpp
@@ -311,10 +311,25 @@ QList<QString> AssetLibrary::currentPaths() const
     return paths;
 }
 
+QList<QString> AssetLibrary::currentFolderIds() const
+{
+    if (!m_project)
+        return {};
+
+    QList<QString> folderIds;
+    folderIds.reserve(m_project->assetOrder().size());
+    for (const QString &id : m_project->assetOrder()) {
+        const drift::MediaAsset *asset = m_project->asset(id);
+        folderIds.append(asset ? asset->folderId : QString{});
+    }
+    return folderIds;
+}
+
 void AssetLibrary::snapshotAssets()
 {
     m_syncedOrder = m_project ? m_project->assetOrder() : QList<QString>{};
     m_syncedPaths = currentPaths();
+    m_syncedFolderIds = currentFolderIds();
 }
 
 void AssetLibrary::syncToProject()
@@ -331,20 +346,28 @@ void AssetLibrary::syncToProject()
         return;
     }
 
-    // An undone source replace leaves the order untouched — same row, same id, different file —
-    // so the paths have to be compared too or the card keeps showing the media it no longer
-    // points at. Only the rows that actually moved are re-read.
+    // An undone source replace or folder move leaves the order untouched — same row, same id,
+    // different file or folder — so both have to be compared too or the card keeps showing stale
+    // data. Only the rows that actually changed are re-read.
     const QList<QString> paths = currentPaths();
-    if (paths == m_syncedPaths)
+    const QList<QString> folderIds = currentFolderIds();
+    if (paths == m_syncedPaths && folderIds == m_syncedFolderIds)
         return;
 
     for (int i = 0; i < paths.size(); ++i) {
-        if (i < m_syncedPaths.size() && m_syncedPaths.at(i) == paths.at(i))
+        const bool pathChanged = i >= m_syncedPaths.size() || m_syncedPaths.at(i) != paths.at(i);
+        const bool folderChanged =
+            i >= m_syncedFolderIds.size() || m_syncedFolderIds.at(i) != folderIds.at(i);
+        if (!pathChanged && !folderChanged)
             continue;
-        emitAssetRowChanged(i, {}); // empty roles: every role may have moved with the file
-        emit assetMetadataChanged(m_project->assetIdAt(i));
+        // Empty roles: every role may have moved with the file. A folder-only change only
+        // touches FolderIdRole.
+        emitAssetRowChanged(i, pathChanged ? QList<int>{} : QList<int>{FolderIdRole});
+        if (pathChanged)
+            emit assetMetadataChanged(m_project->assetIdAt(i));
     }
     m_syncedPaths = paths;
+    m_syncedFolderIds = folderIds;
 }
 
 void AssetLibrary::setProject(drift::Project *project)
@@ -401,6 +424,8 @@ QVariant AssetLibrary::data(const QModelIndex &index, int role) const
         return asset->thumbnailPath;
     case FilmstripPathRole:
         return asset->filmstripPath;
+    case FolderIdRole:
+        return asset->folderId;
     default:
         return {};
     }
@@ -417,6 +442,7 @@ QHash<int, QByteArray> AssetLibrary::roleNames() const
         {PathRole, "path"},
         {ThumbnailPathRole, "thumbnailPath"},
         {FilmstripPathRole, "filmstripPath"},
+        {FolderIdRole, "folderId"},
     };
 }
 
@@ -605,8 +631,10 @@ bool AssetLibrary::applyProbedSource(const QString &assetId, const drift::MediaA
         return false;
 
     const QString id = asset->id;
+    const QString folderId = asset->folderId;
     *asset = filled;
     asset->id = id;
+    asset->folderId = folderId;
 
     // Jobs still in flight were started against the old file. They drop themselves on landing
     // because the path they probed no longer matches; clearing the pending flags is what lets
@@ -687,6 +715,7 @@ QVariantMap AssetLibrary::assetAt(int index) const
         {QStringLiteral("thumbnailPath"), asset->thumbnailPath},
         {QStringLiteral("filmstripPath"), asset->filmstripPath},
         {QStringLiteral("assetIndex"), index},
+        {QStringLiteral("folderId"), asset->folderId},
     };
 }
 
@@ -813,6 +842,37 @@ bool AssetLibrary::setAssetName(int index, const QString &name)
     emitAssetRowChanged(index, {NameRole});
     snapshotAssets();
     return true;
+}
+
+bool AssetLibrary::moveAssetToFolder(int index, const QString &folderId)
+{
+    drift::MediaAsset *asset = assetAtIndex(index);
+    if (!asset || asset->folderId == folderId)
+        return false;
+
+    asset->folderId = folderId;
+    emitAssetRowChanged(index, {FolderIdRole});
+    snapshotAssets();
+    return true;
+}
+
+int AssetLibrary::reparentAssetsInFolder(const QString &folderId, const QString &newFolderId)
+{
+    if (!m_project)
+        return 0;
+
+    int moved = 0;
+    for (int i = 0; i < m_project->assetOrder().size(); ++i) {
+        drift::MediaAsset *asset = assetAtIndex(i);
+        if (!asset || asset->folderId != folderId)
+            continue;
+        asset->folderId = newFolderId;
+        emitAssetRowChanged(i, {FolderIdRole});
+        ++moved;
+    }
+    if (moved > 0)
+        snapshotAssets();
+    return moved;
 }
 
 void AssetLibrary::sortByKind()
@@ -1023,7 +1083,7 @@ void AssetLibrary::importUrls(const QList<QUrl> &urls)
         if (!sourceUri.isEmpty())
             sourceUris.insert(QFileInfo(path).absoluteFilePath(), sourceUri);
     }
-    importFiles(paths, sourceUris);
+    importFiles(paths, sourceUris, m_importFolderId);
 }
 
 bool AssetLibrary::importUrlsAsync(const QList<QUrl> &urls)
@@ -1038,15 +1098,20 @@ bool AssetLibrary::importUrlsAsync(const QList<QUrl> &urls)
     m_importing = true;
     emit importingChanged();
 
+    // Captured now, not read from m_importFolderId when the copy finishes: the user can
+    // navigate to a different folder while a large/slow copy is still running, and the import
+    // should land wherever they were when they started it, not wherever they ended up.
+    const QString destinationFolderId = m_importFolderId;
     const int total = urls.size();
     auto *watcher = new QFutureWatcher<Materialized>(this);
-    connect(watcher, &QFutureWatcher<Materialized>::finished, this, [this, watcher]() {
+    connect(watcher, &QFutureWatcher<Materialized>::finished, this,
+            [this, watcher, destinationFolderId]() {
         watcher->deleteLater();
         const Materialized result = watcher->result();
 
         // The rows have to exist before importFinished lands: AndroidHome walks countBefore..count
         // and turns every new asset into a clip the moment it sees the signal.
-        importFiles(result.paths, result.sourceUris);
+        importFiles(result.paths, result.sourceUris, destinationFolderId);
 
         m_importing = false;
         emit importingChanged();
@@ -1082,7 +1147,7 @@ bool AssetLibrary::importUrlsAsync(const QList<QUrl> &urls)
 
 QStringList AssetLibrary::importLocalPaths(const QStringList &paths)
 {
-    return importFilesReturningIds(paths);
+    return importFilesReturningIds(paths, {}, m_importFolderId);
 }
 
 bool AssetLibrary::isImportPending(const QString &assetId) const
@@ -1106,17 +1171,29 @@ QString AssetLibrary::addGeneratedAsset(drift::MediaAsset asset)
     return id;
 }
 
-void AssetLibrary::importFiles(const QStringList &paths, const QHash<QString, QString> &sourceUris)
+void AssetLibrary::importFiles(const QStringList &paths, const QHash<QString, QString> &sourceUris,
+                               const QString &destinationFolderId)
 {
-    importFilesReturningIds(paths, sourceUris);
+    importFilesReturningIds(paths, sourceUris, destinationFolderId);
 }
 
 QStringList AssetLibrary::importFilesReturningIds(const QStringList &paths,
-                                                  const QHash<QString, QString> &sourceUris)
+                                                  const QHash<QString, QString> &sourceUris,
+                                                  const QString &destinationFolderId)
 {
     QStringList ids;
     if (!m_project)
         return ids;
+
+    // The destination was captured when the import started, but completion can land well after
+    // that — long enough for the folder to have been deleted, or for the whole project to have
+    // been replaced by a load. An asset filed under an id that no longer names a folder would be
+    // unreachable from the bin (nothing lists "every asset regardless of folder"), so re-check
+    // against the project as it stands now and fall back to root rather than orphan it.
+    const QString validatedFolderId =
+        (destinationFolderId.isEmpty() || m_project->binFolder(destinationFolderId))
+            ? destinationFolderId
+            : QString();
 
     for (const QString &path : paths) {
         const QFileInfo fileInfo(path);
@@ -1137,6 +1214,7 @@ QStringList AssetLibrary::importFilesReturningIds(const QStringList &paths,
         placeholder.path = absolutePath;
         placeholder.sourceUri = sourceUris.value(absolutePath);
         placeholder.kind = provisionalKind(absolutePath);
+        placeholder.folderId = validatedFolderId;
 
         const int row = m_project->assetOrder().size();
         beginInsertRows({}, row, row);

--- a/src/models/AssetLibrary.h
+++ b/src/models/AssetLibrary.h
@@ -35,6 +35,7 @@ public:
         PathRole,
         ThumbnailPathRole,
         FilmstripPathRole,
+        FolderIdRole,
     };
     Q_ENUM(Role)
 
@@ -78,6 +79,13 @@ public:
     // Drops the row from the project's asset table. Callers own the undo
     // snapshot and the in-use check; this only touches the bin.
     bool removeAssetAt(int index);
+    // Reassigns which bin folder the row lives in (empty = root). Callers own the undo snapshot.
+    bool moveAssetToFolder(int index, const QString &folderId);
+    // Moves every asset currently in `folderId` to `newFolderId` in one pass — used when a folder
+    // is deleted, to carry its direct-child assets up to the parent. Callers own the undo snapshot.
+    int reparentAssetsInFolder(const QString &folderId, const QString &newFolderId);
+    // Folder a new import lands in; empty = bin root. Set by AppController as the user navigates.
+    void setImportFolderId(const QString &folderId) { m_importFolderId = folderId; }
     // Probes `absolutePath` off-thread and reports it back through assetSourceProbed without
     // touching the project, so the caller can apply the swap, the clip fixups and the undo
     // snapshot as one transaction. Returns false when nothing was started.
@@ -109,10 +117,15 @@ signals:
 
 private:
     // `sourceUris` maps an absolute path to the content:// URI it was materialized from, so the
-    // asset can be rehydrated after its copy is gone. Empty on desktop.
-    void importFiles(const QStringList &paths, const QHash<QString, QString> &sourceUris = {});
+    // asset can be rehydrated after its copy is gone. Empty on desktop. `destinationFolderId` is
+    // captured by the caller at import *start*, not read from m_importFolderId here — the async
+    // path's copy stage can outlive the user navigating to a different folder, and a member read
+    // at completion would land new assets wherever they'd navigated to instead.
+    void importFiles(const QStringList &paths, const QHash<QString, QString> &sourceUris,
+                     const QString &destinationFolderId);
     QStringList importFilesReturningIds(const QStringList &paths,
-                                        const QHash<QString, QString> &sourceUris = {});
+                                        const QHash<QString, QString> &sourceUris,
+                                        const QString &destinationFolderId);
     bool containsPath(const QString &path) const;
     void refreshMediaAt(int index);
     void startImportJob(const QString &assetId, const QString &absolutePath, bool imageOnly);
@@ -127,6 +140,7 @@ private:
     void emitAssetRowChanged(int index, const QList<int> &roles);
     void snapshotAssets();
     QList<QString> currentPaths() const;
+    QList<QString> currentFolderIds() const;
     const drift::MediaAsset *assetAtIndex(int index) const;
     drift::MediaAsset *assetAtIndex(int index);
 
@@ -137,6 +151,8 @@ private:
     // leaves the order alone and only moves a path, which is why both are tracked.
     QList<QString> m_syncedOrder;
     QList<QString> m_syncedPaths;
+    QList<QString> m_syncedFolderIds;
+    QString m_importFolderId;
     QSet<QString> m_importPending;
     QSet<QString> m_thumbPending;
     QSet<QString> m_audioProbePending;

--- a/src/models/BinFolderListModel.cpp
+++ b/src/models/BinFolderListModel.cpp
@@ -1,0 +1,256 @@
+#include "BinFolderListModel.h"
+
+#include "core/Project.h"
+
+#include <QUuid>
+
+BinFolderListModel::BinFolderListModel(QObject *parent)
+    : QAbstractListModel(parent)
+{
+    connect(this, &QAbstractItemModel::rowsInserted, this, &BinFolderListModel::countChanged);
+    connect(this, &QAbstractItemModel::rowsRemoved, this, &BinFolderListModel::countChanged);
+    connect(this, &QAbstractItemModel::modelReset, this, &BinFolderListModel::countChanged);
+
+    connect(this, &QAbstractItemModel::rowsInserted, this, &BinFolderListModel::snapshotFolders);
+    connect(this, &QAbstractItemModel::rowsRemoved, this, &BinFolderListModel::snapshotFolders);
+    connect(this, &QAbstractItemModel::modelReset, this, &BinFolderListModel::snapshotFolders);
+}
+
+void BinFolderListModel::setProject(drift::Project *project)
+{
+    beginResetModel();
+    m_project = project;
+    endResetModel();
+}
+
+int BinFolderListModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid() || !m_project)
+        return 0;
+    return m_project->binFolderOrder().size();
+}
+
+const drift::BinFolder *BinFolderListModel::folderAtIndex(int index) const
+{
+    if (!m_project || index < 0 || index >= m_project->binFolderOrder().size())
+        return nullptr;
+    return m_project->binFolder(m_project->binFolderIdAt(index));
+}
+
+drift::BinFolder *BinFolderListModel::folderAtIndex(int index)
+{
+    if (!m_project || index < 0 || index >= m_project->binFolderOrder().size())
+        return nullptr;
+    return m_project->binFolder(m_project->binFolderIdAt(index));
+}
+
+QVariant BinFolderListModel::data(const QModelIndex &index, int role) const
+{
+    const drift::BinFolder *folder = folderAtIndex(index.row());
+    if (!index.isValid() || !folder)
+        return {};
+
+    switch (role) {
+    case IdRole:
+        return folder->id;
+    case NameRole:
+        return folder->name;
+    case ParentIdRole:
+        return folder->parentId;
+    default:
+        return {};
+    }
+}
+
+QHash<int, QByteArray> BinFolderListModel::roleNames() const
+{
+    return {
+        {IdRole, "id"},
+        {NameRole, "name"},
+        {ParentIdRole, "parentId"},
+    };
+}
+
+QVariantMap BinFolderListModel::folderAt(int index) const
+{
+    const drift::BinFolder *folder = folderAtIndex(index);
+    if (!folder)
+        return {};
+    return {
+        {QStringLiteral("id"), folder->id},
+        {QStringLiteral("name"), folder->name},
+        {QStringLiteral("parentId"), folder->parentId},
+    };
+}
+
+QVariantMap BinFolderListModel::folderById(const QString &id) const
+{
+    if (!m_project || id.isEmpty())
+        return {};
+    const drift::BinFolder *folder = m_project->binFolder(id);
+    if (!folder)
+        return {};
+    return {
+        {QStringLiteral("id"), folder->id},
+        {QStringLiteral("name"), folder->name},
+        {QStringLiteral("parentId"), folder->parentId},
+    };
+}
+
+int BinFolderListModel::indexOfId(const QString &id) const
+{
+    if (!m_project)
+        return -1;
+    return m_project->binFolderIndex(id);
+}
+
+QString BinFolderListModel::idAt(int index) const
+{
+    if (!m_project)
+        return {};
+    return m_project->binFolderIdAt(index);
+}
+
+QString BinFolderListModel::parentIdOf(const QString &id) const
+{
+    if (!m_project)
+        return {};
+    const drift::BinFolder *folder = m_project->binFolder(id);
+    return folder ? folder->parentId : QString{};
+}
+
+void BinFolderListModel::emitFolderRowChanged(int index, const QList<int> &roles)
+{
+    if (index < 0)
+        return;
+    const QModelIndex modelIndex = createIndex(index, 0);
+    emit dataChanged(modelIndex, modelIndex, roles);
+}
+
+QList<QString> BinFolderListModel::currentParentIds() const
+{
+    if (!m_project)
+        return {};
+
+    QList<QString> parentIds;
+    parentIds.reserve(m_project->binFolderOrder().size());
+    for (const QString &id : m_project->binFolderOrder()) {
+        const drift::BinFolder *folder = m_project->binFolder(id);
+        parentIds.append(folder ? folder->parentId : QString{});
+    }
+    return parentIds;
+}
+
+QList<QString> BinFolderListModel::currentNames() const
+{
+    if (!m_project)
+        return {};
+
+    QList<QString> names;
+    names.reserve(m_project->binFolderOrder().size());
+    for (const QString &id : m_project->binFolderOrder()) {
+        const drift::BinFolder *folder = m_project->binFolder(id);
+        names.append(folder ? folder->name : QString{});
+    }
+    return names;
+}
+
+void BinFolderListModel::snapshotFolders()
+{
+    m_syncedOrder = m_project ? m_project->binFolderOrder() : QList<QString>{};
+    m_syncedParentIds = currentParentIds();
+    m_syncedNames = currentNames();
+}
+
+void BinFolderListModel::syncToProject()
+{
+    if (!m_project)
+        return;
+
+    // Undo/redo assigns the whole project behind this model's back. Resetting unconditionally
+    // would rebuild every tile on every unrelated project edit, so only an actual order change is
+    // worth the churn.
+    if (m_syncedOrder != m_project->binFolderOrder()) {
+        beginResetModel();
+        endResetModel();
+        return;
+    }
+
+    // An undone rename or reparent leaves the order untouched — same row, same id, different
+    // field — so both parent ids and names have to be compared too.
+    const QList<QString> parentIds = currentParentIds();
+    const QList<QString> names = currentNames();
+    if (parentIds == m_syncedParentIds && names == m_syncedNames)
+        return;
+
+    for (int i = 0; i < parentIds.size(); ++i) {
+        const bool parentChanged = i >= m_syncedParentIds.size() || m_syncedParentIds.at(i) != parentIds.at(i);
+        const bool nameChanged = i >= m_syncedNames.size() || m_syncedNames.at(i) != names.at(i);
+        if (!parentChanged && !nameChanged)
+            continue;
+        QList<int> roles;
+        if (parentChanged)
+            roles.append(ParentIdRole);
+        if (nameChanged)
+            roles.append(NameRole);
+        emitFolderRowChanged(i, roles);
+    }
+    m_syncedParentIds = parentIds;
+    m_syncedNames = names;
+}
+
+QString BinFolderListModel::createFolder(const QString &name, const QString &parentId)
+{
+    if (!m_project)
+        return {};
+
+    drift::BinFolder folder;
+    folder.name = name;
+    folder.parentId = parentId;
+
+    const int row = m_project->binFolderOrder().size();
+    beginInsertRows({}, row, row);
+    const QString id = m_project->addBinFolder(folder);
+    endInsertRows();
+    return id;
+}
+
+bool BinFolderListModel::renameFolder(const QString &id, const QString &name)
+{
+    const int index = indexOfId(id);
+    drift::BinFolder *folder = folderAtIndex(index);
+    if (!folder || folder->name == name)
+        return false;
+
+    folder->name = name;
+    emitFolderRowChanged(index, {NameRole});
+    snapshotFolders();
+    return true;
+}
+
+bool BinFolderListModel::deleteFolder(const QString &id)
+{
+    if (!m_project)
+        return false;
+
+    const int index = indexOfId(id);
+    if (index < 0)
+        return false;
+
+    const drift::BinFolder *deleted = m_project->binFolder(id);
+    const QString parentId = deleted ? deleted->parentId : QString{};
+
+    for (int i = 0; i < m_project->binFolderOrder().size(); ++i) {
+        drift::BinFolder *child = folderAtIndex(i);
+        if (child && child->parentId == id) {
+            child->parentId = parentId;
+            emitFolderRowChanged(i, {ParentIdRole});
+        }
+    }
+
+    beginRemoveRows({}, index, index);
+    m_project->binFolders().remove(id);
+    m_project->binFolderOrder().removeAll(id);
+    endRemoveRows();
+    return true;
+}

--- a/src/models/BinFolderListModel.h
+++ b/src/models/BinFolderListModel.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "core/BinFolder.h"
+
+#include <QAbstractListModel>
+#include <QList>
+#include <QString>
+#include <QVariantMap>
+
+namespace drift {
+class Project;
+}
+
+// Media bin folder tree model, backed by the project's folder table. Mirrors AssetLibrary's
+// shape: flat list, no structural reset on navigation — QML filters rows by parentId the same
+// way MediaAssetsTab filters assets by folderId.
+class BinFolderListModel : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+
+public:
+    enum Role {
+        IdRole = Qt::UserRole + 1,
+        NameRole,
+        ParentIdRole,
+    };
+    Q_ENUM(Role)
+
+    explicit BinFolderListModel(QObject *parent = nullptr);
+
+    void setProject(drift::Project *project);
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    int count() const { return rowCount(); }
+
+    Q_INVOKABLE QVariantMap folderAt(int index) const;
+    // Empty map when `id` doesn't name a folder (including the root "" id) — QML's breadcrumb
+    // walk stops there.
+    Q_INVOKABLE QVariantMap folderById(const QString &id) const;
+    Q_INVOKABLE int indexOfId(const QString &id) const;
+    Q_INVOKABLE QString idAt(int index) const;
+
+    // Plain mutators — undo-agnostic, same contract as AssetLibrary::removeAssetAt: callers own
+    // the undo snapshot.
+    QString createFolder(const QString &name, const QString &parentId);
+    bool renameFolder(const QString &id, const QString &name);
+    // Removes the folder row. Any other folder whose parentId == id is reparented to this
+    // folder's own parentId (moved up one level, not deleted). Does not touch assets — the
+    // caller reparents those separately via AssetLibrary::reparentAssetsInFolder.
+    bool deleteFolder(const QString &id);
+    // The folder's parentId, read before deleteFolder mutates the tree.
+    QString parentIdOf(const QString &id) const;
+
+    // Re-reads the project after undo/redo has swapped it wholesale.
+    void syncToProject();
+
+signals:
+    void countChanged();
+
+private:
+    void snapshotFolders();
+    void emitFolderRowChanged(int index, const QList<int> &roles);
+    const drift::BinFolder *folderAtIndex(int index) const;
+    drift::BinFolder *folderAtIndex(int index);
+    QList<QString> currentParentIds() const;
+    QList<QString> currentNames() const;
+
+    drift::Project *m_project = nullptr;
+    QList<QString> m_syncedOrder;
+    QList<QString> m_syncedParentIds;
+    QList<QString> m_syncedNames;
+};

--- a/src/qml/AssetsPanel.qml
+++ b/src/qml/AssetsPanel.qml
@@ -161,6 +161,190 @@ PanelFrame {
         onRejected: root.pendingRenameIndex = -1
     }
 
+    ThemedDialog {
+        id: newFolderDialog
+        title: qsTr("New folder")
+        acceptText: qsTr("Create")
+        preferredWidth: Theme.dialogWidthSm
+
+        contentItem: Column {
+            width: parent ? parent.width : Theme.dialogWidthSm
+            spacing: Theme.spacingMd
+
+            ThemedLabel {
+                width: parent.width
+                text: qsTr("Name")
+                size: "sm"
+            }
+            ThemedTextField {
+                id: newFolderNameField
+                width: parent.width
+                placeholderText: qsTr("Folder name")
+            }
+        }
+
+        onOpened: {
+            newFolderNameField.text = ""
+            newFolderNameField.forceActiveFocus()
+        }
+        onAccepted: {
+            const label = newFolderNameField.text.trim()
+            if (label.length > 0)
+                EditorState.createBinFolder(label, EditorState.currentBinFolderId)
+        }
+    }
+
+    property string pendingFolderRenameId: ""
+
+    function requestRenameFolder(folderId, folderName) {
+        root.pendingFolderRenameId = folderId
+        folderRenameField.text = folderName || ""
+        folderRenameDialog.open()
+    }
+
+    ThemedDialog {
+        id: folderRenameDialog
+        title: qsTr("Rename folder")
+        acceptText: qsTr("Rename")
+        preferredWidth: Theme.dialogWidthSm
+
+        contentItem: Column {
+            width: parent ? parent.width : Theme.dialogWidthSm
+            spacing: Theme.spacingMd
+
+            ThemedLabel {
+                width: parent.width
+                text: qsTr("Name")
+                size: "sm"
+            }
+            ThemedTextField {
+                id: folderRenameField
+                width: parent.width
+                placeholderText: qsTr("Folder name")
+            }
+        }
+
+        onOpened: {
+            folderRenameField.forceActiveFocus()
+            folderRenameField.selectAll()
+        }
+        onAccepted: {
+            if (root.pendingFolderRenameId.length === 0)
+                return
+            const label = folderRenameField.text.trim()
+            if (label.length > 0)
+                EditorState.renameBinFolder(root.pendingFolderRenameId, label)
+            root.pendingFolderRenameId = ""
+        }
+        onRejected: root.pendingFolderRenameId = ""
+    }
+
+    // The "move to folder" path — right-click on a card, choose a destination from a flat list.
+    property int pendingMoveAssetIndex: -1
+    // The folder the asset is in right now, so the picker can omit it — moving it "into" the
+    // folder it's already in isn't a real destination.
+    property string pendingMoveAssetCurrentFolderId: ""
+
+    function requestMoveAssetToFolder(assetIndex) {
+        root.pendingMoveAssetIndex = assetIndex
+        root.pendingMoveAssetCurrentFolderId = AssetLibrary.assetAt(assetIndex).folderId || ""
+        folderPickerDialog.open()
+    }
+
+    ThemedDialog {
+        id: folderPickerDialog
+        title: qsTr("Move to folder")
+        showFooter: false
+        preferredWidth: Theme.dialogWidthSm
+
+        // Flat list, root first, minus the folder the asset is already in — nesting depth is
+        // not shown, matching the breadcrumb's "where you are" rather than "the whole tree"
+        // framing.
+        //
+        // folderAt() is a plain invokable call, not a property read, so it isn't by itself
+        // enough to make this binding re-evaluate after a rename (BinFolderModel.count doesn't
+        // change either). Reading undoAvailable is a cheap way to add that dependency: its
+        // NOTIFY is undoStackChanged, which fires after every project edit including a rename.
+        readonly property var folderOptions: {
+            void EditorState.undoAvailable
+            const currentFolderId = root.pendingMoveAssetCurrentFolderId
+            const out = []
+            if (currentFolderId !== "")
+                out.push({ id: "", name: qsTr("Media") })
+            for (let i = 0; i < BinFolderModel.count; ++i) {
+                const folder = BinFolderModel.folderAt(i)
+                if (folder.id !== currentFolderId)
+                    out.push(folder)
+            }
+            return out
+        }
+
+        // A Rectangle used directly as contentItem never reports its explicit `height` as
+        // `implicitHeight`, so the Dialog (which sizes off contentItem.implicitHeight) sees zero
+        // and clips the list away entirely. Wrapping in a Column — which does propagate its
+        // children's real heights into implicitHeight — is the same fix LanguageChooserDialog
+        // already uses for the identical list-in-a-dialog shape.
+        contentItem: Column {
+            width: parent ? parent.width : Theme.dialogWidthSm
+
+            Rectangle {
+                width: parent.width
+                height: Math.min(pickerList.contentHeight + 2, 280)
+                radius: Theme.radiusSm
+                color: Theme.appBackground
+                border.width: Theme.borderWidth
+                border.color: Theme.panelBorder
+                clip: true
+
+                ListView {
+                    id: pickerList
+                    anchors.fill: parent
+                    anchors.margins: 1
+                    clip: true
+                    model: folderPickerDialog.folderOptions
+                    interactive: contentHeight > height
+                    boundsBehavior: Flickable.StopAtBounds
+                    ScrollBar.vertical: AppScrollBar { }
+
+                    delegate: ItemDelegate {
+                        id: optionRow
+                        required property var modelData
+                        width: pickerList.width
+                        height: 40
+                        hoverEnabled: true
+
+                        HoverHandler {
+                            cursorShape: Qt.PointingHandCursor
+                        }
+
+                        background: Rectangle {
+                            color: optionRow.hovered ? Theme.popoverHover : "transparent"
+                        }
+
+                        contentItem: Text {
+                            anchors.fill: parent
+                            anchors.leftMargin: 12
+                            anchors.rightMargin: 12
+                            verticalAlignment: Text.AlignVCenter
+                            text: optionRow.modelData.name
+                            elide: Text.ElideRight
+                            color: Theme.panelForeground
+                            font.family: Theme.fontFamily
+                            font.pixelSize: Theme.fontSizeSm
+                        }
+
+                        onClicked: {
+                            if (root.pendingMoveAssetIndex >= 0)
+                                EditorState.moveAssetToFolder(root.pendingMoveAssetIndex, optionRow.modelData.id)
+                            root.pendingMoveAssetIndex = -1
+                            folderPickerDialog.close()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // Points a bin row at a different file while every clip using it stays put, so a project set
     // up once — music, outro, CTA — can be re-pointed at the next video instead of rebuilt.
     function requestReplaceAsset(assetIndex) {
@@ -552,6 +736,15 @@ PanelFrame {
                                 AssetLibrary.sortByKind()
                             root.sortByKind = !root.sortByKind
                         }
+                    }
+
+                    ThemedButton {
+                        text: qsTr("New Folder")
+                        variant: "ghost"
+                        glyph: Theme.icons.folder
+                        tooltip: qsTr("Create a new folder here")
+                        anchors.verticalCenter: parent.verticalCenter
+                        onClicked: newFolderDialog.open()
                     }
 
                     ThemedButton {
@@ -971,6 +1164,8 @@ PanelFrame {
                 onRenameRequested: (assetIndex) => root.requestRenameAsset(assetIndex)
                 onExportRequested: (assetIndex) => root.requestExportAsset(assetIndex)
                 onImportRequested: root.importMedia()
+                onMoveToFolderRequested: (assetIndex) => root.requestMoveAssetToFolder(assetIndex)
+                onFolderRenameRequested: (folderId, folderName) => root.requestRenameFolder(folderId, folderName)
             }
         }
     }

--- a/src/qml/components/assets/BinBreadcrumb.qml
+++ b/src/qml/components/assets/BinBreadcrumb.qml
@@ -1,0 +1,79 @@
+import QtQuick
+import QtQuick.Controls.Basic
+import Drift
+import ".."
+
+// Path trail back to the bin root for the folder currently being viewed. Walks
+// BinFolderModel.folderById up through parentId; only shown once folders exist.
+Row {
+    id: root
+
+    property string currentFolderId: ""
+    signal navigate(string folderId)
+
+    spacing: 4
+    visible: BinFolderModel.count > 0
+    // Row sizes itself from its Repeater's content regardless of `visible`; collapse it
+    // explicitly so an invisible breadcrumb doesn't leave a gap before the search field.
+    height: visible ? implicitHeight : 0
+
+    // folderById() is a plain invokable call, not a property read, so on its own it gives
+    // `trail` nothing to depend on — the crumb would only ever refresh when currentFolderId
+    // itself changes, never when a folder along the trail is renamed (live, or reverted via
+    // undo/redo) while it's still showing. BinFolderModel.dataChanged is the model's own signal
+    // for exactly that, now that it actually fires for renames.
+    property int _refreshTick: 0
+    Connections {
+        target: BinFolderModel
+        function onDataChanged() { root._refreshTick++ }
+    }
+
+    readonly property var trail: {
+        void root._refreshTick
+        const chain = []
+        let id = root.currentFolderId
+        while (id !== "") {
+            const folder = BinFolderModel.folderById(id)
+            if (!folder || Object.keys(folder).length === 0)
+                break
+            chain.unshift(folder)
+            id = folder.parentId
+        }
+        return [{id: "", name: qsTr("Media")}].concat(chain)
+    }
+
+    Repeater {
+        model: root.trail
+        delegate: Row {
+            required property var modelData
+            required property int index
+            spacing: 4
+
+            IconGlyph {
+                visible: index > 0
+                anchors.verticalCenter: crumbLabel.verticalCenter
+                glyph: Theme.icons.chevronRight
+                iconSize: Theme.iconSizeSm
+                iconColor: Theme.mutedForeground
+            }
+
+            Text {
+                id: crumbLabel
+                text: modelData.name
+                color: modelData.id === root.currentFolderId
+                       ? Theme.panelForeground : Theme.mutedForeground
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeSm
+                font.weight: modelData.id === root.currentFolderId ? Font.Medium : Font.Normal
+
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: modelData.id === root.currentFolderId
+                                 ? Qt.ArrowCursor : Qt.PointingHandCursor
+                    enabled: modelData.id !== root.currentFolderId
+                    onClicked: root.navigate(modelData.id)
+                }
+            }
+        }
+    }
+}

--- a/src/qml/components/assets/MediaAssetsTab.qml
+++ b/src/qml/components/assets/MediaAssetsTab.qml
@@ -31,38 +31,114 @@ Item {
     signal exportRequested(int assetIndex)
     // Emitted when the empty-state action asks to import media.
     signal importRequested()
+    // Emitted from the card/row context menu — the only way to move an asset into a folder;
+    // there is no drag-onto-a-folder-tile path on desktop or touch. The parent owns the
+    // folder-picker dialog.
+    signal moveToFolderRequested(int assetIndex)
+    // Emitted from a folder tile's context menu. The parent owns the rename dialog.
+    signal folderRenameRequested(string folderId, string folderName)
 
-    function assetMatches(name, kind) {
-        if (!root.assetVisibleFn(kind))
-            return false
-        if (root.query.length === 0)
-            return true
-        return name.toLowerCase().indexOf(root.query) >= 0
+    // Bumped on every project edit (rename, folder create/delete/reparent, move-to-folder,
+    // undo/redo — anything that goes through pushProjectEdit) and on every async metadata
+    // update (import probe/thumbnail landing, replace finishing) so combinedItems below
+    // recomputes for changes a plain JS array wouldn't otherwise notice: unlike binding a
+    // view's `model` straight to AssetLibrary, this array is a one-shot snapshot with no
+    // subscription to the model's own dataChanged — without this tick, a card would keep
+    // showing its provisional kind/duration/thumbnail until an unrelated edit happened to
+    // rebuild the array.
+    //
+    // Routed through a short debounce rather than bumped directly: assigning a freshly-built
+    // array to a view's `model` reconstructs every delegate, not just the row that changed.
+    // A bulk import lands a metadata signal per file per probe/thumbnail stage in quick
+    // succession, and without coalescing that into one rebuild, the whole grid would be torn
+    // down and rebuilt once per signal — quadratic work, and a chance of destroying a delegate
+    // out from under a card that owns an active drag or has its context menu open.
+    property int _refreshTick: 0
+    Timer {
+        id: refreshCoalesceTimer
+        interval: 100
+        onTriggered: root._refreshTick++
+    }
+    Connections {
+        target: EditorState
+        function onUndoStackChanged() { refreshCoalesceTimer.restart() }
+    }
+    Connections {
+        target: AssetLibrary
+        function onAssetMetadataChanged(assetId) { refreshCoalesceTimer.restart() }
     }
 
-    // How many bin rows pass kind + search — drives the "no matches" empty state.
-    readonly property int matchCount: {
+    // Single source of truth for what's shown: folders in the current bin folder first, then
+    // its media, one flat array — not two separately-scrolling views. Every entry carries the
+    // same set of keys regardless of kind (folder rows get placeholder asset fields and vice
+    // versa) so one delegate below can bind every field as `required` without runtime errors.
+    readonly property var combinedItems: {
+        void root._refreshTick
         const q = root.query
-        let n = 0
+        const currentFolder = EditorState.currentBinFolderId
+        const items = []
+
+        for (let j = 0; j < BinFolderModel.count; ++j) {
+            const folder = BinFolderModel.folderAt(j)
+            if (folder.parentId !== currentFolder)
+                continue
+            if (q.length > 0 && folder.name.toLowerCase().indexOf(q) < 0)
+                continue
+            items.push({
+                isFolder: true,
+                folderId: folder.id,
+                name: folder.name,
+                assetIndex: -1,
+                kind: "",
+                duration: "",
+                durationSeconds: 0,
+                path: "",
+                thumbnailPath: "",
+                filmstripPath: ""
+            })
+        }
+
         for (let i = 0; i < AssetLibrary.count; ++i) {
             const asset = AssetLibrary.assetAt(i)
+            if (asset.folderId !== currentFolder)
+                continue
             if (!root.assetVisibleFn(asset.kind))
                 continue
             if (q.length > 0 && asset.name.toLowerCase().indexOf(q) < 0)
                 continue
-            ++n
+            items.push({
+                isFolder: false,
+                folderId: "",
+                name: asset.name,
+                assetIndex: asset.assetIndex,
+                kind: asset.kind,
+                duration: asset.duration,
+                durationSeconds: asset.durationSeconds,
+                path: asset.path,
+                thumbnailPath: asset.thumbnailPath,
+                filmstripPath: asset.filmstripPath
+            })
         }
-        return n
+
+        return items
     }
 
+    // One delegate type for both folder and asset rows — not a DelegateChooser. A
+    // DelegateChooser turned out to change enough about how the chosen delegate is parented
+    // that it broke the drag: the asset card's Drag.active binding started detecting a binding
+    // loop the instant a drag began, and the drag died before DragHandler.active ever went
+    // true. Keeping one concrete item type, with the folder/asset visuals as sibling blocks
+    // toggled by `isFolder`, keeps the exact Column/Rectangle/DragHandler nesting that already
+    // works for the timeline drop.
     Component {
         id: gridDelegate
         Column {
-            width: visible ? Theme.assetCardWidth : 0
+            id: cardRoot
+            width: Theme.assetCardWidth
             spacing: 4
-            visible: root.assetMatches(name, kind)
 
-            required property int index
+            required property bool isFolder
+            required property string folderId
             required property string name
             required property string kind
             required property string duration
@@ -70,8 +146,7 @@ Item {
             required property string path
             required property string thumbnailPath
             required property string filmstripPath
-
-            property int assetIndex: index
+            required property int assetIndex
 
             // Lift on grab: dims and grows slightly, so the card reads as
             // picked up rather than just sitting there while a ghost moves.
@@ -85,7 +160,7 @@ Item {
                 NumberAnimation { duration: Theme.durationFast; easing.type: Theme.easing }
             }
 
-            Drag.active: assetDrag.active
+            Drag.active: !isFolder && assetDrag.active
             Drag.dragType: Drag.Automatic
             Drag.supportedActions: Qt.CopyAction
             Drag.keys: ["text/plain"]
@@ -100,12 +175,18 @@ Item {
             // cursor, while the list rows had both.
             HoverHandler {
                 id: cardHover
-                cursorShape: assetDrag.active ? Qt.ClosedHandCursor : Qt.OpenHandCursor
+                cursorShape: cardRoot.isFolder ? Qt.PointingHandCursor
+                             : (assetDrag.active ? Qt.ClosedHandCursor : Qt.OpenHandCursor)
             }
 
             ThemedToolTip {
-                text: qsTr("%1 — drag to the timeline, right-click to preview").arg(name)
+                text: cardRoot.isFolder ? name
+                      : qsTr("%1 — drag to the timeline, right-click to preview").arg(name)
                 visible: cardHover.hovered
+                // Explicit rather than the default above-parent Popup placement: for the top
+                // row, that placement had no room to spare and overlapped the folder row/search
+                // field above the grid.
+                y: parent.height + 4
             }
 
             Rectangle {
@@ -116,13 +197,24 @@ Item {
                 clip: true
                 border.width: cardHover.hovered ? Theme.borderWidth : 0
                 border.color: Theme.primary
-                scale: cardHover.hovered ? 1.03 : 1.0
+                scale: (!cardRoot.isFolder && cardHover.hovered) ? 1.03 : 1.0
 
                 Behavior on scale {
                     NumberAnimation { duration: Theme.durationFast; easing.type: Theme.easing }
                 }
                 Behavior on border.width {
                     NumberAnimation { duration: Theme.durationFast; easing.type: Theme.easing }
+                }
+                Behavior on color {
+                    ColorAnimation { duration: Theme.durationFast; easing.type: Theme.easing }
+                }
+
+                IconGlyph {
+                    visible: cardRoot.isFolder
+                    anchors.centerIn: parent
+                    glyph: Theme.icons.folder
+                    iconSize: Theme.spacing3xl
+                    iconColor: Theme.mutedForeground
                 }
 
                 // Placeholder while the thumbnail decodes. The
@@ -131,15 +223,15 @@ Item {
                 SkeletonBox {
                     anchors.fill: parent
                     radius: parent.radius
-                    visible: thumbnailPath.length > 0
+                    visible: !cardRoot.isFolder && thumbnailPath.length > 0
                                 && gridThumb.status === Image.Loading
                 }
 
                 Image {
                     id: gridThumb
                     anchors.fill: parent
-                    visible: thumbnailPath.length > 0 && status === Image.Ready
-                    source: thumbnailPath.length > 0 ? EditorState.imageUrl(thumbnailPath) : ""
+                    visible: !cardRoot.isFolder && thumbnailPath.length > 0 && status === Image.Ready
+                    source: !cardRoot.isFolder && thumbnailPath.length > 0 ? EditorState.imageUrl(thumbnailPath) : ""
                     fillMode: Image.PreserveAspectFit
                     asynchronous: true
                     // Fades in rather than popping at full opacity.
@@ -155,8 +247,8 @@ Item {
                     // Also covers Image.Error, so a missing
                     // thumbnail file falls back to the kind icon
                     // instead of staying blank forever.
-                    visible: thumbnailPath.length === 0
-                                || gridThumb.status === Image.Error
+                    visible: !cardRoot.isFolder
+                             && (thumbnailPath.length === 0 || gridThumb.status === Image.Error)
                     glyph: kind === "audio" ? Theme.icons.music
                             : kind === "image" ? Theme.icons.image
                             : Theme.icons.film
@@ -175,7 +267,7 @@ Item {
                     radius: parent.radius
                     color: Theme.scrimStrong
                     readonly property bool busy:
-                        EditorState.replacingAssetId.length > 0
+                        !cardRoot.isFolder && EditorState.replacingAssetId.length > 0
                         && EditorState.replacingAssetId === AssetLibrary.assetIdAt(assetIndex)
                     visible: opacity > 0
                     opacity: busy ? 1 : 0
@@ -201,7 +293,7 @@ Item {
                 }
 
                 Rectangle {
-                    visible: duration.length > 0
+                    visible: !cardRoot.isFolder && duration.length > 0
                     anchors.right: parent.right
                     anchors.bottom: parent.bottom
                     anchors.margins: Theme.spacingSm
@@ -232,7 +324,8 @@ Item {
                     // Touch keeps press-and-hold for the lift below — the menu
                     // is a tap there.
                     enabled: !Theme.touchUi && !assetDrag.active
-                    onLongPressed: cardMenu.popup()
+                    onDoubleTapped: if (cardRoot.isFolder) EditorState.currentBinFolderId = cardRoot.folderId
+                    onLongPressed: cardRoot.isFolder ? folderMenu.popup() : cardMenu.popup()
                 }
                 DragHandler {
                     id: assetDrag
@@ -240,8 +333,10 @@ Item {
                     // clobbering the Grid positioner's x/y.
                     target: null
                     // Touch lifts through TouchDrag instead: a platform drag has
-                    // no touch gesture and cannot leave the sheet.
-                    enabled: !Theme.touchUi
+                    // no touch gesture and cannot leave the sheet. Folders aren't
+                    // draggable at all — moving an asset into one is a context-menu
+                    // action only ("Move to folder…"), not a drag-and-drop target.
+                    enabled: !Theme.touchUi && !cardRoot.isFolder
                     acceptedButtons: Qt.LeftButton
                     onActiveChanged: {
                         if (active) {
@@ -256,21 +351,25 @@ Item {
                 }
                 TapHandler {
                     acceptedButtons: Qt.RightButton
-                    onTapped: cardMenu.popup()
+                    onTapped: cardRoot.isFolder ? folderMenu.popup() : cardMenu.popup()
                 }
 
-                // Hold to carry the asset onto the timeline, tap for the menu.
-                // The phone's asset browser is a modal sheet, which the platform
-                // drag above cannot leave, so touch gets the lift instead.
+                // Hold to carry the asset onto the timeline, tap for the menu. The phone's
+                // asset browser is a modal sheet, which the platform drag above cannot leave,
+                // so touch gets the lift instead. Folders aren't draggable, but this is still
+                // the only tap surface touch has here — leaving it disabled for folder rows
+                // left touch with no way to open a folder or reach its rename/delete menu at
+                // all. A folder's dragKind is left empty so a stray press-and-hold doesn't
+                // start a lift no drop target recognizes as media.
                 TouchLiftArea {
-                    dragKind: "media"
-                    payload: assetIndex
+                    dragKind: cardRoot.isFolder ? "" : "media"
+                    payload: cardRoot.isFolder ? cardRoot.folderId : assetIndex
                     label: name
                     thumbnail: thumbnailPath
                     glyph: kind === "audio" ? Theme.icons.music
                             : kind === "image" ? Theme.icons.image
                             : Theme.icons.film
-                    onLiftTapped: cardMenu.popup()
+                    onLiftTapped: cardRoot.isFolder ? folderMenu.popup() : cardMenu.popup()
                 }
 
                 ThemedContextMenu {
@@ -292,6 +391,12 @@ Item {
                         onTriggered: root.replaceRequested(assetIndex)
                     }
                     ThemedMenuItem {
+                        text: qsTr("Move to folder…")
+                        icon.name: Theme.icons.folder
+                        visible: BinFolderModel.count > 0
+                        onTriggered: root.moveToFolderRequested(assetIndex)
+                    }
+                    ThemedMenuItem {
                         text: qsTr("Export image…")
                         icon.name: Theme.icons.save
                         visible: kind === "image"
@@ -301,6 +406,27 @@ Item {
                         text: qsTr("Remove from project")
                         icon.name: Theme.icons.trash
                         onTriggered: root.removeRequested(assetIndex)
+                    }
+                }
+
+                ThemedContextMenu {
+                    id: folderMenu
+
+                    ThemedMenuItem {
+                        text: qsTr("Open")
+                        icon.name: Theme.icons.folder
+                        onTriggered: EditorState.currentBinFolderId = cardRoot.folderId
+                    }
+                    ThemedMenuItem {
+                        text: qsTr("Rename…")
+                        icon.name: Theme.icons.pencil
+                        onTriggered: root.folderRenameRequested(cardRoot.folderId, cardRoot.name)
+                    }
+                    ThemedMenuSeparator { }
+                    ThemedMenuItem {
+                        text: qsTr("Delete")
+                        icon.name: Theme.icons.trash
+                        onTriggered: EditorState.deleteBinFolder(cardRoot.folderId)
                     }
                 }
             }
@@ -320,11 +446,10 @@ Item {
         id: listDelegate
         Rectangle {
             id: listRow
-            width: listColumn.width
-            height: visible ? 48 : 0
+            width: ListView.view ? ListView.view.width : 0
+            height: 48
             radius: Theme.radiusSm
             color: rowHover.hovered ? Theme.popoverHover : Theme.panelAccent
-            visible: root.assetMatches(name, kind)
             opacity: rowDrag.active ? 0.85 : 1
             scale: rowDrag.active ? 1.02 : 1.0
 
@@ -338,18 +463,18 @@ Item {
                 NumberAnimation { duration: Theme.durationFast; easing.type: Theme.easing }
             }
 
-            required property int index
+            required property bool isFolder
+            required property string folderId
             required property string name
             required property string kind
             required property string duration
             required property string thumbnailPath
-
-            property int assetIndex: index
+            required property int assetIndex
             readonly property bool replaceBusy:
-                EditorState.replacingAssetId.length > 0
+                !isFolder && EditorState.replacingAssetId.length > 0
                 && EditorState.replacingAssetId === AssetLibrary.assetIdAt(assetIndex)
 
-            Drag.active: rowDrag.active
+            Drag.active: !isFolder && rowDrag.active
             Drag.dragType: Drag.Automatic
             Drag.supportedActions: Qt.CopyAction
             Drag.keys: ["text/plain"]
@@ -359,7 +484,8 @@ Item {
 
             HoverHandler {
                 id: rowHover
-                cursorShape: rowDrag.active ? Qt.ClosedHandCursor : Qt.OpenHandCursor
+                cursorShape: isFolder ? Qt.PointingHandCursor
+                             : (rowDrag.active ? Qt.ClosedHandCursor : Qt.OpenHandCursor)
             }
 
             Row {
@@ -379,15 +505,15 @@ Item {
                     SkeletonBox {
                         anchors.fill: parent
                         radius: parent.radius
-                        visible: thumbnailPath.length > 0
+                        visible: !listRow.isFolder && thumbnailPath.length > 0
                                     && listThumb.status === Image.Loading
                     }
 
                     Image {
                         id: listThumb
                         anchors.fill: parent
-                        visible: thumbnailPath.length > 0 && status === Image.Ready
-                        source: thumbnailPath.length > 0 ? EditorState.imageUrl(thumbnailPath) : ""
+                        visible: !listRow.isFolder && thumbnailPath.length > 0 && status === Image.Ready
+                        source: !listRow.isFolder && thumbnailPath.length > 0 ? EditorState.imageUrl(thumbnailPath) : ""
                         fillMode: Image.PreserveAspectFit
                         // Was missing, so list thumbnails decoded
                         // on the UI thread and stalled scrolling.
@@ -396,9 +522,10 @@ Item {
 
                     IconGlyph {
                         anchors.centerIn: parent
-                        visible: thumbnailPath.length === 0
-                                    || listThumb.status === Image.Error
-                        glyph: kind === "audio" ? Theme.icons.music : Theme.icons.film
+                        visible: listRow.isFolder
+                                    || thumbnailPath.length === 0 || listThumb.status === Image.Error
+                        glyph: listRow.isFolder ? Theme.icons.folder
+                               : (kind === "audio" ? Theme.icons.music : Theme.icons.film)
                         iconSize: Theme.iconSizeBase
                         iconColor: Theme.mutedForeground
                     }
@@ -439,6 +566,7 @@ Item {
                         width: parent.width
                     }
                     Text {
+                        visible: !listRow.isFolder
                         text: kind + (duration.length > 0 ? " · " + duration : "")
                         color: Theme.mutedForeground
                         font.pixelSize: Theme.fontSizeXs
@@ -452,8 +580,10 @@ Item {
             }
 
             ThemedToolTip {
-                text: qsTr("%1 — drag to the timeline, right-click to preview").arg(name)
+                text: listRow.isFolder ? name
+                      : qsTr("%1 — drag to the timeline, right-click to preview").arg(name)
                 visible: rowHover.hovered
+                y: parent.height + 4
             }
 
             Item {
@@ -463,12 +593,13 @@ Item {
                 TapHandler {
                     acceptedButtons: Qt.LeftButton
                     enabled: !Theme.touchUi && !rowDrag.active
-                    onLongPressed: rowMenu.popup()
+                    onDoubleTapped: if (listRow.isFolder) EditorState.currentBinFolderId = listRow.folderId
+                    onLongPressed: listRow.isFolder ? folderRowMenu.popup() : rowMenu.popup()
                 }
                 DragHandler {
                     id: rowDrag
                     target: null
-                    enabled: !Theme.touchUi
+                    enabled: !Theme.touchUi && !listRow.isFolder
                     acceptedButtons: Qt.LeftButton
                     onActiveChanged: {
                         if (active) {
@@ -483,19 +614,21 @@ Item {
                 }
                 TapHandler {
                     acceptedButtons: Qt.RightButton
-                    onTapped: rowMenu.popup()
+                    onTapped: listRow.isFolder ? folderRowMenu.popup() : rowMenu.popup()
                 }
 
-                // See the grid card: hold lifts, tap opens the menu.
+                // See the grid card: hold lifts, tap opens the menu — also a folder row's
+                // only touch surface, so it stays enabled there too (empty dragKind so a
+                // stray press-and-hold doesn't start a lift no drop target recognizes).
                 TouchLiftArea {
-                    dragKind: "media"
-                    payload: assetIndex
+                    dragKind: listRow.isFolder ? "" : "media"
+                    payload: listRow.isFolder ? listRow.folderId : assetIndex
                     label: name
                     thumbnail: thumbnailPath
                     glyph: kind === "audio" ? Theme.icons.music
                             : kind === "image" ? Theme.icons.image
                             : Theme.icons.film
-                    onLiftTapped: rowMenu.popup()
+                    onLiftTapped: listRow.isFolder ? folderRowMenu.popup() : rowMenu.popup()
                 }
             }
 
@@ -518,6 +651,12 @@ Item {
                     onTriggered: root.replaceRequested(assetIndex)
                 }
                 ThemedMenuItem {
+                    text: qsTr("Move to folder…")
+                    icon.name: Theme.icons.folder
+                    visible: BinFolderModel.count > 0
+                    onTriggered: root.moveToFolderRequested(assetIndex)
+                }
+                ThemedMenuItem {
                     text: qsTr("Export image…")
                     icon.name: Theme.icons.save
                     visible: kind === "image"
@@ -529,16 +668,37 @@ Item {
                     onTriggered: root.removeRequested(assetIndex)
                 }
             }
+
+            ThemedContextMenu {
+                id: folderRowMenu
+
+                ThemedMenuItem {
+                    text: qsTr("Open")
+                    icon.name: Theme.icons.folder
+                    onTriggered: EditorState.currentBinFolderId = listRow.folderId
+                }
+                ThemedMenuItem {
+                    text: qsTr("Rename…")
+                    icon.name: Theme.icons.pencil
+                    onTriggered: root.folderRenameRequested(listRow.folderId, listRow.name)
+                }
+                ThemedMenuSeparator { }
+                ThemedMenuItem {
+                    text: qsTr("Delete")
+                    icon.name: Theme.icons.trash
+                    onTriggered: EditorState.deleteBinFolder(listRow.folderId)
+                }
+            }
         }
     }
 
-    // First-run screen for a project with no media. This area used to
-    // render as a blank rectangle, with no hint that the panel accepts
-    // drops or that an Import button exists.
+    // First-run screen for a project with no media at all — folders included. This area used
+    // to render as a blank rectangle, with no hint that the panel accepts drops or that an
+    // Import button exists.
     EmptyState {
         width: parent.width
         height: parent.height
-        visible: AssetLibrary.count === 0 && !root.importing
+        visible: AssetLibrary.count === 0 && BinFolderModel.count === 0 && !root.importing
         glyph: Theme.icons.film
         title: qsTr("No media yet")
         hint: qsTr("Import video, audio or images, then drag them onto the timeline. Right-click a clip to preview and trim it first.")
@@ -547,37 +707,62 @@ Item {
         onActionTriggered: root.importRequested()
     }
 
-    ThemedTextField {
-        id: search
+    BinBreadcrumb {
+        id: breadcrumb
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.margins: Theme.pagePadding
-        visible: AssetLibrary.count > 0
+        anchors.bottomMargin: 0
+        currentFolderId: EditorState.currentBinFolderId
+        onNavigate: (folderId) => EditorState.currentBinFolderId = folderId
+    }
+
+    ThemedTextField {
+        id: search
+        anchors.top: breadcrumb.visible ? breadcrumb.bottom : parent.top
+        anchors.topMargin: breadcrumb.visible ? Theme.spacingSm : 0
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.margins: Theme.pagePadding
+        visible: AssetLibrary.count > 0 || BinFolderModel.count > 0
         placeholderText: qsTr("Search media")
         font.family: Theme.fontFamily
     }
 
+    // Search matched nothing in this folder.
     EmptyState {
         anchors.centerIn: parent
         width: parent.width
-        visible: AssetLibrary.count > 0 && root.matchCount === 0
+        visible: root.query.length > 0 && root.combinedItems.length === 0
         compact: true
         glyph: Theme.icons.search
         title: qsTr("No media match “%1”").arg(search.text.trim())
         hint: qsTr("Try a different name.")
     }
 
+    // This folder (or root, once other folders exist) has nothing in it, but the project
+    // isn't empty — distinct from the "No media yet" first-run state above.
+    EmptyState {
+        anchors.centerIn: parent
+        width: parent.width
+        visible: root.query.length === 0 && root.combinedItems.length === 0
+                 && (AssetLibrary.count > 0 || BinFolderModel.count > 0)
+        compact: true
+        glyph: Theme.icons.folder
+        title: qsTr("This folder is empty")
+        hint: qsTr("Drag media here, or import more.")
+    }
+
     GridView {
         id: grid
-        visible: root.gridMode && AssetLibrary.count > 0
-        
+        visible: root.gridMode && root.combinedItems.length > 0
+
         anchors.top: search.bottom
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: parent.bottom
-        
-        
+
         anchors.margins: Theme.pagePadding
         anchors.topMargin: Theme.spacingMd
         anchors.rightMargin: Theme.pagePadding - Theme.assetCardGap
@@ -588,13 +773,13 @@ Item {
         clip: true
         ScrollBar.vertical: AppScrollBar { }
 
-        model: AssetLibrary
+        model: root.combinedItems
         delegate: gridDelegate
     }
 
     ListView {
         id: listColumn
-        visible: !root.gridMode && AssetLibrary.count > 0
+        visible: !root.gridMode && root.combinedItems.length > 0
 
         anchors.top: search.bottom
         anchors.left: parent.left
@@ -609,7 +794,7 @@ Item {
         clip: true
         ScrollBar.vertical: AppScrollBar { }
 
-        model: AssetLibrary
+        model: root.combinedItems
         delegate: listDelegate
     }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ qt_add_executable(tst_editorstate
     ../src/models/AppController.cpp
     ../src/models/AddonManager.cpp
     ../src/models/AssetLibrary.cpp
+    ../src/models/BinFolderListModel.cpp
     ../src/models/TimelineModel.cpp
     ../src/models/ClipListModel.cpp
     ../src/playback/PlaybackEngine.cpp
@@ -111,6 +112,7 @@ qt_add_executable(tst_mcp
     ../src/models/AppController.cpp
     ../src/models/AddonManager.cpp
     ../src/models/AssetLibrary.cpp
+    ../src/models/BinFolderListModel.cpp
     ../src/models/TimelineModel.cpp
     ../src/models/ClipListModel.cpp
     ../src/playback/PlaybackEngine.cpp

--- a/tests/tst_core.cpp
+++ b/tests/tst_core.cpp
@@ -37,6 +37,8 @@ private slots:
     void legacyTrackInterpolationMigratesLosslessly();
     void keyframeNearestQuery();
     void projectSerializationRoundTrip();
+    void binFolderSerializationRoundTrip();
+    void binFolderDeletionMovesChildrenToParent();
     void projectMetadataRoundTrip();
     void effectColorParamSurvivesRoundTrip();
     void clipTransformSerialization();
@@ -401,6 +403,83 @@ void CoreTest::projectSerializationRoundTrip()
     QVERIFY(loaded.hasWorkArea());
     QCOMPARE(loaded.workAreaInUs(), drift::secondsToUs(1.0));
     QCOMPARE(loaded.workAreaOutUs(), drift::secondsToUs(4.0));
+}
+
+void CoreTest::binFolderSerializationRoundTrip()
+{
+    drift::Project project;
+
+    drift::BinFolder root;
+    root.name = QStringLiteral("B-Roll");
+    const QString rootFolderId = project.addBinFolder(root);
+
+    drift::BinFolder nested;
+    nested.name = QStringLiteral("Drone");
+    nested.parentId = rootFolderId;
+    const QString nestedFolderId = project.addBinFolder(nested);
+
+    drift::MediaAsset asset;
+    asset.name = QStringLiteral("aerial.mp4");
+    asset.kind = drift::MediaKind::Video;
+    asset.path = QStringLiteral("/tmp/aerial.mp4");
+    asset.folderId = nestedFolderId;
+    const QString assetId = project.addAsset(asset);
+
+    const QJsonObject json = project.toJson();
+    QString error;
+    const drift::Project loaded = drift::Project::fromJson(json, &error);
+
+    QVERIFY(error.isEmpty());
+    QCOMPARE(loaded.binFolders().size(), 2);
+    QVERIFY(loaded.binFolder(rootFolderId));
+    QCOMPARE(loaded.binFolder(rootFolderId)->parentId, QString());
+    QVERIFY(loaded.binFolder(nestedFolderId));
+    QCOMPARE(loaded.binFolder(nestedFolderId)->parentId, rootFolderId);
+    QVERIFY(loaded.asset(assetId));
+    QCOMPARE(loaded.asset(assetId)->folderId, nestedFolderId);
+}
+
+void CoreTest::binFolderDeletionMovesChildrenToParent()
+{
+    drift::Project project;
+
+    drift::BinFolder parent;
+    parent.name = QStringLiteral("Interviews");
+    const QString parentId = project.addBinFolder(parent);
+
+    drift::BinFolder child;
+    child.name = QStringLiteral("Day 1");
+    child.parentId = parentId;
+    const QString childId = project.addBinFolder(child);
+
+    drift::MediaAsset asset;
+    asset.name = QStringLiteral("clip.mp4");
+    asset.kind = drift::MediaKind::Video;
+    asset.path = QStringLiteral("/tmp/clip.mp4");
+    asset.folderId = childId;
+    const QString assetId = project.addAsset(asset);
+
+    // Mirrors BinFolderListModel::deleteFolder + AssetLibrary::reparentAssetsInFolder:
+    // reparent everything that pointed at the deleted folder up to its own parent, then
+    // remove the folder row.
+    const QString deletedParentId = project.binFolder(childId)->parentId;
+    for (const QString &id : project.binFolderOrder()) {
+        drift::BinFolder *folder = project.binFolder(id);
+        if (folder && folder->parentId == childId)
+            folder->parentId = deletedParentId;
+    }
+    for (const QString &id : project.assetOrder()) {
+        drift::MediaAsset *a = project.asset(id);
+        if (a && a->folderId == childId)
+            a->folderId = deletedParentId;
+    }
+    project.binFolders().remove(childId);
+    project.binFolderOrder().removeAll(childId);
+
+    QCOMPARE(project.binFolders().size(), 1);
+    QVERIFY(!project.binFolder(childId));
+    QVERIFY(project.binFolder(parentId));
+    QCOMPARE(project.asset(assetId)->folderId, parentId);
 }
 
 // A colour parameter is stored as a "#rrggbb" string rather than a number, so it has to survive the

--- a/tests/tst_editorstate.cpp
+++ b/tests/tst_editorstate.cpp
@@ -56,6 +56,11 @@ private slots:
     void workAreaMarkClearAndUndo();
     void bookmarkSnapTarget();
     void renameClipAndAsset();
+    void createRenameAndDeleteBinFolder();
+    void undoingBinFolderRenameEmitsDataChanged();
+    void importIntoDeletedFolderFallsBackToRoot();
+    void moveAssetToFolderAndUndo();
+    void deleteBinFolderMovesChildrenAndUndo();
     void moveTrackReordersAndRemapsSelection();
     void addTrackInsertsEmptyTrackByType();
     void projectPersistenceRoundTrip();
@@ -368,6 +373,141 @@ void EditorStateTest::renameClipAndAsset()
     QCOMPARE(library.assetAt(0).value(QStringLiteral("name")).toString(), QStringLiteral("A-roll"));
     // Existing timeline text clip is untouched.
     QCOMPARE(state.clipAt(0, 0).value(QStringLiteral("name")).toString(), QStringLiteral("Hello"));
+}
+
+void EditorStateTest::createRenameAndDeleteBinFolder()
+{
+    AssetLibrary library;
+    AppController state(&library);
+
+    const QString id = state.createBinFolder(QStringLiteral("B-Roll"), QString());
+    QVERIFY(!id.isEmpty());
+    QCOMPARE(state.binFolderModel()->count(), 1);
+    QCOMPARE(state.binFolderModel()->folderById(id).value(QStringLiteral("name")).toString(),
+             QStringLiteral("B-Roll"));
+
+    QVERIFY(state.renameBinFolder(id, QStringLiteral("A-Roll")));
+    QCOMPARE(state.binFolderModel()->folderById(id).value(QStringLiteral("name")).toString(),
+             QStringLiteral("A-Roll"));
+
+    QVERIFY(state.deleteBinFolder(id));
+    QCOMPARE(state.binFolderModel()->count(), 0);
+
+    QVERIFY(state.undoAvailable());
+    state.undo();
+    QCOMPARE(state.binFolderModel()->count(), 1);
+    state.undo();
+    QCOMPARE(state.binFolderModel()->folderById(id).value(QStringLiteral("name")).toString(),
+             QStringLiteral("B-Roll"));
+    state.undo();
+    QCOMPARE(state.binFolderModel()->count(), 0);
+}
+
+void EditorStateTest::undoingBinFolderRenameEmitsDataChanged()
+{
+    AssetLibrary library;
+    AppController state(&library);
+
+    const QString id = state.createBinFolder(QStringLiteral("B-Roll"), QString());
+    QVERIFY(state.renameBinFolder(id, QStringLiteral("A-Roll")));
+
+    // Consumers bound to BinFolderModel (the breadcrumb, folder tiles) rely on dataChanged to
+    // notice a rename that undo/redo reverted behind their backs — the row's own value changing
+    // isn't enough if nothing signals that it did.
+    QSignalSpy dataChangedSpy(state.binFolderModel(), &QAbstractItemModel::dataChanged);
+    state.undo();
+    QVERIFY(dataChangedSpy.count() >= 1);
+    const QModelIndex changedIndex = state.binFolderModel()->index(state.binFolderModel()->indexOfId(id));
+    bool sawNameRole = false;
+    for (const QList<QVariant> &args : dataChangedSpy) {
+        const QModelIndex topLeft = args.at(0).toModelIndex();
+        const QList<int> roles = args.at(2).value<QList<int>>();
+        if (topLeft == changedIndex && roles.contains(int(BinFolderListModel::NameRole)))
+            sawNameRole = true;
+    }
+    QVERIFY(sawNameRole);
+    QCOMPARE(state.binFolderModel()->folderById(id).value(QStringLiteral("name")).toString(),
+             QStringLiteral("B-Roll"));
+}
+
+void EditorStateTest::importIntoDeletedFolderFallsBackToRoot()
+{
+    AssetLibrary library;
+    AppController state(&library);
+
+    const QString folderId = state.createBinFolder(QStringLiteral("Temp"), QString());
+    library.setImportFolderId(folderId);
+    // Mirrors a slow async import completing after its destination folder was deleted out from
+    // under it — the captured id is stale by the time the placeholder row is created.
+    QVERIFY(state.deleteBinFolder(folderId));
+
+    QTemporaryFile file(QDir::tempPath() + QStringLiteral("/drift-import-XXXXXX.mp4"));
+    QVERIFY(file.open());
+    file.write("not a real media file");
+    file.close();
+
+    const QStringList ids = library.importLocalPaths({file.fileName()});
+    QCOMPARE(ids.size(), 1);
+    const int index = library.indexOfId(ids.first());
+    QVERIFY(index >= 0);
+    QCOMPARE(library.assetAt(index).value(QStringLiteral("folderId")).toString(), QString());
+
+    // The probe this kicked off runs on a QtConcurrent worker thread that captures `library` by
+    // raw pointer. Qt's queued-connection context-object safety only protects the case where the
+    // object is destroyed after the worker has already posted its result; it does nothing if the
+    // worker is still running and dereferences that pointer after `library` goes out of scope at
+    // the end of this function. Wait for the probe to actually finish first.
+    QTRY_VERIFY_WITH_TIMEOUT(!library.isImportPending(ids.first()), 5000);
+}
+
+void EditorStateTest::moveAssetToFolderAndUndo()
+{
+    AssetLibrary library;
+    AppController state(&library);
+
+    drift::MediaAsset asset;
+    asset.id = QStringLiteral("asset-1");
+    asset.name = QStringLiteral("clip.mp4");
+    asset.path = QStringLiteral("/tmp/clip.mp4");
+    asset.kind = drift::MediaKind::Video;
+    state.project()->assets().insert(asset.id, asset);
+    state.project()->assetOrder().append(asset.id);
+    library.syncToProject();
+    QCOMPARE(library.count(), 1);
+
+    const QString folderId = state.createBinFolder(QStringLiteral("B-Roll"), QString());
+    QVERIFY(state.moveAssetToFolder(0, folderId));
+    QCOMPARE(library.assetAt(0).value(QStringLiteral("folderId")).toString(), folderId);
+
+    state.undo();
+    QCOMPARE(library.assetAt(0).value(QStringLiteral("folderId")).toString(), QString());
+}
+
+void EditorStateTest::deleteBinFolderMovesChildrenAndUndo()
+{
+    AssetLibrary library;
+    AppController state(&library);
+
+    const QString parentId = state.createBinFolder(QStringLiteral("Interviews"), QString());
+    const QString childId = state.createBinFolder(QStringLiteral("Day 1"), parentId);
+
+    drift::MediaAsset asset;
+    asset.id = QStringLiteral("asset-1");
+    asset.name = QStringLiteral("clip.mp4");
+    asset.path = QStringLiteral("/tmp/clip.mp4");
+    asset.kind = drift::MediaKind::Video;
+    asset.folderId = childId;
+    state.project()->assets().insert(asset.id, asset);
+    state.project()->assetOrder().append(asset.id);
+    library.syncToProject();
+
+    QVERIFY(state.deleteBinFolder(childId));
+    QCOMPARE(state.binFolderModel()->count(), 1);
+    QCOMPARE(library.assetAt(0).value(QStringLiteral("folderId")).toString(), parentId);
+
+    state.undo();
+    QCOMPARE(state.binFolderModel()->count(), 2);
+    QCOMPARE(library.assetAt(0).value(QStringLiteral("folderId")).toString(), childId);
 }
 
 void EditorStateTest::moveTrackReordersAndRemapsSelection()


### PR DESCRIPTION
Media was a single flat list with no way to organize it as projects grew.
Folders can now be created, renamed, and deleted, nest arbitrarily deep, and
are navigated via a breadcrumb; assets move between them via the right-click
"Move to folder…" menu, kept off drag-and-drop after that path proved
unreliable with the existing card/timeline drag mechanics. Deleting a
non-empty folder promotes its contents to the parent instead of deleting
them, and every folder action is a full undo/redo citizen alongside the rest
of the project's edit history.

Folder actions reuse AppController's existing plain-copy undo pattern rather
than the deep-copying one, since none of them touch the timeline — the deep
copy was costing several seconds per edit on larger projects. Async imports
capture their destination folder at start rather than at completion, and
re-validate it against the live project, so a slow import can't land assets
in a folder the user has since navigated away from or deleted. The bin's
combined folder+media view is a derived array rather than the model
directly, so it explicitly resubscribes to asset metadata updates and folder
renames (debounced to avoid rebuilding the whole grid per signal during bulk
imports); the same reactivity gap is why the breadcrumb re-reads folder data
on every model change instead of only on navigation. Touch keeps parity with
desktop through the existing tap-for-menu affordance now enabled for folder
tiles too.

Translates the new UI strings into all supported languages.