### PR TITLE
 perf: Keep preview and export on the GPU so playback and encode no longer copy every frame through the CPU.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,6 +473,7 @@ add_library(driftengine STATIC
     src/engine/GpuCompositor.cpp
     src/engine/GlRuntime.h
     src/engine/GlRuntime.cpp
+    src/engine/VaapiZeroCopy.h
     src/engine/GpuEffectExecutor.h
     src/engine/GpuEffectExecutor.cpp
     src/engine/CompositorFrameHistory.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,6 +437,7 @@ add_library(driftengine STATIC
     src/engine/ObjectDetector.cpp
     src/engine/Exporter.h
     src/engine/Exporter.cpp
+    src/engine/PreviewVideoFrame.h
     src/engine/ClipReader.h
     src/engine/ClipReader.cpp
     src/engine/DebugReport.h

--- a/i18n/drift.ts
+++ b/i18n/drift.ts
@@ -1429,6 +1429,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Faster preview takes effect after you restart Drift.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>System default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6239,6 +6243,14 @@ If playback stutters, try another.</source>
     </message>
     <message>
         <source>100% (system)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Faster preview (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can make playback smoother by keeping video on the graphics card. Turn it off if the picture looks wrong. Takes effect after restart.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/drift_es.ts
+++ b/i18n/drift_es.ts
@@ -1429,6 +1429,10 @@
         <translation>Herramienta de corte</translation>
     </message>
     <message>
+        <source>Faster preview takes effect after you restart Drift.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>System default</source>
         <translation>Valor por defecto del sistema</translation>
     </message>
@@ -6247,6 +6251,14 @@ Si la reproducción se corta, prueba con otra opción.</translation>
     <message>
         <source>100% (system)</source>
         <translation>100% (sistema)</translation>
+    </message>
+    <message>
+        <source>Faster preview (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can make playback smoother by keeping video on the graphics card. Turn it off if the picture looks wrong. Takes effect after restart.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Makes buttons, text, and icons larger. This is extra scale on top of the size already set in your display settings. Takes effect after restart.</source>

--- a/i18n/drift_fr_CA.ts
+++ b/i18n/drift_fr_CA.ts
@@ -1431,6 +1431,10 @@
         <translation>Outil de coupe</translation>
     </message>
     <message>
+        <source>Faster preview takes effect after you restart Drift.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>System default</source>
         <translation>Par défaut du système</translation>
     </message>
@@ -6250,6 +6254,14 @@ En cas de saccades à la lecture, essayez un autre mode.</translation>
     <message>
         <source>100% (system)</source>
         <translation>100% (système)</translation>
+    </message>
+    <message>
+        <source>Faster preview (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can make playback smoother by keeping video on the graphics card. Turn it off if the picture looks wrong. Takes effect after restart.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Makes buttons, text, and icons larger. This is extra scale on top of the size already set in your display settings. Takes effect after restart.</source>

--- a/i18n/drift_it.ts
+++ b/i18n/drift_it.ts
@@ -1429,6 +1429,10 @@
         <translation>Strumento Taglierina</translation>
     </message>
     <message>
+        <source>Faster preview takes effect after you restart Drift.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>System default</source>
         <translation>Predefinito di sistema</translation>
     </message>
@@ -6247,6 +6251,14 @@ Se la riproduzione va a scatti, prova un&apos;altra opzione.</translation>
     <message>
         <source>100% (system)</source>
         <translation>100% (sistema)</translation>
+    </message>
+    <message>
+        <source>Faster preview (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can make playback smoother by keeping video on the graphics card. Turn it off if the picture looks wrong. Takes effect after restart.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Makes buttons, text, and icons larger. This is extra scale on top of the size already set in your display settings. Takes effect after restart.</source>

--- a/i18n/drift_pt_BR.ts
+++ b/i18n/drift_pt_BR.ts
@@ -1429,6 +1429,10 @@
         <translation>Ferramenta de corte</translation>
     </message>
     <message>
+        <source>Faster preview takes effect after you restart Drift.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>System default</source>
         <translation>Padrão do sistema</translation>
     </message>
@@ -6247,6 +6251,14 @@ Se a reprodução travar, experimente outro.</translation>
     <message>
         <source>100% (system)</source>
         <translation>100% (sistema)</translation>
+    </message>
+    <message>
+        <source>Faster preview (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can make playback smoother by keeping video on the graphics card. Turn it off if the picture looks wrong. Takes effect after restart.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Makes buttons, text, and icons larger. This is extra scale on top of the size already set in your display settings. Takes effect after restart.</source>

--- a/i18n/drift_si.ts
+++ b/i18n/drift_si.ts
@@ -1429,6 +1429,10 @@
         <translation>කැපුම් මෙවලම</translation>
     </message>
     <message>
+        <source>Faster preview takes effect after you restart Drift.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>System default</source>
         <translation>පද්ධති පෙරනිමිය</translation>
     </message>
@@ -6247,6 +6251,14 @@ If playback stutters, try another.</source>
     <message>
         <source>100% (system)</source>
         <translation>100% (පද්ධතිය)</translation>
+    </message>
+    <message>
+        <source>Faster preview (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can make playback smoother by keeping video on the graphics card. Turn it off if the picture looks wrong. Takes effect after restart.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Makes buttons, text, and icons larger. This is extra scale on top of the size already set in your display settings. Takes effect after restart.</source>

--- a/i18n/drift_zh_Hans.ts
+++ b/i18n/drift_zh_Hans.ts
@@ -1428,6 +1428,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Faster preview takes effect after you restart Drift.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>System default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6229,6 +6233,14 @@ If playback stutters, try another.</source>
     </message>
     <message>
         <source>100% (system)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Faster preview (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can make playback smoother by keeping video on the graphics card. Turn it off if the picture looks wrong. Takes effect after restart.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/engine/ClipReader.cpp
+++ b/src/engine/ClipReader.cpp
@@ -5,6 +5,7 @@
 
 #include <QTransform>
 #include <QtMath>
+#include <QByteArray>
 #include <QFile>
 #include <QDir>
 #include <QUuid>
@@ -152,60 +153,6 @@ AVPixelFormat hwGetFormat(AVCodecContext *ctx, const AVPixelFormat *pixFmts)
     return pixFmts ? pixFmts[0] : AV_PIX_FMT_NONE;
 }
 
-// Rotate a plane of Sample-sized elements. NV12's UV plane is half-resolution
-// interleaved U,V pairs, and 4:2:0's 2x2 subsampling is symmetric, so rotating it as
-// 16-bit samples keeps each pair's U,V order intact. Templated on the sample so the
-// inner loop is a plain typed store — this runs per preview frame.
-template <typename Sample>
-void rotatePlane(const Sample *src, Sample *dst, int srcW, int srcH, int rotation)
-{
-    const int dstW = (rotation == 180) ? srcW : srcH;
-    for (int y = 0; y < srcH; ++y) {
-        const Sample *row = src + qsizetype(y) * srcW;
-        for (int x = 0; x < srcW; ++x) {
-            int dx = 0;
-            int dy = 0;
-            switch (rotation) {
-            case 90:
-                dx = srcH - 1 - y;
-                dy = x;
-                break;
-            case 180:
-                dx = srcW - 1 - x;
-                dy = srcH - 1 - y;
-                break;
-            default: // 270
-                dx = y;
-                dy = srcW - 1 - x;
-                break;
-            }
-            dst[qsizetype(dy) * dstW + dx] = row[x];
-        }
-    }
-}
-
-Nv12Frame rotateNv12(const Nv12Frame &frame, int rotation)
-{
-    if (rotation == 0 || !frame.isValid())
-        return frame;
-
-    Nv12Frame out;
-    out.width = (rotation == 180) ? frame.width : frame.height;
-    out.height = (rotation == 180) ? frame.height : frame.width;
-    out.data.resize(frame.data.size());
-
-    const qsizetype yBytes = qsizetype(frame.width) * frame.height;
-    const uchar *src = reinterpret_cast<const uchar *>(frame.data.constData());
-    uchar *dst = reinterpret_cast<uchar *>(out.data.data());
-    rotatePlane(src, dst, frame.width, frame.height, rotation);
-    // Both dimensions are even (frameToNv12 masks them), so yBytes is even and the UV
-    // plane is 2-byte aligned — safe to walk it as U,V pairs.
-    rotatePlane(reinterpret_cast<const quint16 *>(src + yBytes),
-                reinterpret_cast<quint16 *>(dst + yBytes), frame.width / 2, frame.height / 2,
-                rotation);
-    return out;
-}
-
 QImage frameToRgba(const AVFrame *frame, SwsContext *&sws, int targetWidth, int targetHeight,
                    int rotation)
 {
@@ -246,75 +193,47 @@ QImage frameToRgba(const AVFrame *frame, SwsContext *&sws, int targetWidth, int 
     return copy;
 }
 
-// Pack an NV12 AVFrame into the flat Y-then-UV buffer the compositor uploads.
-Nv12Frame packNv12(const AVFrame *nv12, int targetWidth, int targetHeight)
+// Software preview frames: NV12 at the decode size, still an AVFrame (no packed
+// QByteArray, no CPU rotate). The GL importer honours linesize and applies rotation.
+AVFrame *softwareFrameToNv12(const AVFrame *frame, SwsContext *&sws, int targetWidth, int targetHeight)
 {
-    Nv12Frame out;
-    const qsizetype yBytes = qsizetype(targetWidth) * targetHeight;
-    const qsizetype uvBytes = qsizetype(targetWidth) * (targetHeight / 2);
-    out.data.resize(yBytes + uvBytes);
-    // Copy plane-by-plane in case linesize > width.
-    for (int y = 0; y < targetHeight; ++y) {
-        memcpy(out.data.data() + qsizetype(y) * targetWidth, nv12->data[0] + y * nv12->linesize[0],
-               size_t(targetWidth));
-    }
-    for (int y = 0; y < targetHeight / 2; ++y) {
-        memcpy(out.data.data() + yBytes + qsizetype(y) * targetWidth,
-               nv12->data[1] + y * nv12->linesize[1], size_t(targetWidth));
-    }
-    out.width = targetWidth;
-    out.height = targetHeight;
-    return out;
-}
-
-Nv12Frame frameToNv12(const AVFrame *frame, SwsContext *&sws, int targetWidth, int targetHeight,
-                      int rotation)
-{
-    Nv12Frame out;
     if (!frame || targetWidth <= 0 || targetHeight <= 0)
-        return out;
+        return nullptr;
     if (isHardwarePixelFormat(static_cast<AVPixelFormat>(frame->format)))
-        return out;
+        return nullptr;
 
-    // NV12 requires even dimensions.
     targetWidth &= ~1;
     targetHeight &= ~1;
     if (targetWidth < 2 || targetHeight < 2)
-        return out;
+        return nullptr;
 
-    // The VAAPI VPP path already produced NV12 at exactly this size — packing it
-    // directly skips a full-frame scale that would only be a copy.
     if (frame->format == AV_PIX_FMT_NV12 && frame->width == targetWidth
-        && frame->height == targetHeight) {
-        return rotateNv12(packNv12(frame, targetWidth, targetHeight), rotation);
-    }
+        && frame->height == targetHeight)
+        return av_frame_clone(frame);
 
     const int flags = swsFlagsForResize(frame->width, frame->height, targetWidth, targetHeight);
     sws = sws_getCachedContext(sws, frame->width, frame->height,
                                static_cast<AVPixelFormat>(frame->format), targetWidth, targetHeight,
                                AV_PIX_FMT_NV12, flags, nullptr, nullptr, nullptr);
     if (!sws)
-        return out;
-    // Keep limited-range YUV so GlRuntime's TV-range BT.709 shader expands correctly.
-    configureDecodeSws(sws, frame, 0 /* limited-range NV12 */);
+        return nullptr;
+    configureDecodeSws(sws, frame, frame->color_range == AVCOL_RANGE_JPEG ? 1 : 0);
 
     AVFrame *nv12 = av_frame_alloc();
     if (!nv12)
-        return out;
-
+        return nullptr;
     nv12->format = AV_PIX_FMT_NV12;
     nv12->width = targetWidth;
     nv12->height = targetHeight;
+    nv12->colorspace = frame->colorspace;
+    nv12->color_range = frame->color_range;
+    nv12->pts = frame->pts;
     if (av_frame_get_buffer(nv12, 0) < 0) {
         av_frame_free(&nv12);
-        return out;
+        return nullptr;
     }
-
     sws_scale(sws, frame->data, frame->linesize, 0, frame->height, nv12->data, nv12->linesize);
-
-    out = rotateNv12(packNv12(nv12, targetWidth, targetHeight), rotation);
-    av_frame_free(&nv12);
-    return out;
+    return nv12;
 }
 
 drift::TimeUs ptsToUs(const AVFrame *frame, const AVRational &timeBase)
@@ -358,7 +277,7 @@ void ClipReader::teardownVideoDecoder()
     m_decodeW = 0;
     m_decodeH = 0;
     m_videoCache.clear();
-    m_nv12Cache.clear();
+    m_previewCache.clear();
 }
 
 QSize ClipReader::decodeSizeFor(int maxWidth, int maxHeight) const
@@ -400,7 +319,7 @@ void ClipReader::applyDecodeSize(const QSize &size)
     m_decodeW = size.width();
     m_decodeH = size.height();
     m_videoCache.clear();
-    m_nv12Cache.clear();
+    m_previewCache.clear();
 }
 
 namespace {
@@ -506,13 +425,13 @@ void ClipReader::storeCachedFrame(drift::TimeUs ptsUs, const QImage &image)
         m_videoCache.removeLast();
 }
 
-bool ClipReader::lookupCachedNv12(drift::TimeUs sourceUs, Nv12Frame &out) const
+bool ClipReader::lookupCachedPreview(drift::TimeUs sourceUs, PreviewVideoFrame &out) const
 {
     const drift::TimeUs tolerance = frameToleranceUs();
     drift::TimeUs bestDelta = tolerance + 1;
     int bestIndex = -1;
-    for (int i = 0; i < m_nv12Cache.size(); ++i) {
-        const drift::TimeUs delta = qAbs(m_nv12Cache.at(i).ptsUs - sourceUs);
+    for (int i = 0; i < m_previewCache.size(); ++i) {
+        const drift::TimeUs delta = qAbs(m_previewCache.at(i).ptsUs - sourceUs);
         if (delta <= tolerance && delta < bestDelta) {
             bestDelta = delta;
             bestIndex = i;
@@ -521,76 +440,79 @@ bool ClipReader::lookupCachedNv12(drift::TimeUs sourceUs, Nv12Frame &out) const
     if (bestIndex < 0)
         return false;
 
-    out = m_nv12Cache.at(bestIndex).frame;
+    out = m_previewCache.at(bestIndex).frame;
     return out.isValid();
 }
 
-void ClipReader::storeCachedNv12(drift::TimeUs ptsUs, const Nv12Frame &frame)
+void ClipReader::storeCachedPreview(drift::TimeUs ptsUs, const PreviewVideoFrame &frame)
 {
     if (!frame.isValid())
         return;
 
-    for (int i = 0; i < m_nv12Cache.size(); ++i) {
-        if (m_nv12Cache.at(i).ptsUs == ptsUs) {
-            m_nv12Cache.move(i, 0);
+    for (int i = 0; i < m_previewCache.size(); ++i) {
+        if (m_previewCache.at(i).ptsUs == ptsUs) {
+            m_previewCache.move(i, 0);
             return;
         }
     }
 
-    m_nv12Cache.prepend(CachedNv12{ptsUs, frame});
-    trimNv12Cache();
+    m_previewCache.prepend(CachedPreview{ptsUs, frame});
+    trimPreviewCache();
 }
 
-int ClipReader::nv12CacheCapacity() const
+int ClipReader::previewCacheCapacity() const
 {
+    const int historyFrames = qMax(kMinCachedFrames, kMaxCachedFrames / m_previewCacheShares);
+
+    const bool hw = !m_previewCache.isEmpty() && m_previewCache.constFirst().frame.isHardware();
+    if (hw) {
+        return qMax(2, kMaxHwCachedFrames / m_previewCacheShares);
+    }
+
     if (m_readAheadUs <= 0 || m_sourceFrameDurationUs <= 0)
         return kMaxCachedFrames;
 
     const int aheadFrames =
         qBound(0, static_cast<int>(m_readAheadUs / m_sourceFrameDurationUs), kMaxReadAheadFrames);
-    // The history slots stay reserved on top of the read-ahead: time_echo and
-    // backward scrubbing read behind the playhead and must not lose their frames
-    // to the buffer in front of it.
-    const int historyFrames = qMax(kMinCachedFrames, kMaxCachedFrames / m_nv12CacheShares);
     int capacity = historyFrames + aheadFrames;
 
-    const qsizetype frameBytes = m_nv12Cache.isEmpty() ? 0 : m_nv12Cache.constFirst().frame.data.size();
+    qsizetype frameBytes = 0;
+    if (!m_previewCache.isEmpty() && m_previewCache.constFirst().frame.frame) {
+        const AVFrame *f = m_previewCache.constFirst().frame.frame.get();
+        frameBytes = av_image_get_buffer_size(static_cast<AVPixelFormat>(f->format), f->width, f->height, 1);
+    }
     if (frameBytes > 0) {
-        const qsizetype budget = kNv12CacheByteBudget / m_nv12CacheShares;
+        const qsizetype budget = kPreviewCacheByteBudget / m_previewCacheShares;
         capacity = qMin<qsizetype>(capacity, qMax<qsizetype>(historyFrames, budget / frameBytes));
     }
     return capacity;
 }
 
-void ClipReader::trimNv12Cache()
+void ClipReader::trimPreviewCache()
 {
-    const int capacity = nv12CacheCapacity();
-    while (m_nv12Cache.size() > capacity) {
-        // Evict what playback is furthest past, not what was decoded longest ago:
-        // plain insertion order would drop the read-ahead frames first, which are
-        // precisely the ones about to be shown. Frames behind the last requested
-        // position go before any frame in front of it.
+    const int capacity = previewCacheCapacity();
+    while (m_previewCache.size() > capacity) {
         int worst = 0;
         drift::TimeUs worstRank = std::numeric_limits<drift::TimeUs>::min();
-        for (int i = 0; i < m_nv12Cache.size(); ++i) {
-            const drift::TimeUs delta = m_lastRequestedNv12Us - m_nv12Cache.at(i).ptsUs;
+        for (int i = 0; i < m_previewCache.size(); ++i) {
+            const drift::TimeUs delta = m_lastRequestedPreviewUs - m_previewCache.at(i).ptsUs;
             const drift::TimeUs rank = delta >= 0 ? delta + std::numeric_limits<qint32>::max() : -delta;
             if (rank > worstRank) {
                 worstRank = rank;
                 worst = i;
             }
         }
-        m_nv12Cache.removeAt(worst);
+        m_previewCache.removeAt(worst);
     }
 }
 
-bool ClipReader::wantsMoreNv12ReadAhead() const
+bool ClipReader::wantsMorePreviewReadAhead() const
 {
     if (m_readAheadUs <= 0 || !m_videoPositioned || m_sourceFrameDurationUs <= 0)
         return false;
-    if (m_nv12Cache.size() >= nv12CacheCapacity())
+    if (m_previewCache.size() >= previewCacheCapacity())
         return false;
-    return m_lastVideoPtsUs - m_lastRequestedNv12Us < m_readAheadUs;
+    return m_lastVideoPtsUs - m_lastRequestedPreviewUs < m_readAheadUs;
 }
 
 void ClipReader::close()
@@ -755,6 +677,9 @@ bool ClipReader::openHardwareDecoderWith(drift::hwaccel::Backend backend)
     m_videoCtx->hw_device_ctx = av_buffer_ref(m_hwDeviceCtx);
     m_videoCtx->opaque = &m_hwPixFmt;
     m_videoCtx->get_format = hwGetFormat;
+    // Preview caches a short ring of hardware surfaces. Without extra pool slots
+    // the decoder stalls once those refs are outstanding.
+    m_videoCtx->extra_hw_frames = kHwExtraFrames;
 
     if (avcodec_open2(m_videoCtx, codec, nullptr) < 0) {
         avcodec_free_context(&m_videoCtx);
@@ -1044,112 +969,111 @@ bool ClipReader::ensureHwScaler(const AVFrame *hwFrame, int targetWidth, int tar
     if (m_hwScalerFailed || !hwFrame->hw_frames_ctx)
         return false;
 
-    // A backend with no surface scaler (D3D11VA) has to read back full-size surfaces;
-    // the sticky flag routes hwFrameToSoftware() straight to that path from here on.
+    // A backend with no surface scaler (D3D11VA) leaves the full-size hardware
+    // frame for the GL importer to downscale.
     const char *scalerName = drift::hwaccel::scaleFilter(m_hwBackend);
     if (!scalerName) {
         m_hwScalerFailed = true;
         return false;
     }
 
-    // Rebuild when the caller's decode size changes, or when the decoder handed us
-    // a new frame pool (it reallocates on resolution changes and after a flush).
     if (m_vppGraph && m_vppW == targetWidth && m_vppH == targetHeight && m_vppFramesCtx
         && m_vppFramesCtx->data == hwFrame->hw_frames_ctx->data) {
         return true;
-    }
-
-    teardownHwScaler();
-
-    m_vppGraph = avfilter_graph_alloc();
-    m_vppScaled = av_frame_alloc();
-    m_swFrame = av_frame_alloc();
-    if (!m_vppGraph || !m_vppScaled || !m_swFrame) {
-        teardownHwScaler();
-        m_hwScalerFailed = true;
-        return false;
     }
 
     const AVFilter *bufferFilter = avfilter_get_by_name("buffer");
     const AVFilter *sinkFilter = avfilter_get_by_name("buffersink");
     const AVFilter *scaleFilter = avfilter_get_by_name(scalerName);
     if (!bufferFilter || !sinkFilter || !scaleFilter) {
-        teardownHwScaler();
         m_hwScalerFailed = true;
         return false;
     }
 
-    // The source has to know the hw frame pool before it is initialized —
-    // "buffer" rejects a hardware pix_fmt with a null hw_frames_ctx.
-    m_vppSrc = avfilter_graph_alloc_filter(m_vppGraph, bufferFilter, "in");
-    if (!m_vppSrc) {
-        teardownHwScaler();
-        m_hwScalerFailed = true;
-        return false;
-    }
-
-    AVBufferSrcParameters *params = av_buffersrc_parameters_alloc();
-    if (!params) {
-        teardownHwScaler();
-        m_hwScalerFailed = true;
-        return false;
-    }
-    params->format = hwFrame->format;
-    params->width = hwFrame->width;
-    params->height = hwFrame->height;
-    params->time_base = m_fmt->streams[m_videoStream]->time_base;
-    params->hw_frames_ctx = hwFrame->hw_frames_ctx;
-    const int paramsRc = av_buffersrc_parameters_set(m_vppSrc, params);
-    av_free(params);
-    if (paramsRc < 0 || avfilter_init_str(m_vppSrc, nullptr) < 0) {
-        teardownHwScaler();
-        m_hwScalerFailed = true;
-        return false;
-    }
-
-    AVFilterContext *scale = nullptr;
-    const QByteArray scaleArgs =
+    const QByteArray sizeArgs =
         QByteArray("w=") + QByteArray::number(targetWidth) + ":h=" + QByteArray::number(targetHeight);
-    if (avfilter_graph_create_filter(&scale, scaleFilter, "vpp", scaleArgs.constData(), nullptr,
-                                     m_vppGraph)
-            < 0
-        || avfilter_graph_create_filter(&m_vppSink, sinkFilter, "out", nullptr, nullptr, m_vppGraph) < 0
-        || avfilter_link(m_vppSrc, 0, scale, 0) < 0 || avfilter_link(scale, 0, m_vppSink, 0) < 0
-        || avfilter_graph_config(m_vppGraph, nullptr) < 0) {
+    const QByteArray args[2] = {sizeArgs + ":format=nv12", sizeArgs};
+
+    for (const QByteArray &scaleArgs : args) {
         teardownHwScaler();
-        m_hwScalerFailed = true;
-        return false;
+
+        m_vppGraph = avfilter_graph_alloc();
+        m_vppScaled = av_frame_alloc();
+        m_swFrame = av_frame_alloc();
+        if (!m_vppGraph || !m_vppScaled || !m_swFrame)
+            continue;
+
+        m_vppSrc = avfilter_graph_alloc_filter(m_vppGraph, bufferFilter, "in");
+        if (!m_vppSrc)
+            continue;
+
+        AVBufferSrcParameters *params = av_buffersrc_parameters_alloc();
+        if (!params)
+            continue;
+        params->format = hwFrame->format;
+        params->width = hwFrame->width;
+        params->height = hwFrame->height;
+        params->time_base = m_fmt->streams[m_videoStream]->time_base;
+        params->hw_frames_ctx = hwFrame->hw_frames_ctx;
+        const int paramsRc = av_buffersrc_parameters_set(m_vppSrc, params);
+        av_free(params);
+        if (paramsRc < 0 || avfilter_init_str(m_vppSrc, nullptr) < 0)
+            continue;
+
+        AVFilterContext *scale = nullptr;
+        if (avfilter_graph_create_filter(&scale, scaleFilter, "vpp", scaleArgs.constData(), nullptr,
+                                         m_vppGraph)
+                < 0
+            || avfilter_graph_create_filter(&m_vppSink, sinkFilter, "out", nullptr, nullptr, m_vppGraph)
+                < 0
+            || avfilter_link(m_vppSrc, 0, scale, 0) < 0 || avfilter_link(scale, 0, m_vppSink, 0) < 0
+            || avfilter_graph_config(m_vppGraph, nullptr) < 0)
+            continue;
+
+        m_vppFramesCtx = av_buffer_ref(hwFrame->hw_frames_ctx);
+        m_vppW = targetWidth;
+        m_vppH = targetHeight;
+        return true;
     }
 
-    m_vppFramesCtx = av_buffer_ref(hwFrame->hw_frames_ctx);
-    m_vppW = targetWidth;
-    m_vppH = targetHeight;
-    return true;
+    teardownHwScaler();
+    m_hwScalerFailed = true;
+    return false;
+}
+
+const AVFrame *ClipReader::scaleHwFrame(const AVFrame *hwFrame, int targetWidth, int targetHeight)
+{
+    if (!hwFrame)
+        return nullptr;
+
+    bool needsFormat = false;
+    if (hwFrame->hw_frames_ctx) {
+        const auto *fc = reinterpret_cast<const AVHWFramesContext *>(hwFrame->hw_frames_ctx->data);
+        needsFormat = fc && fc->sw_format != AV_PIX_FMT_NV12;
+    }
+    if (hwFrame->width == targetWidth && hwFrame->height == targetHeight && !needsFormat)
+        return hwFrame;
+
+    if (!ensureHwScaler(hwFrame, targetWidth, targetHeight))
+        return hwFrame;
+
+    av_frame_unref(m_vppScaled);
+    if (av_buffersrc_add_frame_flags(m_vppSrc, const_cast<AVFrame *>(hwFrame),
+                                     AV_BUFFERSRC_FLAG_KEEP_REF)
+            >= 0
+        && av_buffersink_get_frame(m_vppSink, m_vppScaled) >= 0)
+        return m_vppScaled;
+
+    m_hwScalerFailed = true;
+    teardownHwScaler();
+    return hwFrame;
 }
 
 AVFrame *ClipReader::hwFrameToSoftware(const AVFrame *hwFrame, int targetWidth, int targetHeight)
 {
-    // Downscale on the GPU first when we can: the readback is the dominant cost of
-    // the whole hwaccel path and it is proportional to the surface area, so moving
-    // preview-sized pixels instead of full-resolution ones is most of the win.
-    // Backends without a surface scaler skip this and transfer at full size.
-    if (ensureHwScaler(hwFrame, targetWidth, targetHeight)) {
-        av_frame_unref(m_vppScaled);
-        av_frame_unref(m_swFrame);
-        if (av_buffersrc_add_frame_flags(m_vppSrc, const_cast<AVFrame *>(hwFrame),
-                                         AV_BUFFERSRC_FLAG_KEEP_REF)
-                >= 0
-            && av_buffersink_get_frame(m_vppSink, m_vppScaled) >= 0) {
-            const int rc = av_hwframe_transfer_data(m_swFrame, m_vppScaled, 0);
-            av_frame_unref(m_vppScaled);
-            if (rc >= 0)
-                return m_swFrame;
-            av_frame_unref(m_swFrame);
-        }
-        // The scaler is configured but misbehaving — stop using it, transfer full size.
-        m_hwScalerFailed = true;
-        teardownHwScaler();
-    }
+    const AVFrame *scaled = scaleHwFrame(hwFrame, targetWidth, targetHeight);
+    if (!scaled)
+        return nullptr;
 
     if (!m_swFrame) {
         m_swFrame = av_frame_alloc();
@@ -1157,10 +1081,12 @@ AVFrame *ClipReader::hwFrameToSoftware(const AVFrame *hwFrame, int targetWidth, 
             return nullptr;
     }
     av_frame_unref(m_swFrame);
-    if (av_hwframe_transfer_data(m_swFrame, hwFrame, 0) < 0) {
+    if (av_hwframe_transfer_data(m_swFrame, scaled, 0) < 0) {
         av_frame_unref(m_swFrame);
         return nullptr;
     }
+    if (scaled == m_vppScaled)
+        av_frame_unref(m_vppScaled);
     return m_swFrame;
 }
 
@@ -1263,20 +1189,24 @@ bool ClipReader::convertFrame(const AVFrame *frame, QImage &out, int targetWidth
     return true;
 }
 
-bool ClipReader::convertFrameNv12(const AVFrame *frame, Nv12Frame &out, int targetWidth, int targetHeight)
+bool ClipReader::convertFramePreview(const AVFrame *frame, PreviewVideoFrame &out, int targetWidth,
+                                     int targetHeight)
 {
     if (!frame)
         return false;
 
-    const AVFrame *swFrame = frame;
-    if ((m_hwAccelActive && frame->format == m_hwPixFmt)
-        || isHardwarePixelFormat(static_cast<AVPixelFormat>(frame->format))) {
-        swFrame = hwFrameToSoftware(frame, targetWidth, targetHeight);
-        if (!swFrame)
-            return false;
+    const bool hw = (m_hwAccelActive && frame->format == m_hwPixFmt)
+        || isHardwarePixelFormat(static_cast<AVPixelFormat>(frame->format));
+    if (hw) {
+        const AVFrame *scaled = scaleHwFrame(frame, targetWidth, targetHeight);
+        out = makePreviewFrame(scaled, m_sourceRotation);
+        if (scaled == m_vppScaled)
+            av_frame_unref(m_vppScaled);
+        return out.isValid();
     }
 
-    out = frameToNv12(swFrame, m_swsNv12, targetWidth, targetHeight, m_sourceRotation);
+    AVFrame *nv12 = softwareFrameToNv12(frame, m_swsNv12, targetWidth, targetHeight);
+    out = takePreviewFrame(nv12, m_sourceRotation);
     return out.isValid();
 }
 
@@ -1528,8 +1458,8 @@ bool ClipReader::readVideoFrameAt(drift::TimeUs sourceUs, QImage &out, int maxWi
     return decodeVideoFrameAtOnce(sourceUs, out, maxWidth, maxHeight, nullptr);
 }
 
-bool ClipReader::decodeVideoFrameAtOnceNv12(drift::TimeUs sourceUs, Nv12Frame &out, int maxWidth,
-                                            int maxHeight, bool *hwFailure)
+bool ClipReader::decodePreviewVideoFrameAtOnce(drift::TimeUs sourceUs, PreviewVideoFrame &out, int maxWidth,
+                                               int maxHeight, bool *hwFailure)
 {
     if (hwFailure)
         *hwFailure = false;
@@ -1538,7 +1468,7 @@ bool ClipReader::decodeVideoFrameAtOnceNv12(drift::TimeUs sourceUs, Nv12Frame &o
 
     applyDecodeSize(decodeSizeFor(maxWidth, maxHeight));
 
-    if (lookupCachedNv12(sourceUs, out))
+    if (lookupCachedPreview(sourceUs, out))
         return true;
 
     const drift::TimeUs tolerance = frameToleranceUs();
@@ -1653,10 +1583,10 @@ bool ClipReader::decodeVideoFrameAtOnceNv12(drift::TimeUs sourceUs, Nv12Frame &o
         drained = true;
     }
 
-    Nv12Frame converted;
+    PreviewVideoFrame converted;
     bool convertedOk = false;
     if (found && !sawHwFailure) {
-        convertedOk = convertFrameNv12(best, converted, m_decodeW, m_decodeH);
+        convertedOk = convertFramePreview(best, converted, m_decodeW, m_decodeH);
         if (!convertedOk && m_hwAccelActive
             && (best->format == m_hwPixFmt
                 || isHardwarePixelFormat(static_cast<AVPixelFormat>(best->format)))) {
@@ -1679,7 +1609,7 @@ bool ClipReader::decodeVideoFrameAtOnceNv12(drift::TimeUs sourceUs, Nv12Frame &o
 
     if (convertedOk) {
         out = converted;
-        storeCachedNv12(bestPtsUs, converted);
+        storeCachedPreview(bestPtsUs, converted);
         m_videoPositioned = !drained && !droppedPacket;
         return true;
     }
@@ -1688,13 +1618,14 @@ bool ClipReader::decodeVideoFrameAtOnceNv12(drift::TimeUs sourceUs, Nv12Frame &o
     return false;
 }
 
-bool ClipReader::readVideoFrameAtNv12(drift::TimeUs sourceUs, Nv12Frame &out, int maxWidth, int maxHeight)
+bool ClipReader::readPreviewVideoFrame(drift::TimeUs sourceUs, PreviewVideoFrame &out, int maxWidth,
+                                       int maxHeight)
 {
     if (!m_prefetching)
-        m_lastRequestedNv12Us = sourceUs;
+        m_lastRequestedPreviewUs = sourceUs;
 
     bool hwFailure = false;
-    if (decodeVideoFrameAtOnceNv12(sourceUs, out, maxWidth, maxHeight, &hwFailure))
+    if (decodePreviewVideoFrameAtOnce(sourceUs, out, maxWidth, maxHeight, &hwFailure))
         return true;
 
     if (!hwFailure)
@@ -1703,7 +1634,7 @@ bool ClipReader::readVideoFrameAtNv12(drift::TimeUs sourceUs, Nv12Frame &out, in
     if (!fallbackFromHardwareDecoder())
         return false;
 
-    return decodeVideoFrameAtOnceNv12(sourceUs, out, maxWidth, maxHeight, nullptr);
+    return decodePreviewVideoFrameAtOnce(sourceUs, out, maxWidth, maxHeight, nullptr);
 }
 
 void ClipReader::prefetchNextVideoFrame(int maxWidth, int maxHeight)
@@ -1715,34 +1646,28 @@ void ClipReader::prefetchNextVideoFrame(int maxWidth, int maxHeight)
     readVideoFrameAt(m_lastVideoPtsUs + m_sourceFrameDurationUs, ignored, maxWidth, maxHeight);
 }
 
-bool ClipReader::prefetchNextVideoFrameNv12(int maxWidth, int maxHeight, drift::TimeUs readAheadUs)
+bool ClipReader::prefetchNextPreviewVideoFrame(int maxWidth, int maxHeight, drift::TimeUs readAheadUs)
 {
-    // Sticky: the caller passes the current depth on every prefetch, so dropping
-    // to 0 (playback stopped) shrinks the cache back on the next call.
     m_readAheadUs = qMax<drift::TimeUs>(0, readAheadUs);
-    trimNv12Cache();
+    trimPreviewCache();
 
     if (!m_videoPositioned || m_sourceFrameDurationUs <= 0)
         return false;
 
-    // Step over frames the buffer already holds. A cache hit leaves the decoder
-    // where it is, so walking by decoder position alone would ask for the same
-    // frame forever once the walk reaches an earlier run's frames — which is
-    // exactly what a backward seek into a buffered region sets up.
     drift::TimeUs target = m_lastVideoPtsUs + m_sourceFrameDurationUs;
-    Nv12Frame cached;
-    while (target - m_lastRequestedNv12Us < m_readAheadUs && lookupCachedNv12(target, cached))
+    PreviewVideoFrame cached;
+    while (target - m_lastRequestedPreviewUs < m_readAheadUs && lookupCachedPreview(target, cached))
         target += m_sourceFrameDurationUs;
 
-    if (m_readAheadUs > 0 && target - m_lastRequestedNv12Us >= m_readAheadUs)
+    if (m_readAheadUs > 0 && target - m_lastRequestedPreviewUs >= m_readAheadUs)
         return false;
 
-    Nv12Frame ignored;
+    PreviewVideoFrame ignored;
     m_prefetching = true;
-    const bool decoded = readVideoFrameAtNv12(target, ignored, maxWidth, maxHeight);
+    const bool decoded = readPreviewVideoFrame(target, ignored, maxWidth, maxHeight);
     m_prefetching = false;
 
-    return decoded && wantsMoreNv12ReadAhead();
+    return decoded && wantsMorePreviewReadAhead();
 }
 
 int ClipReader::readAudioInterleaved(drift::TimeUs sourceStartUs, int sampleCount, int outputSampleRate,

--- a/src/engine/ClipReader.h
+++ b/src/engine/ClipReader.h
@@ -1,12 +1,11 @@
 #pragma once
 
 #include "HwAccel.h"
+#include "PreviewVideoFrame.h"
 #include "core/Time.h"
 
-#include <QByteArray>
 #include <QImage>
 #include <QList>
-#include <QMetaType>
 #include <QSize>
 #include <QString>
 #include <QVector>
@@ -17,23 +16,6 @@ extern "C" {
 #include <libavutil/pixfmt.h>
 struct AVFrame;
 }
-
-// Semi-planar NV12 frame for GPU upload (Y plane then interleaved UV).
-struct Nv12Frame
-{
-    QByteArray data;
-    int width = 0;
-    int height = 0;
-
-    bool isValid() const
-    {
-        if (width <= 0 || height <= 0 || (width % 2) || (height % 2))
-            return false;
-        const qsizetype need = qsizetype(width) * height + qsizetype(width) * (height / 2);
-        return data.size() >= need;
-    }
-};
-Q_DECLARE_METATYPE(Nv12Frame)
 
 // Threaded-capable demux/decode for a single media file.
 // Opens its own AVFormatContext; seeks via keyframe + forward decode.
@@ -60,9 +42,9 @@ public:
     // change the decode size — and therefore does not invalidate the frame cache
     // — on every frame. Callers scale the returned image to their layout rect.
     bool readVideoFrameAt(drift::TimeUs sourceUs, QImage &out, int maxWidth, int maxHeight);
-    // Same seek/decode path as readVideoFrameAt, but converts to NV12 for the
-    // preview compositor (half the upload bandwidth vs RGBA).
-    bool readVideoFrameAtNv12(drift::TimeUs sourceUs, Nv12Frame &out, int maxWidth, int maxHeight);
+    // Same seek/decode path as readVideoFrameAt, but returns an AVFrame handle for
+    // the preview compositor (hardware surfaces stay on the GPU).
+    bool readPreviewVideoFrame(drift::TimeUs sourceUs, PreviewVideoFrame &out, int maxWidth, int maxHeight);
     // Decode one frame past the current position into the cache, to overlap
     // decode with the caller's compositing work. Match the format of the last
     // read so prefetch does not consume a frame the other format still needs.
@@ -71,17 +53,17 @@ public:
     // still short of readAheadUs of decoded source past the last frame the
     // caller asked for. Callers step it one frame at a time so a real read never
     // waits behind more than a single decode. 0 keeps the old one-frame prefetch.
-    bool prefetchNextVideoFrameNv12(int maxWidth, int maxHeight, drift::TimeUs readAheadUs = 0);
+    bool prefetchNextPreviewVideoFrame(int maxWidth, int maxHeight, drift::TimeUs readAheadUs = 0);
     int readAudioInterleaved(drift::TimeUs sourceStartUs, int sampleCount, int outputSampleRate,
                              float *interleavedStereoOut);
     // Drop the sequential audio cursor so the next read seeks to the position it is given. The
     // fast path below only honours sourceStartUs on a discontinuity it can see; a seek of the
     // timeline playhead is one it cannot.
     void invalidateAudioPosition() { m_audioPositioned = false; }
-    // How many readers on this media path divide the NV12 read-ahead budget between them. Several
+    // How many readers on this media path divide the preview read-ahead budget between them. Several
     // exist when clips cut from one file overlap; each still keeps a cache, so without this the
     // memory ceiling would multiply by the number of them.
-    void setNv12CacheShare(int shares) { m_nv12CacheShares = qMax(1, shares); }
+    void setPreviewCacheShare(int shares) { m_previewCacheShares = qMax(1, shares); }
 
     // Diagnostics, summed over every reader in this process. A reader asked for a position its
     // cursor is not near has to decode its way there from the preceding keyframe, so this is what
@@ -129,21 +111,21 @@ private:
     void teardownVideoDecoder();
     bool fallbackFromHardwareDecoder();
 
-    // GPU-side downscale so the GPU->CPU readback moves preview-sized pixels
-    // instead of full-resolution ones. Returns a software frame owned by the
-    // reader (valid until the next call), or nullptr to fall back to a plain
-    // full-size transfer.
+    // GPU-side downscale. Returns a hardware frame (the VPP output, or `hwFrame`
+    // when the scaler is skipped/unavailable). Owned by the reader until the next
+    // call. The QImage path then transfers; the preview path clones the surface.
     bool ensureHwScaler(const AVFrame *hwFrame, int targetWidth, int targetHeight);
     void teardownHwScaler();
+    const AVFrame *scaleHwFrame(const AVFrame *hwFrame, int targetWidth, int targetHeight);
     AVFrame *hwFrameToSoftware(const AVFrame *hwFrame, int targetWidth, int targetHeight);
 
     bool transferHwFrameToImage(const AVFrame *hwFrame, QImage &out, int targetWidth, int targetHeight);
     bool convertFrame(const AVFrame *frame, QImage &out, int targetWidth, int targetHeight);
-    bool convertFrameNv12(const AVFrame *frame, Nv12Frame &out, int targetWidth, int targetHeight);
+    bool convertFramePreview(const AVFrame *frame, PreviewVideoFrame &out, int targetWidth, int targetHeight);
     bool decodeVideoFrameAtOnce(drift::TimeUs sourceUs, QImage &out, int maxWidth, int maxHeight,
                                 bool *hwFailure);
-    bool decodeVideoFrameAtOnceNv12(drift::TimeUs sourceUs, Nv12Frame &out, int maxWidth, int maxHeight,
-                                    bool *hwFailure);
+    bool decodePreviewVideoFrameAtOnce(drift::TimeUs sourceUs, PreviewVideoFrame &out, int maxWidth,
+                                       int maxHeight, bool *hwFailure);
     bool seekVideoStream(drift::TimeUs sourceUs);
     bool seekAudioStream(drift::TimeUs sourceUs);
 
@@ -154,11 +136,11 @@ private:
     drift::TimeUs frameToleranceUs() const;
     bool lookupCachedFrame(drift::TimeUs sourceUs, QImage &out) const;
     void storeCachedFrame(drift::TimeUs ptsUs, const QImage &image);
-    bool lookupCachedNv12(drift::TimeUs sourceUs, Nv12Frame &out) const;
-    void storeCachedNv12(drift::TimeUs ptsUs, const Nv12Frame &frame);
-    int nv12CacheCapacity() const;
-    void trimNv12Cache();
-    bool wantsMoreNv12ReadAhead() const;
+    bool lookupCachedPreview(drift::TimeUs sourceUs, PreviewVideoFrame &out) const;
+    void storeCachedPreview(drift::TimeUs ptsUs, const PreviewVideoFrame &frame);
+    int previewCacheCapacity() const;
+    void trimPreviewCache();
+    bool wantsMorePreviewReadAhead() const;
 
     QString m_path;
     struct AVFormatContext *m_fmt = nullptr;
@@ -243,29 +225,33 @@ private:
         QImage image;
     };
     QList<CachedFrame> m_videoCache;
-    struct CachedNv12
+    struct CachedPreview
     {
         drift::TimeUs ptsUs = 0;
-        Nv12Frame frame;
+        PreviewVideoFrame frame;
     };
-    QList<CachedNv12> m_nv12Cache;
+    QList<CachedPreview> m_previewCache;
     static constexpr int kMaxCachedFrames = 16;
+    // Hardware surfaces live in FFmpeg's decoder pool. Holding 2 s of them would
+    // exhaust extra_hw_frames and stall decode, so the GPU ring is short.
+    static constexpr int kMaxHwCachedFrames = 8;
+    static constexpr int kHwExtraFrames = 16;
 
-    // Preview read-ahead. m_lastRequestedNv12Us is the last position a caller
+    // Preview read-ahead. m_lastRequestedPreviewUs is the last position a caller
     // actually asked for — prefetch must not advance it, or the buffer would
     // always measure itself as one frame deep. m_prefetching marks those reads.
     drift::TimeUs m_readAheadUs = 0;
-    drift::TimeUs m_lastRequestedNv12Us = 0;
+    drift::TimeUs m_lastRequestedPreviewUs = 0;
     bool m_prefetching = false;
-    // Read-ahead frames are held in RAM on top of the history above, so the depth
+    // Software read-ahead is held in RAM on top of the history above, so the depth
     // is capped by bytes as well as by time: the same 2 s is 60 frames of a 25 fps
     // 720p clip (~83 MB) but only a handful of 4K ones.
-    static constexpr qsizetype kNv12CacheByteBudget = 128 * 1024 * 1024;
+    static constexpr qsizetype kPreviewCacheByteBudget = 128 * 1024 * 1024;
     static constexpr int kMaxReadAheadFrames = 300;
     // Floor on the history slots even when the byte budget is tighter than they are. It shrinks
     // with the share so several readers on one path cannot each hold a full history.
     static constexpr int kMinCachedFrames = 4;
-    int m_nv12CacheShares = 1;
+    int m_previewCacheShares = 1;
 
     // Sequential audio decode state (mirrors the video fast-path): keep the
     // resampler and demux position across buffers so contiguous playback decodes

--- a/src/engine/ClipReaderPool.cpp
+++ b/src/engine/ClipReaderPool.cpp
@@ -13,7 +13,7 @@ ClipReaderPool &ClipReaderPool::instance()
     static bool registered = false;
     if (!registered) {
         qRegisterMetaType<drift::TimeUs>("drift::TimeUs");
-        qRegisterMetaType<Nv12Frame>("Nv12Frame");
+        qRegisterMetaType<PreviewVideoFrame>("PreviewVideoFrame");
         registered = true;
     }
     return pool;
@@ -132,8 +132,8 @@ void ClipReaderPool::warmVideoFrames(const QList<VideoRequest> &requests)
         // The post happens under the pool mutex: it does not block, and holding the lock is what
         // stops the idle release from deleting the worker between resolving it and posting to it.
         QMutexLocker lock(&m_mutex);
-        // Prefer NV12 warm — matches the live-preview decode path.
-        QMetaObject::invokeMethod(ensureWorker(m_videoWorkers, request.path).worker, "decodeVideoNv12",
+        // Prefer the preview decode path so warm hits the same cache as composite.
+        QMetaObject::invokeMethod(ensureWorker(m_videoWorkers, request.path).worker, "decodePreviewVideo",
                                   Qt::QueuedConnection,
                                   Q_ARG(quint64, request.streamId), Q_ARG(drift::TimeUs, request.sourceUs),
                                   Q_ARG(int, request.maxWidth), Q_ARG(int, request.maxHeight));
@@ -176,10 +176,10 @@ QImage ClipReaderPool::readVideoFrame(const QString &path, quint64 streamId, dri
     return frame;
 }
 
-Nv12Frame ClipReaderPool::readVideoFrameNv12(const QString &path, quint64 streamId,
-                                             drift::TimeUs sourceUs, int maxWidth, int maxHeight,
-                                             const QString &stabilizePath,
-                                             int stabilizeSmoothing, bool stabilizeTripod)
+PreviewVideoFrame ClipReaderPool::readPreviewVideoFrame(const QString &path, quint64 streamId,
+                                                        drift::TimeUs sourceUs, int maxWidth, int maxHeight,
+                                                        const QString &stabilizePath,
+                                                        int stabilizeSmoothing, bool stabilizeTripod)
 {
     if (path.isEmpty())
         return {};
@@ -192,15 +192,16 @@ Nv12Frame ClipReaderPool::readVideoFrameNv12(const QString &path, quint64 stream
     }
     ClipReaderWorker *worker = entry->worker;
 
-    Nv12Frame frame;
-    QMetaObject::invokeMethod(worker, "decodeVideoNv12", Qt::BlockingQueuedConnection,
-                               Q_RETURN_ARG(Nv12Frame, frame), Q_ARG(quint64, streamId),
+    PreviewVideoFrame frame;
+    QMetaObject::invokeMethod(worker, "decodePreviewVideo", Qt::BlockingQueuedConnection,
+                               Q_RETURN_ARG(PreviewVideoFrame, frame), Q_ARG(quint64, streamId),
                                Q_ARG(drift::TimeUs, sourceUs), Q_ARG(int, maxWidth),
                                Q_ARG(int, maxHeight),
-                               Q_ARG(QString, stabilizePath), Q_ARG(int, stabilizeSmoothing), Q_ARG(bool, stabilizeTripod));
+                               Q_ARG(QString, stabilizePath), Q_ARG(int, stabilizeSmoothing),
+                               Q_ARG(bool, stabilizeTripod));
 
-    worker->requestPrefetchNv12(streamId, maxWidth, maxHeight,
-                                m_readAheadUs.load(std::memory_order_relaxed));
+    worker->requestPrefetchPreview(streamId, maxWidth, maxHeight,
+                                   m_readAheadUs.load(std::memory_order_relaxed));
 
     QMutexLocker lock(&m_mutex);
     --entry->inFlight;

--- a/src/engine/ClipReaderPool.h
+++ b/src/engine/ClipReaderPool.h
@@ -51,7 +51,7 @@ public:
 
     // How far past the frame being composited each reader keeps decoding, in
     // source time. Set per composite from the render options; 0 (the default)
-    // leaves the plain one-frame-ahead prefetch. Only the NV12 preview path
+    // leaves the plain one-frame-ahead prefetch. Only the preview path
     // buffers — export and thumbnails consume as fast as they decode anyway.
     void setReadAheadUs(drift::TimeUs readAheadUs);
 
@@ -63,10 +63,11 @@ public:
     QImage readVideoFrame(const QString &path, quint64 streamId, drift::TimeUs sourceUs, int maxWidth,
                           int maxHeight, const QString &stabilizePath = QString(),
                           int stabilizeSmoothing = 15, bool stabilizeTripod = false);
-    // Preview path: NV12 for cheaper GPU upload. Falls back empty when decode fails.
-    Nv12Frame readVideoFrameNv12(const QString &path, quint64 streamId, drift::TimeUs sourceUs,
-                                 int maxWidth, int maxHeight, const QString &stabilizePath = QString(),
-                                 int stabilizeSmoothing = 15, bool stabilizeTripod = false);
+    // Preview path: AVFrame handle (hardware surfaces stay on the GPU). Empty when decode fails.
+    PreviewVideoFrame readPreviewVideoFrame(const QString &path, quint64 streamId, drift::TimeUs sourceUs,
+                                            int maxWidth, int maxHeight,
+                                            const QString &stabilizePath = QString(),
+                                            int stabilizeSmoothing = 15, bool stabilizeTripod = false);
     int readAudioInterleaved(const QString &path, quint64 streamId, drift::TimeUs sourceStartUs,
                              int sampleCount, int outputSampleRate, float *interleavedStereoOut);
     // Tell every audio reader its cursor is stale, so the next read seeks to the position asked

--- a/src/engine/ClipReaderWorker.cpp
+++ b/src/engine/ClipReaderWorker.cpp
@@ -44,7 +44,7 @@ ClipReader *ClipReaderWorker::readerFor(quint64 streamId)
     // The read-ahead budget belongs to the path, not to any one reader on it.
     const int shares = static_cast<int>(m_readers.size());
     for (auto &entry : m_readers)
-        entry.second->setNv12CacheShare(shares);
+        entry.second->setPreviewCacheShare(shares);
 
     return it->second.get();
 }
@@ -62,16 +62,17 @@ QImage ClipReaderWorker::decodeVideo(quint64 streamId, drift::TimeUs sourceUs, i
     return frame;
 }
 
-Nv12Frame ClipReaderWorker::decodeVideoNv12(quint64 streamId, drift::TimeUs sourceUs, int maxWidth,
-                                            int maxHeight, const QString &stabilizePath,
-                                            int stabilizeSmoothing, bool stabilizeTripod)
+PreviewVideoFrame ClipReaderWorker::decodePreviewVideo(quint64 streamId, drift::TimeUs sourceUs,
+                                                       int maxWidth, int maxHeight,
+                                                       const QString &stabilizePath,
+                                                       int stabilizeSmoothing, bool stabilizeTripod)
 {
     QMutexLocker lock(&m_mutex);
     ClipReader *reader = readerFor(streamId);
     if (reader)
         reader->setStabilizeParams(stabilizePath, stabilizeSmoothing, stabilizeTripod);
-    Nv12Frame frame;
-    if (!reader || !reader->readVideoFrameAtNv12(sourceUs, frame, maxWidth, maxHeight))
+    PreviewVideoFrame frame;
+    if (!reader || !reader->readPreviewVideoFrame(sourceUs, frame, maxWidth, maxHeight))
         return {};
     return frame;
 }
@@ -100,25 +101,23 @@ void ClipReaderWorker::prefetchNextVideo(quint64 streamId, int maxWidth, int max
         reader->prefetchNextVideoFrame(maxWidth, maxHeight);
 }
 
-void ClipReaderWorker::requestPrefetchNv12(quint64 streamId, int maxWidth, int maxHeight,
-                                           drift::TimeUs readAheadUs)
+void ClipReaderWorker::requestPrefetchPreview(quint64 streamId, int maxWidth, int maxHeight,
+                                              drift::TimeUs readAheadUs)
 {
     {
         QMutexLocker lock(&m_prefetchMutex);
-        // Per stream: one clip's in-flight read-ahead must not suppress another's, or overlapping
-        // clips would take turns buffering and neither would get ahead.
         if (m_prefetchPending.contains(streamId))
             return;
         m_prefetchPending.insert(streamId);
     }
 
-    QMetaObject::invokeMethod(this, "prefetchNextVideoNv12", Qt::QueuedConnection,
+    QMetaObject::invokeMethod(this, "prefetchNextPreviewVideo", Qt::QueuedConnection,
                               Q_ARG(quint64, streamId), Q_ARG(int, maxWidth), Q_ARG(int, maxHeight),
                               Q_ARG(drift::TimeUs, readAheadUs));
 }
 
-void ClipReaderWorker::prefetchNextVideoNv12(quint64 streamId, int maxWidth, int maxHeight,
-                                             drift::TimeUs readAheadUs)
+void ClipReaderWorker::prefetchNextPreviewVideo(quint64 streamId, int maxWidth, int maxHeight,
+                                                drift::TimeUs readAheadUs)
 {
     {
         QMutexLocker lock(&m_prefetchMutex);
@@ -128,18 +127,13 @@ void ClipReaderWorker::prefetchNextVideoNv12(quint64 streamId, int maxWidth, int
     bool more = false;
     {
         QMutexLocker lock(&m_mutex);
-        // Read-ahead must not create a reader: a stream nothing is asking for any more would open
-        // a decoder and evict a live one from the LRU.
         auto it = m_readers.find(streamId);
         if (it != m_readers.end())
-            more = it->second->prefetchNextVideoFrameNv12(maxWidth, maxHeight, readAheadUs);
+            more = it->second->prefetchNextPreviewVideoFrame(maxWidth, maxHeight, readAheadUs);
     }
 
-    // Re-post instead of looping: this yields the event queue and the reader
-    // mutex between frames, so a decode request that arrives mid-buffer waits
-    // for one frame rather than for the whole read-ahead.
     if (more)
-        requestPrefetchNv12(streamId, maxWidth, maxHeight, readAheadUs);
+        requestPrefetchPreview(streamId, maxWidth, maxHeight, readAheadUs);
 }
 
 void ClipReaderWorker::resetVideoDecoders()

--- a/src/engine/ClipReaderWorker.h
+++ b/src/engine/ClipReaderWorker.h
@@ -35,7 +35,7 @@ public:
     // that step re-arms itself until the reader has readAheadUs of decoded source buffered.
     // Keeping a single step in flight per stream is what bounds a decode request's wait to one
     // frame — a queue of them would serialize ahead of it.
-    void requestPrefetchNv12(quint64 streamId, int maxWidth, int maxHeight, drift::TimeUs readAheadUs);
+    void requestPrefetchPreview(quint64 streamId, int maxWidth, int maxHeight, drift::TimeUs readAheadUs);
 
     // Callable from any thread. Marks every audio reader here as unpositioned, so the next decode
     // seeks to the position it is asked for instead of continuing its stream. Set as a flag rather
@@ -49,13 +49,14 @@ public slots:
     QImage decodeVideo(quint64 streamId, drift::TimeUs sourceUs, int maxWidth, int maxHeight,
                        const QString &stabilizePath = QString(), int stabilizeSmoothing = 15,
                        bool stabilizeTripod = false);
-    Nv12Frame decodeVideoNv12(quint64 streamId, drift::TimeUs sourceUs, int maxWidth, int maxHeight,
-                              const QString &stabilizePath = QString(), int stabilizeSmoothing = 15,
-                              bool stabilizeTripod = false);
+    PreviewVideoFrame decodePreviewVideo(quint64 streamId, drift::TimeUs sourceUs, int maxWidth,
+                                         int maxHeight, const QString &stabilizePath = QString(),
+                                         int stabilizeSmoothing = 15, bool stabilizeTripod = false);
     int decodeAudio(quint64 streamId, drift::TimeUs sourceStartUs, int sampleCount,
                     int outputSampleRate, float *interleavedStereoOut);
     void prefetchNextVideo(quint64 streamId, int maxWidth, int maxHeight);
-    void prefetchNextVideoNv12(quint64 streamId, int maxWidth, int maxHeight, drift::TimeUs readAheadUs);
+    void prefetchNextPreviewVideo(quint64 streamId, int maxWidth, int maxHeight,
+                                  drift::TimeUs readAheadUs);
     void resetVideoDecoders();
 
 private:

--- a/src/engine/DebugReport.cpp
+++ b/src/engine/DebugReport.cpp
@@ -2,8 +2,10 @@
 
 #include "ClipReader.h"
 #include "Exporter.h"
+#include "GlRuntime.h"
 #include "HwAccel.h"
 #include "OrtRuntime.h"
+#include "VaapiZeroCopy.h"
 
 #include <QCoreApplication>
 #include <QDir>
@@ -479,6 +481,37 @@ bool gpuIsNvidia(const GpuAdapter &gpu)
            || gpu.vendor.compare(QLatin1String("NVIDIA"), Qt::CaseInsensitive) == 0;
 }
 
+bool gpuIsAmd(const GpuAdapter &gpu)
+{
+    return gpu.vendorId == 0x1002 || gpu.vendorId == 0x1022
+           || gpu.driver == QLatin1String("amdgpu") || gpu.driver == QLatin1String("radeon")
+           || gpu.vendor.compare(QLatin1String("AMD"), Qt::CaseInsensitive) == 0;
+}
+
+QString previewUploadLabel()
+{
+    using Path = drift::gl::GlRuntime::PreviewUploadPath;
+    switch (drift::gl::GlRuntime::lastPreviewUploadPath()) {
+    case Path::CudaInterop:
+        return QStringLiteral("CUDA interop");
+    case Path::VaapiDmaBuf:
+        return QStringLiteral("VAAPI dma-buf");
+    case Path::CpuRoundTrip:
+        return QStringLiteral("CPU round-trip");
+    case Path::None:
+        break;
+    }
+    return trReport("Nothing uploaded yet");
+}
+
+QString zeroCopyLabel()
+{
+    if (!drift::vaapiZeroCopyEnabled())
+        return trReport("Off");
+    const QString reason = drift::gl::GlRuntime::lastVaapiImportReason();
+    return reason.isEmpty() ? trReport("Active") : reason;
+}
+
 QVariantMap hintRow(const QString &id, const QString &title, const QString &detail,
                     const QString &command = {}, const QString &action = {})
 {
@@ -640,6 +673,13 @@ QVariantMap DebugReport::collect()
     }
     system.append(systemRow(trReport("Preview decode"), decodeModeLabel()));
     system.append(systemRow(trReport("Active decode"), activeDecodeLabel()));
+    {
+        const QString platform = QGuiApplication::platformName();
+        system.append(systemRow(trReport("Window platform"),
+                                platform.isEmpty() ? trReport("Unknown") : platform));
+    }
+    system.append(systemRow(trReport("Preview upload"), previewUploadLabel()));
+    system.append(systemRow(trReport("Zero-copy"), zeroCopyLabel()));
     system.append(systemRow(trReport("Locale"), QLocale::system().name()));
     if (drift::hwaccel::disabledByEnv())
         system.append(systemRow(QStringLiteral("DRIFT_NO_HWACCEL"), trReport("Set")));
@@ -671,8 +711,23 @@ QVariantMap DebugReport::collect()
                 trReport("VAAPI encode on NVIDIA needs the NVIDIA VAAPI extension, and so does "
                          "hardware decode when NVDEC is unavailable. Install it, then restart "
                          "Drift."),
-                QStringLiteral("flatpak install org.freedesktop.Platform.VAAPI.nvidia")));
+                    QStringLiteral("flatpak install org.freedesktop.Platform.VAAPI.nvidia")));
         }
+    }
+    bool amd = false;
+    for (const GpuAdapter &gpu : gpus) {
+        if (gpuIsAmd(gpu)) {
+            amd = true;
+            break;
+        }
+    }
+    if (amd) {
+        hints.append(hintRow(
+            QStringLiteral("amd-gfx6-8"), trReport("Pre-Vega AMD skips zero-copy preview"),
+            trReport("GCN 1–4 GPUs (HD 7000 through Polaris / RX 500) export tiled surfaces "
+                     "without a DRM modifier, so Drift refuses zero-copy preview and copies "
+                     "each frame through system memory. Vega, Navi and newer can enable "
+                     "Settings → Preview → Faster preview.")));
     }
     if (ortRuntimes.isEmpty()) {
         hints.append(hintRow(

--- a/src/engine/Exporter.cpp
+++ b/src/engine/Exporter.cpp
@@ -2,6 +2,7 @@
 
 #include "AudioMixer.h"
 #include "FrameCompositor.h"
+#include "GpuCompositor.h"
 #include "HwAccel.h"
 #include "core/Project.h"
 #include "core/Time.h"
@@ -10,6 +11,7 @@
 #include <QHash>
 #include <QImage>
 #include <QMutex>
+#include <QtGlobal>
 
 #ifdef Q_OS_ANDROID
 #include "AndroidUri.h"
@@ -541,6 +543,50 @@ void scaleSize(int projW, int projH, int targetH, int &outW, int &outH)
     outH = targetH > 0 ? targetH : projH;
     outW = static_cast<int>(std::llround(static_cast<double>(projW) * outH / projH));
     evenDims(outW, outH);
+}
+
+void fillLimitedBlackNv12(uint8_t *y, int yStride, uint8_t *uv, int uvStride, int w, int h)
+{
+    for (int row = 0; row < h; ++row)
+        memset(y + row * yStride, 16, size_t(w));
+    for (int row = 0; row < h / 2; ++row)
+        memset(uv + row * uvStride, 128, size_t(w));
+}
+
+void fillLimitedBlackFrame(AVFrame *frame)
+{
+    if (!frame || !frame->data[0])
+        return;
+    if (frame->format == AV_PIX_FMT_NV12 && frame->data[1]) {
+        fillLimitedBlackNv12(frame->data[0], frame->linesize[0], frame->data[1], frame->linesize[1],
+                             frame->width, frame->height);
+        return;
+    }
+    if (frame->format == AV_PIX_FMT_YUV420P && frame->data[1] && frame->data[2]) {
+        for (int row = 0; row < frame->height; ++row)
+            memset(frame->data[0] + row * frame->linesize[0], 16, size_t(frame->width));
+        for (int row = 0; row < frame->height / 2; ++row) {
+            memset(frame->data[1] + row * frame->linesize[1], 128, size_t(frame->width / 2));
+            memset(frame->data[2] + row * frame->linesize[2], 128, size_t(frame->width / 2));
+        }
+    }
+}
+
+void nv12ToYuv420p(const uint8_t *y, int yStride, const uint8_t *uv, int uvStride, AVFrame *dst)
+{
+    const int w = dst->width;
+    const int h = dst->height;
+    for (int row = 0; row < h; ++row)
+        memcpy(dst->data[0] + row * dst->linesize[0], y + row * yStride, size_t(w));
+    for (int row = 0; row < h / 2; ++row) {
+        const uint8_t *src = uv + row * uvStride;
+        uint8_t *u = dst->data[1] + row * dst->linesize[1];
+        uint8_t *v = dst->data[2] + row * dst->linesize[2];
+        for (int x = 0; x < w / 2; ++x) {
+            u[x] = src[2 * x];
+            v[x] = src[2 * x + 1];
+        }
+    }
 }
 
 // Sends a frame (or nullptr to flush) to the encoder and interleaves the packets.
@@ -2030,17 +2076,25 @@ bool Exporter::run(const drift::Project &project, const ExportSettings &settings
         }
         headerWritten = true;
 
-        // Lanczos when down/upscaling; bicubic is enough for a pure format convert.
-        const int swsFlags = (projW != outW || projH != outH) ? SWS_LANCZOS : SWS_BICUBIC;
-        sws = sws_getContext(projW, projH, AV_PIX_FMT_RGBA, outW, outH, swPixFmt, swsFlags, nullptr,
-                             nullptr, nullptr);
-        if (!sws) {
-            error = QStringLiteral("Could not create the scaler");
-            goto cleanup;
-        }
-        if (!configureExportSws(sws)) {
-            error = QStringLiteral("Could not configure export colour conversion");
-            goto cleanup;
+        const bool forceCpuSws = qEnvironmentVariableIsSet("DRIFT_EXPORT_SWSCALE")
+                                 && qgetenv("DRIFT_EXPORT_SWSCALE") != "0";
+        const bool useGpuNv12 = !forceCpuSws && GpuCompositor::isAvailable()
+            && (swPixFmt == AV_PIX_FMT_NV12 || swPixFmt == AV_PIX_FMT_YUV420P) && (outW % 2 == 0)
+            && (outH % 2 == 0);
+
+        if (!useGpuNv12) {
+            // Lanczos when down/upscaling; bicubic is enough for a pure format convert.
+            const int swsFlags = (projW != outW || projH != outH) ? SWS_LANCZOS : SWS_BICUBIC;
+            sws = sws_getContext(projW, projH, AV_PIX_FMT_RGBA, outW, outH, swPixFmt, swsFlags,
+                                 nullptr, nullptr, nullptr);
+            if (!sws) {
+                error = QStringLiteral("Could not create the scaler");
+                goto cleanup;
+            }
+            if (!configureExportSws(sws)) {
+                error = QStringLiteral("Could not configure export colour conversion");
+                goto cleanup;
+            }
         }
 
         pkt = av_packet_alloc();
@@ -2110,6 +2164,96 @@ bool Exporter::run(const drift::Project &project, const ExportSettings &settings
             return true;
         };
 
+        auto sendVideoAndAudio = [&](int64_t pts) -> bool {
+            applySdrBt709Tags(vframe);
+            vframe->pts = pts;
+            AVFrame *encodeFrame = vframe;
+            if (hwUpload) {
+                av_frame_unref(hwframe);
+                if (av_hwframe_get_buffer(vctx->hw_frames_ctx, hwframe, 0) < 0) {
+                    error = QStringLiteral("Could not allocate a hardware frame");
+                    return false;
+                }
+                if (av_hwframe_transfer_data(hwframe, vframe, 0) < 0) {
+                    error = QStringLiteral("Could not upload a frame to the encoder");
+                    return false;
+                }
+                applySdrBt709Tags(hwframe);
+                hwframe->pts = pts;
+                encodeFrame = hwframe;
+            }
+            if (!encodeWriteFrame(fmt, vctx, vstream, encodeFrame, pkt, &error))
+                return false;
+
+            const int64_t targetSamples =
+                qMin(totalAudioSamples,
+                     ((pts + 1) * static_cast<int64_t>(sampleRate) * frameRate.den) / frameRate.num);
+            const int need = static_cast<int>(targetSamples - audioSamplesGenerated);
+            if (need > 0) {
+                const size_t base = audioBuffer.size();
+                audioBuffer.resize(base + static_cast<size_t>(need) * 2);
+                const drift::TimeUs audioStartUs = rangeStartUs
+                    + static_cast<drift::TimeUs>(
+                        (static_cast<int64_t>(audioSamplesGenerated) * drift::kUsPerSecond)
+                        / sampleRate);
+                mixer.mix(audioStartUs, need, sampleRate, audioBuffer.data() + base);
+                audioSamplesGenerated = targetSamples;
+            }
+            return flushAudioFrames(false);
+        };
+
+        FrameCompositor::RenderOptions composeOptions;
+        if (outH < projH)
+            composeOptions.previewScale = double(outH) / double(projH);
+        composeOptions.readAheadUs = static_cast<drift::TimeUs>(
+            std::llround(2.0 * 1e6 * frameRate.den / frameRate.num));
+
+        std::vector<uint8_t> nv12Y;
+        std::vector<uint8_t> nv12Uv;
+        if (useGpuNv12 && swPixFmt == AV_PIX_FMT_YUV420P) {
+            nv12Y.resize(size_t(outW) * size_t(outH));
+            nv12Uv.resize(size_t(outW) * size_t(outH / 2));
+        }
+
+        struct InflightNv12
+        {
+            int slot = 0;
+            int64_t pts = 0;
+            bool packed = false;
+        };
+        InflightNv12 inflight[GpuCompositor::kExportNv12Slots];
+        int inflightCount = 0;
+
+        auto consumeNv12Head = [&]() -> bool {
+            const InflightNv12 job = inflight[0];
+            for (int i = 0; i < inflightCount - 1; ++i)
+                inflight[i] = inflight[i + 1];
+            --inflightCount;
+
+            if (av_frame_make_writable(vframe) < 0) {
+                error = QStringLiteral("Video frame not writable");
+                return false;
+            }
+
+            bool mapped = false;
+            if (job.packed) {
+                if (swPixFmt == AV_PIX_FMT_NV12) {
+                    mapped = GpuCompositor::finishExportNv12(job.slot, vframe->data[0],
+                                                             vframe->linesize[0], vframe->data[1],
+                                                             vframe->linesize[1], outW, outH);
+                } else {
+                    mapped = GpuCompositor::finishExportNv12(job.slot, nv12Y.data(), outW,
+                                                             nv12Uv.data(), outW, outW, outH);
+                    if (mapped)
+                        nv12ToYuv420p(nv12Y.data(), outW, nv12Uv.data(), outW, vframe);
+                }
+            }
+            if (!mapped)
+                fillLimitedBlackFrame(vframe);
+
+            return sendVideoAndAudio(job.pts);
+        };
+
         for (int64_t i = 0; i < totalFrames; ++i) {
             if (onProgress && !onProgress(static_cast<double>(i) / totalFrames)) {
                 cancelled = true;
@@ -2118,6 +2262,26 @@ bool Exporter::run(const drift::Project &project, const ExportSettings &settings
 
             const drift::TimeUs t = rangeStartUs + static_cast<drift::TimeUs>(
                 std::llround(static_cast<double>(i) * 1e6 * frameRate.den / frameRate.num));
+
+            if (useGpuNv12) {
+                if (inflightCount == GpuCompositor::kExportNv12Slots) {
+                    if (!consumeNv12Head())
+                        goto cleanup;
+                }
+
+                GpuScene scene;
+                if (!compositor.buildSceneAt(t, composeOptions, &scene)) {
+                    scene = GpuScene{};
+                    scene.canvasSize = QSize(outW, outH);
+                    scene.backgroundColor = Qt::black;
+                }
+
+                const int slot = int(i % GpuCompositor::kExportNv12Slots);
+                const bool packed = GpuCompositor::beginExportNv12(scene, outW, outH, slot);
+                inflight[inflightCount++] = InflightNv12{slot, i, packed};
+                continue;
+            }
+
             QImage img = compositor.compositeAt(t);
             if (img.isNull()) {
                 img = QImage(projW, projH, QImage::Format_RGBA8888);
@@ -2137,42 +2301,28 @@ bool Exporter::run(const drift::Project &project, const ExportSettings &settings
                 const int srcStride[4] = {static_cast<int>(img.bytesPerLine()), 0, 0, 0};
                 sws_scale(sws, srcData, srcStride, 0, projH, vframe->data, vframe->linesize);
             }
-            applySdrBt709Tags(vframe);
-            vframe->pts = i;
-            AVFrame *encodeFrame = vframe;
-            if (hwUpload) {
-                av_frame_unref(hwframe);
-                if (av_hwframe_get_buffer(vctx->hw_frames_ctx, hwframe, 0) < 0) {
-                    error = QStringLiteral("Could not allocate a hardware frame");
-                    goto cleanup;
-                }
-                if (av_hwframe_transfer_data(hwframe, vframe, 0) < 0) {
-                    error = QStringLiteral("Could not upload a frame to the encoder");
-                    goto cleanup;
-                }
-                applySdrBt709Tags(hwframe);
-                hwframe->pts = i;
-                encodeFrame = hwframe;
-            }
-            if (!encodeWriteFrame(fmt, vctx, vstream, encodeFrame, pkt, &error))
+            if (!sendVideoAndAudio(i))
                 goto cleanup;
+        }
 
-            // Integer math keeps A/V in exact lockstep even on 1001-denominator rates.
-            const int64_t targetSamples =
-                qMin(totalAudioSamples,
-                     ((i + 1) * static_cast<int64_t>(sampleRate) * frameRate.den) / frameRate.num);
-            const int need = static_cast<int>(targetSamples - audioSamplesGenerated);
-            if (need > 0) {
-                const size_t base = audioBuffer.size();
-                audioBuffer.resize(base + static_cast<size_t>(need) * 2);
-                const drift::TimeUs audioStartUs = rangeStartUs
-                    + static_cast<drift::TimeUs>(
-                        (static_cast<int64_t>(audioSamplesGenerated) * drift::kUsPerSecond) / sampleRate);
-                mixer.mix(audioStartUs, need, sampleRate, audioBuffer.data() + base);
-                audioSamplesGenerated = targetSamples;
+        if (useGpuNv12 && !cancelled) {
+            while (inflightCount > 0) {
+                if (!consumeNv12Head())
+                    goto cleanup;
             }
-            if (!flushAudioFrames(false))
-                goto cleanup;
+        } else if (useGpuNv12) {
+            while (inflightCount > 0) {
+                const InflightNv12 job = inflight[0];
+                for (int i = 0; i < inflightCount - 1; ++i)
+                    inflight[i] = inflight[i + 1];
+                --inflightCount;
+                if (!job.packed)
+                    continue;
+                std::vector<uint8_t> dumpY(size_t(outW) * size_t(outH));
+                std::vector<uint8_t> dumpUv(size_t(outW) * size_t(outH / 2));
+                GpuCompositor::finishExportNv12(job.slot, dumpY.data(), outW, dumpUv.data(), outW,
+                                                outW, outH);
+            }
         }
 
         if (!cancelled) {

--- a/src/engine/FrameCompositor.cpp
+++ b/src/engine/FrameCompositor.cpp
@@ -943,7 +943,7 @@ bool FrameCompositor::prepare(drift::TimeUs timelineUs, const RenderOptions &opt
 
     const int projectWidth = m_project->width();
     const int projectHeight = m_project->height();
-    const double renderScale = qBound(0.1, options.previewScale, 1.0);
+    const double renderScale = qBound(kMinPreviewScale, options.previewScale, 1.0);
     const int width = qMax(1, static_cast<int>(std::lround(projectWidth * renderScale)));
     const int height = qMax(1, static_cast<int>(std::lround(projectHeight * renderScale)));
     if (width <= 0 || height <= 0)

--- a/src/engine/FrameCompositor.cpp
+++ b/src/engine/FrameCompositor.cpp
@@ -996,3 +996,12 @@ GpuFrameTexture FrameCompositor::compositeToTextureAt(drift::TimeUs timelineUs,
     return GpuCompositor::renderToTexture(scene);
 }
 
+bool FrameCompositor::buildSceneAt(drift::TimeUs timelineUs, const RenderOptions &options,
+                                   GpuScene *sceneOut) const
+{
+    int width = 0;
+    int height = 0;
+    double renderScale = 1.0;
+    return prepare(timelineUs, options, sceneOut, &width, &height, &renderScale);
+}
+

--- a/src/engine/FrameCompositor.cpp
+++ b/src/engine/FrameCompositor.cpp
@@ -548,8 +548,8 @@ QImage gpuSourceForClip(const drift::Clip &clip, drift::TimeUs timelineUs, int m
     return CompositorFrameHistory::applyTimeEcho(samples, decay, blendMode);
 }
 
-// Prefer NV12 for plain video (preview upload path); fall back to RGBA QImage
-// when time_echo needs CPU blending or NV12 decode fails.
+// Prefer the preview AVFrame path for plain video; fall back to RGBA QImage
+// when time_echo needs CPU blending or preview decode fails.
 void fillGpuLayerPixels(GpuLayer &layer, const drift::Clip &clip, drift::TimeUs timelineUs, int maxWidth,
                         int maxHeight, int projectFps, int maxTimeEchoHistoryFrames)
 {
@@ -559,12 +559,10 @@ void fillGpuLayerPixels(GpuLayer &layer, const drift::Clip &clip, drift::TimeUs 
     const drift::Effect *timeEcho = findTimeEchoEffect(clip.effects);
     if (!timeEcho && clip.type == drift::ClipType::Video) {
         const drift::VideoRead read = drift::resolveVideoRead(clip, timelineUs);
-        const Nv12Frame nv12 = ClipReaderPool::instance().readVideoFrameNv12(
+        const PreviewVideoFrame video = ClipReaderPool::instance().readPreviewVideoFrame(
             read.path, ClipReaderPool::streamIdForClip(clip.id), read.sourceUs, maxWidth, maxHeight);
-        if (nv12.isValid()) {
-            layer.nv12 = nv12.data;
-            layer.nv12Width = nv12.width;
-            layer.nv12Height = nv12.height;
+        if (video.isValid()) {
+            layer.video = video;
             return;
         }
     }

--- a/src/engine/FrameCompositor.h
+++ b/src/engine/FrameCompositor.h
@@ -7,6 +7,11 @@
 #include <QImage>
 #include <QString>
 
+// Preview canvas as a fraction of project resolution. Below this, text and effect
+// radii collapse to subpixels. The compositor never upscales past 1.0.
+inline constexpr double kMinPreviewScale = 0.02;
+inline constexpr int kMinPreviewScalePercent = 2;
+
 // Composites all visible tracks into a single RGBA frame at timeline time T.
 class FrameCompositor
 {

--- a/src/engine/FrameCompositor.h
+++ b/src/engine/FrameCompositor.h
@@ -38,6 +38,10 @@ public:
     // OpenGL is unavailable, in which case callers should use compositeAt.
     GpuFrameTexture compositeToTextureAt(drift::TimeUs timelineUs, const RenderOptions &options) const;
 
+    // Builds the GPU scene for T without composing. Used by the export pipeline
+    // so decode/scene-build can overlap the previous frame's GL work.
+    bool buildSceneAt(drift::TimeUs timelineUs, const RenderOptions &options, GpuScene *sceneOut) const;
+
 private:
     // Shared by both entry points: resolves the canvas size, warms the decoders
     // and builds the scene. Returns false when there is nothing to render.

--- a/src/engine/GlRuntime.cpp
+++ b/src/engine/GlRuntime.cpp
@@ -1,13 +1,16 @@
 #include "GlRuntime.h"
 
 #include "GlModelRenderer.h"
+#include "VaapiZeroCopy.h"
 
 #include <QColor>
 #include <QCoreApplication>
 #include <QMatrix3x3>
+#include <QMutex>
 #include <QMutexLocker>
 #include <QOffscreenSurface>
 #include <QOpenGLContext>
+#include <QSettings>
 #include <QSurfaceFormat>
 #include <QVector2D>
 #include <QVector3D>
@@ -75,6 +78,36 @@ extern "C" {
 #ifndef GL_MAP_INVALIDATE_BUFFER_BIT
 #define GL_MAP_INVALIDATE_BUFFER_BIT 0x0008
 #endif
+
+namespace drift {
+
+bool vaapiZeroCopyEnabled()
+{
+    // Env is read live so tests can qputenv after other imports have already
+    // resolved the settings half. QSettings is what must not run per frame.
+    if (qEnvironmentVariableIsSet("DRIFT_VAAPI_ZEROCOPY"))
+        return qgetenv("DRIFT_VAAPI_ZEROCOPY") != "0";
+    static bool settingsEnabled = false;
+    static std::once_flag once;
+    std::call_once(once, [] {
+        settingsEnabled =
+            QSettings().value(QStringLiteral("preview/vaapiZeroCopy"), false).toBool();
+    });
+    return settingsEnabled;
+}
+
+void applyVaapiZeroCopyXcbEgl()
+{
+#if !defined(Q_OS_WIN) && !defined(Q_OS_MACOS) && !defined(Q_OS_ANDROID)
+    if (!vaapiZeroCopyEnabled())
+        return;
+    if (!qEnvironmentVariableIsEmpty("QT_XCB_GL_INTEGRATION"))
+        return;
+    qputenv("QT_XCB_GL_INTEGRATION", "xcb_egl");
+#endif
+}
+
+} // namespace drift
 
 namespace drift::gl {
 
@@ -344,6 +377,29 @@ bool copyCudaPlaneToTexture(CudaGlApi &api, CUstream stream, CUgraphicsResource 
 }
 #endif
 
+QMutex g_previewImportMutex;
+GlRuntime::PreviewUploadPath g_previewUploadPath = GlRuntime::PreviewUploadPath::None;
+QString g_vaapiImportReason;
+
+void recordPreviewUploadPath(GlRuntime::PreviewUploadPath path)
+{
+    QMutexLocker lock(&g_previewImportMutex);
+    g_previewUploadPath = path;
+}
+
+void logVaapiImportOnce(const QString &reason)
+{
+    {
+        QMutexLocker lock(&g_previewImportMutex);
+        if (g_vaapiImportReason.isEmpty())
+            g_vaapiImportReason = reason;
+    }
+    static std::once_flag once;
+    std::call_once(once, [reason] {
+        qWarning("GlRuntime: VAAPI zero-copy import unavailable (%s)", qUtf8Printable(reason));
+    });
+}
+
 #if defined(DRIFT_VAAPI_IMPORT)
 // libva and the EGL dma-buf import extension, resolved at runtime for the same reason CUDA is:
 // the binary has to start on a host with neither. Only the handful of declarations the import
@@ -394,7 +450,9 @@ constexpr uint32_t fourcc(char a, char b, char c, char d)
 
 constexpr uint32_t kDrmFormatR8 = fourcc('R', '8', ' ', ' ');
 constexpr uint32_t kDrmFormatGr88 = fourcc('G', 'R', '8', '8');
+constexpr uint32_t kDrmFormatNv12 = fourcc('N', 'V', '1', '2');
 constexpr uint64_t kDrmFormatModInvalid = 0x00ffffffffffffffull;
+constexpr uint64_t kDrmFormatModLinear = 0;
 
 using EGLDisplayHandle = void *;
 using EGLImageHandle = void *;
@@ -517,12 +575,30 @@ struct ExportedSurfaceFds
     }
 };
 
-// A zero-copy path that silently falls back is pixel-identical to one that works, so say once
-// why it did not engage. Anything else leaves "preview did not get faster" unfalsifiable.
-void logVaapiImportOnce(const char *reason)
+QString fourccString(uint32_t value)
 {
-    static std::once_flag once;
-    std::call_once(once, [reason] { qInfo("GlRuntime: VAAPI zero-copy import unavailable (%s)", reason); });
+    char s[5] = {char(value), char(value >> 8), char(value >> 16), char(value >> 24), 0};
+    for (char &c : s) {
+        if (c != 0 && (c < 32 || c > 126))
+            c = '?';
+    }
+    return QString::fromLatin1(s);
+}
+
+QString describePrime(const VaDrmPrimeSurfaceDescriptor &desc)
+{
+    QString text = QStringLiteral("fourcc=%1 objects=%2 layers=%3")
+                       .arg(fourccString(desc.fourcc))
+                       .arg(desc.num_objects)
+                       .arg(desc.num_layers);
+    const uint32_t n = qMin(desc.num_layers, 4u);
+    for (uint32_t i = 0; i < n; ++i) {
+        text += QStringLiteral(" layer%1={format=%2 planes=%3}")
+                    .arg(i)
+                    .arg(fourccString(desc.layers[i].drm_format))
+                    .arg(desc.layers[i].num_planes);
+    }
+    return text;
 }
 #endif // DRIFT_VAAPI_IMPORT
 
@@ -953,6 +1029,7 @@ void GlRuntime::destroyVideoUploadState()
     m_videoTexH = 0;
     m_videoPboIndex = 0;
     av_frame_free(&m_hwImportStaging);
+    av_frame_free(&m_importNv12);
     sws_freeContext(m_importSws);
     m_importSws = nullptr;
 }
@@ -1164,11 +1241,11 @@ bool GlRuntime::importVaapiNv12(QOpenGLExtraFunctions *gl, const AVFrame *frame)
     // corrupt preview with nothing to catch. That has been verified on Mesa iris + iHD and
     // nowhere else, so until other drivers have been through it the default stays off: slower
     // preview is a far better failure than a broken picture.
-    if (!qEnvironmentVariableIsSet("DRIFT_VAAPI_ZEROCOPY")) {
-        logVaapiImportOnce("set DRIFT_VAAPI_ZEROCOPY=1 to enable");
-        m_vaapiImportFailed = true;
+    //
+    // Off is not sticky: a later test (or a restart after flipping the setting) must still be
+    // able to engage the path. Real import failures below are.
+    if (!drift::vaapiZeroCopyEnabled())
         return false;
-    }
 
     VaEglApi &api = vaEglApi();
     if (!api.ok) {
@@ -1217,24 +1294,85 @@ bool GlRuntime::importVaapiNv12(QOpenGLExtraFunctions *gl, const AVFrame *frame)
     api.vaSyncSurface(display, surface);
 
     // Guards against a libva ABI change shifting every field past objects[]: without them a
-    // mismatched struct imports plausible-looking garbage instead of failing.
-    if (desc.num_objects < 1 || desc.num_objects > 4 || desc.num_layers != 2)
-        return false;
-    if (desc.layers[0].drm_format != kDrmFormatR8 || desc.layers[1].drm_format != kDrmFormatGr88)
-        return false;
-    for (uint32_t i = 0; i < desc.num_layers; ++i) {
-        if (desc.layers[i].num_planes != 1 || desc.layers[i].object_index[0] >= desc.num_objects
-            || desc.layers[i].pitch[0] == 0)
-            return false;
+    // mismatched struct imports plausible-looking garbage instead of failing. SEPARATE_LAYERS
+    // is still the export request; the composed NV12 shape is accepted because some drivers
+    // ignore that flag.
+    struct ImportPlane
+    {
+        int fd = -1;
+        uint32_t offset = 0;
+        uint32_t pitch = 0;
+        uint32_t fourcc = 0;
+        uint64_t modifier = kDrmFormatModInvalid;
+    };
+    ImportPlane planes[2];
+    bool shapeOk = false;
+    if (desc.num_objects >= 1 && desc.num_objects <= 4) {
+        if (desc.num_layers == 2 && desc.layers[0].drm_format == kDrmFormatR8
+            && desc.layers[1].drm_format == kDrmFormatGr88) {
+            shapeOk = true;
+            for (uint32_t i = 0; i < 2; ++i) {
+                const auto &layer = desc.layers[i];
+                if (layer.num_planes != 1 || layer.object_index[0] >= desc.num_objects
+                    || layer.pitch[0] == 0) {
+                    shapeOk = false;
+                    break;
+                }
+                const auto &object = desc.objects[layer.object_index[0]];
+                planes[i] = {object.fd, layer.offset[0], layer.pitch[0], layer.drm_format,
+                             object.drm_format_modifier};
+            }
+        } else if (desc.num_layers == 1 && desc.layers[0].drm_format == kDrmFormatNv12
+                   && desc.layers[0].num_planes == 2) {
+            const auto &layer = desc.layers[0];
+            if (layer.object_index[0] < desc.num_objects && layer.object_index[1] < desc.num_objects
+                && layer.pitch[0] != 0 && layer.pitch[1] != 0) {
+                const auto &obj0 = desc.objects[layer.object_index[0]];
+                const auto &obj1 = desc.objects[layer.object_index[1]];
+                planes[0] = {obj0.fd, layer.offset[0], layer.pitch[0], kDrmFormatR8,
+                             obj0.drm_format_modifier};
+                planes[1] = {obj1.fd, layer.offset[1], layer.pitch[1], kDrmFormatGr88,
+                             obj1.drm_format_modifier};
+                shapeOk = true;
+            }
+        }
     }
+    if (!shapeOk) {
+        logVaapiImportOnce(
+            QStringLiteral("unexpected drm-prime descriptor (%1)").arg(describePrime(desc)));
+        m_vaapiImportFailed = true;
+        return false;
+    }
+
+    // Decide once per frame, before any EGLImage is created. Importing a tiled buffer as
+    // implicit-linear (what radeonsi GFX6–8 exports as MOD_INVALID) samples garbage.
+    const uint64_t mod0 = planes[0].modifier;
+    const uint64_t mod1 = planes[1].modifier;
+    const bool modifierUnknown = mod0 == kDrmFormatModInvalid || mod1 == kDrmFormatModInvalid;
+    const bool tiled = (mod0 != kDrmFormatModInvalid && mod0 != kDrmFormatModLinear)
+                       || (mod1 != kDrmFormatModInvalid && mod1 != kDrmFormatModLinear);
+    if (modifierUnknown) {
+        logVaapiImportOnce(
+            QStringLiteral("driver reports no DRM modifier (tiling unknown); pre-GFX9 radeonsi "
+                           "does this"));
+        m_vaapiImportFailed = true;
+        return false;
+    }
+    if (tiled && !useModifiers) {
+        logVaapiImportOnce(
+            QStringLiteral("EGL_EXT_image_dma_buf_import_modifiers missing; cannot describe tiled "
+                           "surface"));
+        m_vaapiImportFailed = true;
+        return false;
+    }
+    const bool passModifierAttribs = tiled;
 
     if (!ensureImportTextureNames(gl))
         return false;
 
     const GLuint textures[2] = {m_importY, m_importUV};
     for (uint32_t i = 0; i < 2; ++i) {
-        const auto &layer = desc.layers[i];
-        const auto &object = desc.objects[layer.object_index[0]];
+        const ImportPlane &plane = planes[i];
 
         // The surface allocation is padded (1080 -> 1088); the picture is not. Sizing the image
         // from the descriptor would sample that padding, and because kQuad puts v=0 at the NDC
@@ -1247,18 +1385,18 @@ bool GlRuntime::importVaapiNv12(QOpenGLExtraFunctions *gl, const AVFrame *frame)
         attribs[n++] = kEglHeight;
         attribs[n++] = i == 0 ? codedH : codedH / 2;
         attribs[n++] = kEglLinuxDrmFourccExt;
-        attribs[n++] = int32_t(layer.drm_format);
+        attribs[n++] = int32_t(plane.fourcc);
         attribs[n++] = kEglDmaBufPlane0FdExt;
-        attribs[n++] = object.fd;
+        attribs[n++] = plane.fd;
         attribs[n++] = kEglDmaBufPlane0OffsetExt;
-        attribs[n++] = int32_t(layer.offset[0]);
+        attribs[n++] = int32_t(plane.offset);
         attribs[n++] = kEglDmaBufPlane0PitchExt;
-        attribs[n++] = int32_t(layer.pitch[0]);
-        if (useModifiers && object.drm_format_modifier != kDrmFormatModInvalid) {
+        attribs[n++] = int32_t(plane.pitch);
+        if (passModifierAttribs) {
             attribs[n++] = kEglDmaBufPlane0ModifierLoExt;
-            attribs[n++] = int32_t(object.drm_format_modifier & 0xffffffffu);
+            attribs[n++] = int32_t(plane.modifier & 0xffffffffu);
             attribs[n++] = kEglDmaBufPlane0ModifierHiExt;
-            attribs[n++] = int32_t(object.drm_format_modifier >> 32);
+            attribs[n++] = int32_t(plane.modifier >> 32);
         }
         attribs[n++] = kEglNone;
 
@@ -1323,26 +1461,26 @@ AVFrame *GlRuntime::ensureSoftwareNv12(const AVFrame *src)
     if (!m_importSws)
         return nullptr;
 
-    if (!m_hwImportStaging)
-        m_hwImportStaging = av_frame_alloc();
-    if (!m_hwImportStaging)
+    if (!m_importNv12)
+        m_importNv12 = av_frame_alloc();
+    if (!m_importNv12)
         return nullptr;
-    if (m_hwImportStaging->format != AV_PIX_FMT_NV12 || m_hwImportStaging->width != tw
-        || m_hwImportStaging->height != th || !m_hwImportStaging->data[0]) {
-        av_frame_unref(m_hwImportStaging);
-        m_hwImportStaging->format = AV_PIX_FMT_NV12;
-        m_hwImportStaging->width = tw;
-        m_hwImportStaging->height = th;
-        if (av_frame_get_buffer(m_hwImportStaging, 0) < 0) {
-            av_frame_unref(m_hwImportStaging);
+    if (m_importNv12->format != AV_PIX_FMT_NV12 || m_importNv12->width != tw
+        || m_importNv12->height != th || !m_importNv12->data[0]) {
+        av_frame_unref(m_importNv12);
+        m_importNv12->format = AV_PIX_FMT_NV12;
+        m_importNv12->width = tw;
+        m_importNv12->height = th;
+        if (av_frame_get_buffer(m_importNv12, 0) < 0) {
+            av_frame_unref(m_importNv12);
             return nullptr;
         }
     }
-    sws_scale(m_importSws, src->data, src->linesize, 0, src->height, m_hwImportStaging->data,
-              m_hwImportStaging->linesize);
-    m_hwImportStaging->colorspace = src->colorspace;
-    m_hwImportStaging->color_range = src->color_range;
-    return m_hwImportStaging;
+    sws_scale(m_importSws, src->data, src->linesize, 0, src->height, m_importNv12->data,
+              m_importNv12->linesize);
+    m_importNv12->colorspace = src->colorspace;
+    m_importNv12->color_range = src->color_range;
+    return m_importNv12;
 }
 
 GlTarget &GlRuntime::acquirePresentTarget(int width, int height)
@@ -1631,10 +1769,13 @@ GlTarget promoteVideoFrameToTarget(GlRuntime &rt, QOpenGLExtraFunctions *gl,
     GLuint texY = rt.m_videoY;
     GLuint texUV = rt.m_videoUV;
     bool uploaded = rt.importCudaNv12(gl, av);
-    if (!uploaded && rt.importVaapiNv12(gl, av)) {
+    if (uploaded) {
+        recordPreviewUploadPath(GlRuntime::PreviewUploadPath::CudaInterop);
+    } else if (rt.importVaapiNv12(gl, av)) {
         uploaded = true;
         texY = rt.m_importY;
         texUV = rt.m_importUV;
+        recordPreviewUploadPath(GlRuntime::PreviewUploadPath::VaapiDmaBuf);
     }
     if (!uploaded) {
         AVFrame *nv12 = rt.ensureSoftwareNv12(av);
@@ -1650,6 +1791,7 @@ GlTarget promoteVideoFrameToTarget(GlRuntime &rt, QOpenGLExtraFunctions *gl,
             return {};
         texY = rt.m_videoY;
         texUV = rt.m_videoUV;
+        recordPreviewUploadPath(GlRuntime::PreviewUploadPath::CpuRoundTrip);
     }
 
     const int destW = qMax(2, frame.displayWidth() & ~1);
@@ -1691,6 +1833,18 @@ GlTarget promoteVideoFrameToTarget(GlRuntime &rt, QOpenGLExtraFunctions *gl,
     program->release();
     target.fbo->release();
     return target;
+}
+
+GlRuntime::PreviewUploadPath GlRuntime::lastPreviewUploadPath()
+{
+    QMutexLocker lock(&g_previewImportMutex);
+    return g_previewUploadPath;
+}
+
+QString GlRuntime::lastVaapiImportReason()
+{
+    QMutexLocker lock(&g_previewImportMutex);
+    return g_vaapiImportReason;
 }
 
 void setPackageUniforms(QOpenGLShaderProgram *program, const QMap<QString, QVariant> &parameters,

--- a/src/engine/GlRuntime.cpp
+++ b/src/engine/GlRuntime.cpp
@@ -4,6 +4,7 @@
 
 #include <QColor>
 #include <QCoreApplication>
+#include <QMatrix3x3>
 #include <QMutexLocker>
 #include <QOffscreenSurface>
 #include <QOpenGLContext>
@@ -12,7 +13,23 @@
 #include <QVector3D>
 
 #include <cmath>
+#include <cstring>
 #include <mutex>
+
+extern "C" {
+#include <libavutil/hwcontext.h>
+#include <libavutil/pixdesc.h>
+#include <libswscale/swscale.h>
+}
+
+#if defined(Q_OS_WIN)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#elif !defined(Q_OS_MACOS)
+#include <dlfcn.h>
+#endif
 
 // Qt for Android is built against the GLES 2.0 headers so it can still run on ES2-only devices, and
 // qopengl.h includes <GLES2/gl2.h> accordingly. The ES 3.0 *functions* this file uses still resolve,
@@ -35,6 +52,21 @@
 #endif
 #ifndef GL_SYNC_FLUSH_COMMANDS_BIT
 #define GL_SYNC_FLUSH_COMMANDS_BIT 0x00000001
+#endif
+#ifndef GL_UNPACK_ROW_LENGTH
+#define GL_UNPACK_ROW_LENGTH 0x0CF2
+#endif
+#ifndef GL_PIXEL_UNPACK_BUFFER
+#define GL_PIXEL_UNPACK_BUFFER 0x88EC
+#endif
+#ifndef GL_STREAM_DRAW
+#define GL_STREAM_DRAW 0x88E0
+#endif
+#ifndef GL_MAP_WRITE_BIT
+#define GL_MAP_WRITE_BIT 0x0002
+#endif
+#ifndef GL_MAP_INVALIDATE_BUFFER_BIT
+#define GL_MAP_INVALIDATE_BUFFER_BIT 0x0008
 #endif
 
 namespace drift::gl {
@@ -82,23 +114,23 @@ void main() {
 }
 )";
 
-// BT.709 limited-range (TV) NV12 → straight RGBA (opaque).
-// Expand Y from 16–235 and Cb/Cr from 16–240 before the BT.709 matrix.
+// YUV → RGBA with caller-supplied matrix, range and a UV affine for display rotation.
 constexpr const char *kNv12FragShader = R"(#version 330 core
 in vec2 v_texCoord;
 out vec4 fragColor;
 uniform sampler2D u_y;
 uniform sampler2D u_uv;
+uniform mat3 u_yuvToRgb;
+uniform vec3 u_yuvOffset;
+uniform vec3 u_yuvScale;
+uniform mat3 u_texMap;
 void main() {
-    float y = texture(u_y, v_texCoord).r;
-    vec2 uv = texture(u_uv, v_texCoord).rg;
-    float Y = (y - 16.0 / 255.0) * (255.0 / 219.0);
-    float Cb = (uv.x - 128.0 / 255.0) * (255.0 / 224.0);
-    float Cr = (uv.y - 128.0 / 255.0) * (255.0 / 224.0);
-    float r = Y + 1.5748 * Cr;
-    float g = Y - 0.1873 * Cb - 0.4681 * Cr;
-    float b = Y + 1.8556 * Cb;
-    fragColor = vec4(clamp(vec3(r, g, b), 0.0, 1.0), 1.0);
+    vec2 src = (u_texMap * vec3(v_texCoord, 1.0)).xy;
+    float y = texture(u_y, src).r;
+    vec2 chroma = texture(u_uv, src).rg;
+    vec3 yuv = (vec3(y, chroma) - u_yuvOffset) * u_yuvScale;
+    vec3 rgb = u_yuvToRgb * yuv;
+    fragColor = vec4(clamp(rgb, 0.0, 1.0), 1.0);
 }
 )";
 
@@ -112,6 +144,198 @@ constexpr float kQuad[] = {
     -1.f,  1.f, 0.f, 1.f,
      1.f,  1.f, 1.f, 1.f,
 };
+
+QMatrix3x3 yuvToRgbMatrix(int colorspace)
+{
+    // Row-major, multiplies vec3(Y, Cb, Cr) after range expansion.
+    float m[9] = {1.f, 0.f, 1.5748f, 1.f, -0.1873f, -0.4681f, 1.f, 1.8556f, 0.f};
+    switch (colorspace) {
+    case AVCOL_SPC_BT470BG:
+    case AVCOL_SPC_SMPTE170M:
+        m[2] = 1.402f;
+        m[4] = -0.344f;
+        m[5] = -0.714f;
+        m[7] = 1.772f;
+        break;
+    case AVCOL_SPC_BT2020_NCL:
+    case AVCOL_SPC_BT2020_CL:
+        m[2] = 1.4746f;
+        m[4] = -0.1646f;
+        m[5] = -0.5714f;
+        m[7] = 1.8814f;
+        break;
+    default:
+        break;
+    }
+    return QMatrix3x3(m);
+}
+
+QMatrix3x3 texMapForRotation(int rotation)
+{
+    // codedUV = (mat * vec3(displayUV, 1)).xy. 90/270 are clockwise, matching Qt.
+    float m[9] = {1.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 1.f};
+    if (rotation == 90) {
+        const float r[9] = {0.f, 1.f, 0.f, -1.f, 0.f, 1.f, 0.f, 0.f, 1.f};
+        memcpy(m, r, sizeof(m));
+    } else if (rotation == 180) {
+        const float r[9] = {-1.f, 0.f, 1.f, 0.f, -1.f, 1.f, 0.f, 0.f, 1.f};
+        memcpy(m, r, sizeof(m));
+    } else if (rotation == 270) {
+        const float r[9] = {0.f, -1.f, 1.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f};
+        memcpy(m, r, sizeof(m));
+    }
+    return QMatrix3x3(m);
+}
+
+void yuvRangeUniforms(int colorRange, QVector3D *offset, QVector3D *scale)
+{
+    if (colorRange == AVCOL_RANGE_JPEG) {
+        *offset = QVector3D(0.f, 128.f / 255.f, 128.f / 255.f);
+        *scale = QVector3D(1.f, 1.f, 1.f);
+        return;
+    }
+    *offset = QVector3D(16.f / 255.f, 128.f / 255.f, 128.f / 255.f);
+    *scale = QVector3D(255.f / 219.f, 255.f / 224.f, 255.f / 224.f);
+}
+
+bool isHwPixelFormat(AVPixelFormat fmt)
+{
+    const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(fmt);
+    return desc && (desc->flags & AV_PIX_FMT_FLAG_HWACCEL);
+}
+
+#if !defined(Q_OS_MACOS)
+using CUresult = int;
+using CUdeviceptr = void *;
+using CUarray = void *;
+using CUcontext = void *;
+using CUstream = void *;
+using CUgraphicsResource = void *;
+
+enum { kCuSuccess = 0, kCuMemoryDevice = 2, kCuMemoryArray = 3, kCuRegisterWriteDiscard = 0x02 };
+
+struct CudaMemcpy2D
+{
+    size_t srcXInBytes = 0;
+    size_t srcY = 0;
+    int srcMemoryType = 0;
+    int srcPad = 0;
+    const void *srcHost = nullptr;
+    CUdeviceptr srcDevice = nullptr;
+    CUarray srcArray = nullptr;
+    size_t srcPitch = 0;
+    size_t dstXInBytes = 0;
+    size_t dstY = 0;
+    int dstMemoryType = 0;
+    int dstPad = 0;
+    void *dstHost = nullptr;
+    CUdeviceptr dstDevice = nullptr;
+    CUarray dstArray = nullptr;
+    size_t dstPitch = 0;
+    size_t WidthInBytes = 0;
+    size_t Height = 0;
+};
+
+struct CudaGlApi
+{
+    void *lib = nullptr;
+    CUresult (*cuInit)(unsigned int) = nullptr;
+    CUresult (*cuCtxPushCurrent)(CUcontext) = nullptr;
+    CUresult (*cuCtxPopCurrent)(CUcontext *) = nullptr;
+    CUresult (*cuGraphicsGLRegisterImage)(CUgraphicsResource *, unsigned int, unsigned int,
+                                          unsigned int) = nullptr;
+    CUresult (*cuGraphicsUnregisterResource)(CUgraphicsResource) = nullptr;
+    CUresult (*cuGraphicsMapResources)(unsigned int, CUgraphicsResource *, CUstream) = nullptr;
+    CUresult (*cuGraphicsUnmapResources)(unsigned int, CUgraphicsResource *, CUstream) = nullptr;
+    CUresult (*cuGraphicsSubResourceGetMappedArray)(CUarray *, CUgraphicsResource, unsigned int,
+                                                    unsigned int) = nullptr;
+    CUresult (*cuMemcpy2D)(const CudaMemcpy2D *) = nullptr;
+    bool ok = false;
+};
+
+CudaGlApi &cudaGlApi()
+{
+    static CudaGlApi api;
+    static std::once_flag once;
+    std::call_once(once, [] {
+#if defined(Q_OS_WIN)
+        api.lib = static_cast<void *>(LoadLibraryW(L"nvcuda.dll"));
+        auto sym = [&](const char *name) -> void * {
+            return api.lib ? static_cast<void *>(GetProcAddress(static_cast<HMODULE>(api.lib), name))
+                           : nullptr;
+        };
+#else
+        api.lib = dlopen("libcuda.so.1", RTLD_LAZY | RTLD_LOCAL);
+        auto sym = [&](const char *name) -> void * { return api.lib ? dlsym(api.lib, name) : nullptr; };
+#endif
+        if (!api.lib)
+            return;
+#define DRIFT_CUDA_SYM(field, name) \
+    api.field = reinterpret_cast<decltype(api.field)>(sym(name)); \
+    if (!api.field) \
+        return;
+        DRIFT_CUDA_SYM(cuInit, "cuInit");
+        DRIFT_CUDA_SYM(cuCtxPushCurrent, "cuCtxPushCurrent");
+        DRIFT_CUDA_SYM(cuCtxPopCurrent, "cuCtxPopCurrent");
+        DRIFT_CUDA_SYM(cuGraphicsGLRegisterImage, "cuGraphicsGLRegisterImage");
+        DRIFT_CUDA_SYM(cuGraphicsUnregisterResource, "cuGraphicsUnregisterResource");
+        DRIFT_CUDA_SYM(cuGraphicsMapResources, "cuGraphicsMapResources");
+        DRIFT_CUDA_SYM(cuGraphicsUnmapResources, "cuGraphicsUnmapResources");
+        DRIFT_CUDA_SYM(cuGraphicsSubResourceGetMappedArray, "cuGraphicsSubResourceGetMappedArray");
+        DRIFT_CUDA_SYM(cuMemcpy2D, "cuMemcpy2D");
+#undef DRIFT_CUDA_SYM
+        if (api.cuInit(0) != kCuSuccess)
+            return;
+        api.ok = true;
+    });
+    return api;
+}
+
+bool cudaContextOf(const AVFrame *frame, CUcontext *ctx, CUstream *stream)
+{
+    if (!frame || !frame->hw_frames_ctx)
+        return false;
+    const auto *fc = reinterpret_cast<const AVHWFramesContext *>(frame->hw_frames_ctx->data);
+    if (!fc || !fc->device_ctx || fc->device_ctx->type != AV_HWDEVICE_TYPE_CUDA || !fc->device_ctx->hwctx)
+        return false;
+    const char *hwctx = static_cast<const char *>(fc->device_ctx->hwctx);
+    *ctx = *reinterpret_cast<CUcontext const *>(hwctx);
+    *stream = *reinterpret_cast<CUstream const *>(hwctx + sizeof(void *));
+    return *ctx != nullptr;
+}
+
+bool cudaSwFormatIsNv12(const AVFrame *frame)
+{
+    if (!frame || !frame->hw_frames_ctx)
+        return false;
+    const auto *fc = reinterpret_cast<const AVHWFramesContext *>(frame->hw_frames_ctx->data);
+    return fc && fc->sw_format == AV_PIX_FMT_NV12;
+}
+
+bool copyCudaPlaneToTexture(CudaGlApi &api, CUstream stream, CUgraphicsResource resource,
+                            CUdeviceptr src, size_t srcPitch, size_t widthBytes, size_t height)
+{
+    CUarray array = nullptr;
+    if (api.cuGraphicsMapResources(1, &resource, stream) != kCuSuccess)
+        return false;
+    const bool gotArray =
+        api.cuGraphicsSubResourceGetMappedArray(&array, resource, 0, 0) == kCuSuccess && array;
+    bool copied = false;
+    if (gotArray) {
+        CudaMemcpy2D op{};
+        op.srcMemoryType = kCuMemoryDevice;
+        op.srcDevice = src;
+        op.srcPitch = srcPitch;
+        op.dstMemoryType = kCuMemoryArray;
+        op.dstArray = array;
+        op.WidthInBytes = widthBytes;
+        op.Height = height;
+        copied = api.cuMemcpy2D(&op) == kCuSuccess;
+    }
+    api.cuGraphicsUnmapResources(1, &resource, stream);
+    return copied;
+}
+#endif
 
 uint64_t targetPoolKey(int width, int height, bool wantDepth)
 {
@@ -357,6 +581,7 @@ void GlRuntime::releaseCaches()
 
     exec([this] {
         destroyImageUploadCache();
+        destroyVideoUploadState();
         m_targetPool.clear();
         m_pooledTargets = 0;
         if (auto *gl = functions())
@@ -385,6 +610,7 @@ void GlRuntime::shutdown()
                     }
                 }
                 destroyImageUploadCache();
+                destroyVideoUploadState();
             }
             for (GlTarget &target : m_presentRing)
                 target.fbo.reset();
@@ -508,6 +734,245 @@ void GlRuntime::destroyImageUploadCache()
     m_imageUploadIndex.clear();
 }
 
+void GlRuntime::destroyVideoUploadState()
+{
+    unregisterCudaResources();
+    auto *gl = functions();
+    if (gl) {
+        if (m_videoY) {
+            gl->glDeleteTextures(1, &m_videoY);
+            m_videoY = 0;
+        }
+        if (m_videoUV) {
+            gl->glDeleteTextures(1, &m_videoUV);
+            m_videoUV = 0;
+        }
+        if (m_videoPbo[0] || m_videoPbo[1]) {
+            gl->glDeleteBuffers(2, m_videoPbo);
+            m_videoPbo[0] = m_videoPbo[1] = 0;
+        }
+    }
+    m_videoTexW = 0;
+    m_videoTexH = 0;
+    m_videoPboIndex = 0;
+    av_frame_free(&m_hwImportStaging);
+    sws_freeContext(m_importSws);
+    m_importSws = nullptr;
+}
+
+bool GlRuntime::ensureVideoUploadTextures(QOpenGLExtraFunctions *gl, int width, int height)
+{
+    if (!gl || width < 2 || height < 2 || (width % 2) || (height % 2))
+        return false;
+    if (m_videoY && m_videoUV && m_videoTexW == width && m_videoTexH == height)
+        return true;
+
+    unregisterCudaResources();
+    if (m_videoY)
+        gl->glDeleteTextures(1, &m_videoY);
+    if (m_videoUV)
+        gl->glDeleteTextures(1, &m_videoUV);
+    m_videoY = m_videoUV = 0;
+
+    gl->glGenTextures(1, &m_videoY);
+    gl->glBindTexture(GL_TEXTURE_2D, m_videoY);
+    gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    gl->glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, width, height, 0, GL_RED, GL_UNSIGNED_BYTE, nullptr);
+
+    gl->glGenTextures(1, &m_videoUV);
+    gl->glBindTexture(GL_TEXTURE_2D, m_videoUV);
+    gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    gl->glTexImage2D(GL_TEXTURE_2D, 0, GL_RG8, width / 2, height / 2, 0, GL_RG, GL_UNSIGNED_BYTE,
+                     nullptr);
+
+    m_videoTexW = width;
+    m_videoTexH = height;
+    return m_videoY != 0 && m_videoUV != 0;
+}
+
+bool GlRuntime::uploadPlanePbo(QOpenGLExtraFunctions *gl, GLuint texture, int texW, int texH,
+                               GLenum internalFormat, GLenum format, const uint8_t *src, int srcPitch,
+                               int packedWidth)
+{
+    Q_UNUSED(internalFormat);
+    if (!gl || !texture || !src || texW <= 0 || texH <= 0 || packedWidth <= 0 || srcPitch <= 0)
+        return false;
+    const qsizetype packed = qsizetype(packedWidth) * texH;
+    if (!m_videoPbo[0])
+        gl->glGenBuffers(2, m_videoPbo);
+    const GLuint pbo = m_videoPbo[m_videoPboIndex];
+    m_videoPboIndex ^= 1;
+    gl->glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo);
+    gl->glBufferData(GL_PIXEL_UNPACK_BUFFER, packed, nullptr, GL_STREAM_DRAW);
+    void *dst = gl->glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, packed,
+                                     GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT);
+    if (!dst) {
+        gl->glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+        return false;
+    }
+    if (srcPitch == packedWidth) {
+        memcpy(dst, src, size_t(packed));
+    } else {
+        auto *out = static_cast<uint8_t *>(dst);
+        const int rowBytes = qMin(packedWidth, srcPitch);
+        for (int y = 0; y < texH; ++y)
+            memcpy(out + size_t(y) * packedWidth, src + size_t(y) * srcPitch, size_t(rowBytes));
+    }
+    gl->glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
+    gl->glBindTexture(GL_TEXTURE_2D, texture);
+    gl->glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    gl->glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+    gl->glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, texW, texH, format, GL_UNSIGNED_BYTE, nullptr);
+    gl->glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+    return true;
+}
+
+void GlRuntime::unregisterCudaResources()
+{
+#if !defined(Q_OS_MACOS)
+    CudaGlApi &api = cudaGlApi();
+    if (!api.ok)
+        return;
+    if (m_cudaYResource) {
+        api.cuGraphicsUnregisterResource(static_cast<CUgraphicsResource>(m_cudaYResource));
+        m_cudaYResource = nullptr;
+    }
+    if (m_cudaUvResource) {
+        api.cuGraphicsUnregisterResource(static_cast<CUgraphicsResource>(m_cudaUvResource));
+        m_cudaUvResource = nullptr;
+    }
+    m_cudaTexW = 0;
+    m_cudaTexH = 0;
+#endif
+}
+
+bool GlRuntime::importCudaNv12(QOpenGLExtraFunctions *gl, const AVFrame *frame)
+{
+#if defined(Q_OS_MACOS)
+    Q_UNUSED(gl);
+    Q_UNUSED(frame);
+    return false;
+#else
+    if (m_cudaImportFailed || !frame || frame->format != AV_PIX_FMT_CUDA || !cudaSwFormatIsNv12(frame))
+        return false;
+    CudaGlApi &api = cudaGlApi();
+    if (!api.ok) {
+        m_cudaImportFailed = true;
+        return false;
+    }
+    CUcontext ctx = nullptr;
+    CUstream stream = nullptr;
+    if (!cudaContextOf(frame, &ctx, &stream))
+        return false;
+
+    const int w = frame->width;
+    const int h = frame->height;
+    if (!ensureVideoUploadTextures(gl, w, h))
+        return false;
+
+    if (api.cuCtxPushCurrent(ctx) != kCuSuccess)
+        return false;
+
+    bool ok = false;
+    if (m_cudaTexW != w || m_cudaTexH != h || !m_cudaYResource || !m_cudaUvResource) {
+        unregisterCudaResources();
+        CUgraphicsResource yRes = nullptr;
+        CUgraphicsResource uvRes = nullptr;
+        if (api.cuGraphicsGLRegisterImage(&yRes, m_videoY, GL_TEXTURE_2D, kCuRegisterWriteDiscard)
+                == kCuSuccess
+            && api.cuGraphicsGLRegisterImage(&uvRes, m_videoUV, GL_TEXTURE_2D, kCuRegisterWriteDiscard)
+                == kCuSuccess) {
+            m_cudaYResource = yRes;
+            m_cudaUvResource = uvRes;
+            m_cudaTexW = w;
+            m_cudaTexH = h;
+        } else {
+            if (yRes)
+                api.cuGraphicsUnregisterResource(yRes);
+            if (uvRes)
+                api.cuGraphicsUnregisterResource(uvRes);
+            m_cudaImportFailed = true;
+        }
+    }
+
+    if (m_cudaYResource && m_cudaUvResource) {
+        ok = copyCudaPlaneToTexture(api, stream, static_cast<CUgraphicsResource>(m_cudaYResource),
+                                    frame->data[0], size_t(qMax(0, frame->linesize[0])), size_t(w),
+                                    size_t(h))
+            && copyCudaPlaneToTexture(api, stream, static_cast<CUgraphicsResource>(m_cudaUvResource),
+                                      frame->data[1], size_t(qMax(0, frame->linesize[1])), size_t(w),
+                                      size_t(h / 2));
+        if (!ok)
+            m_cudaImportFailed = true;
+    }
+
+    CUcontext popped = nullptr;
+    api.cuCtxPopCurrent(&popped);
+    return ok;
+#endif
+}
+
+AVFrame *GlRuntime::ensureSoftwareNv12(const AVFrame *src)
+{
+    if (!src)
+        return nullptr;
+    if (src->format == AV_PIX_FMT_NV12)
+        return const_cast<AVFrame *>(src);
+
+    if (isHwPixelFormat(static_cast<AVPixelFormat>(src->format))) {
+        if (!m_hwImportStaging)
+            m_hwImportStaging = av_frame_alloc();
+        if (!m_hwImportStaging)
+            return nullptr;
+        av_frame_unref(m_hwImportStaging);
+        if (av_hwframe_transfer_data(m_hwImportStaging, src, 0) < 0) {
+            av_frame_unref(m_hwImportStaging);
+            return nullptr;
+        }
+        src = m_hwImportStaging;
+        if (src->format == AV_PIX_FMT_NV12)
+            return m_hwImportStaging;
+    }
+
+    const int tw = src->width & ~1;
+    const int th = src->height & ~1;
+    if (tw < 2 || th < 2)
+        return nullptr;
+
+    m_importSws = sws_getCachedContext(m_importSws, src->width, src->height,
+                                       static_cast<AVPixelFormat>(src->format), tw, th, AV_PIX_FMT_NV12,
+                                       SWS_BILINEAR, nullptr, nullptr, nullptr);
+    if (!m_importSws)
+        return nullptr;
+
+    if (!m_hwImportStaging)
+        m_hwImportStaging = av_frame_alloc();
+    if (!m_hwImportStaging)
+        return nullptr;
+    if (m_hwImportStaging->format != AV_PIX_FMT_NV12 || m_hwImportStaging->width != tw
+        || m_hwImportStaging->height != th || !m_hwImportStaging->data[0]) {
+        av_frame_unref(m_hwImportStaging);
+        m_hwImportStaging->format = AV_PIX_FMT_NV12;
+        m_hwImportStaging->width = tw;
+        m_hwImportStaging->height = th;
+        if (av_frame_get_buffer(m_hwImportStaging, 0) < 0) {
+            av_frame_unref(m_hwImportStaging);
+            return nullptr;
+        }
+    }
+    sws_scale(m_importSws, src->data, src->linesize, 0, src->height, m_hwImportStaging->data,
+              m_hwImportStaging->linesize);
+    m_hwImportStaging->colorspace = src->colorspace;
+    m_hwImportStaging->color_range = src->color_range;
+    return m_hwImportStaging;
+}
+
 GlTarget &GlRuntime::acquirePresentTarget(int width, int height)
 {
     const int w = qMax(1, width);
@@ -547,15 +1012,14 @@ void GlRuntime::markPresentReady(GlTarget &presentTarget)
     if (slotIndex < 0)
         return;
 
-    waitPresentFence(slotIndex);
+    // Publish without a client wait: Qt Quick draws on the next vsync. The ring
+    // waits this fence in acquirePresentTarget before reuse of the same slot.
+    if (m_presentFence[slotIndex]) {
+        gl->glDeleteSync(m_presentFence[slotIndex]);
+        m_presentFence[slotIndex] = nullptr;
+    }
     gl->glFlush();
     m_presentFence[slotIndex] = gl->glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
-    // Ensure the just-inserted fence has completed before the texture id is
-    // published to the scene graph (avoids sampling a half-drawn frame).
-    if (m_presentFence[slotIndex]) {
-        gl->glClientWaitSync(m_presentFence[slotIndex], GL_SYNC_FLUSH_COMMANDS_BIT,
-                             GLuint64(16'000'000)); // ~1 frame @ 60 Hz
-    }
 }
 
 QOpenGLShaderProgram *GlRuntime::builtinProgram(const QString &id, const char *vertexSource,
@@ -778,18 +1242,36 @@ GlTarget promoteImageToTargetCached(GlRuntime &rt, QOpenGLExtraFunctions *gl, co
     return target;
 }
 
-GlTarget promoteNv12ToTarget(GlRuntime &rt, QOpenGLExtraFunctions *gl, const QByteArray &nv12,
-                             int width, int height)
+GlTarget promoteVideoFrameToTarget(GlRuntime &rt, QOpenGLExtraFunctions *gl,
+                                   const PreviewVideoFrame &frame)
 {
-    if (!gl || width <= 0 || height <= 0 || (height % 2) != 0 || (width % 2) != 0)
+    if (!gl || !frame.isValid())
         return {};
 
-    const qsizetype yBytes = qsizetype(width) * height;
-    const qsizetype uvBytes = qsizetype(width) * (height / 2);
-    if (nv12.size() < yBytes + uvBytes)
+    const AVFrame *av = frame.frame.get();
+    const int codedW = av->width & ~1;
+    const int codedH = av->height & ~1;
+    if (codedW < 2 || codedH < 2)
         return {};
 
-    GlTarget target = rt.acquireTarget(width, height);
+    bool uploaded = rt.importCudaNv12(gl, av);
+    if (!uploaded) {
+        AVFrame *nv12 = rt.ensureSoftwareNv12(av);
+        if (!nv12 || nv12->format != AV_PIX_FMT_NV12)
+            return {};
+        const int w = nv12->width;
+        const int h = nv12->height;
+        if (!rt.ensureVideoUploadTextures(gl, w, h))
+            return {};
+        if (!rt.uploadPlanePbo(gl, rt.m_videoY, w, h, GL_R8, GL_RED, nv12->data[0], nv12->linesize[0], w)
+            || !rt.uploadPlanePbo(gl, rt.m_videoUV, w / 2, h / 2, GL_RG8, GL_RG, nv12->data[1],
+                                  nv12->linesize[1], w))
+            return {};
+    }
+
+    const int destW = qMax(2, frame.displayWidth() & ~1);
+    const int destH = qMax(2, frame.displayHeight() & ~1);
+    GlTarget target = rt.acquireTarget(destW, destH);
     if (!target.isValid())
         return {};
 
@@ -800,46 +1282,31 @@ GlTarget promoteNv12ToTarget(GlRuntime &rt, QOpenGLExtraFunctions *gl, const QBy
         return {};
     }
 
-    GLuint textures[2] = {0, 0};
-    gl->glGenTextures(2, textures);
-
-    gl->glBindTexture(GL_TEXTURE_2D, textures[0]);
-    gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    gl->glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-    gl->glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, width, height, 0, GL_RED, GL_UNSIGNED_BYTE,
-                     nv12.constData());
-
-    gl->glBindTexture(GL_TEXTURE_2D, textures[1]);
-    gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    gl->glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-    gl->glTexImage2D(GL_TEXTURE_2D, 0, GL_RG8, width / 2, height / 2, 0, GL_RG, GL_UNSIGNED_BYTE,
-                     nv12.constData() + yBytes);
+    QVector3D offset;
+    QVector3D scale;
+    yuvRangeUniforms(frame.colorRange, &offset, &scale);
 
     target.fbo->bind();
-    gl->glViewport(0, 0, width, height);
+    gl->glViewport(0, 0, destW, destH);
     gl->glDisable(GL_BLEND);
     gl->glClearColor(0.f, 0.f, 0.f, 0.f);
     gl->glClear(GL_COLOR_BUFFER_BIT);
     program->bind();
     program->setUniformValue("u_y", 0);
     program->setUniformValue("u_uv", 1);
+    program->setUniformValue("u_yuvToRgb", yuvToRgbMatrix(frame.colorspace));
+    program->setUniformValue("u_yuvOffset", offset);
+    program->setUniformValue("u_yuvScale", scale);
+    program->setUniformValue("u_texMap", texMapForRotation(frame.rotation));
     gl->glActiveTexture(GL_TEXTURE0);
-    gl->glBindTexture(GL_TEXTURE_2D, textures[0]);
+    gl->glBindTexture(GL_TEXTURE_2D, rt.m_videoY);
     gl->glActiveTexture(GL_TEXTURE1);
-    gl->glBindTexture(GL_TEXTURE_2D, textures[1]);
+    gl->glBindTexture(GL_TEXTURE_2D, rt.m_videoUV);
     gl->glBindVertexArray(rt.vao);
     gl->glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     gl->glBindVertexArray(0);
     program->release();
     target.fbo->release();
-
-    gl->glDeleteTextures(2, textures);
     return target;
 }
 

--- a/src/engine/GlRuntime.cpp
+++ b/src/engine/GlRuntime.cpp
@@ -31,6 +31,13 @@ extern "C" {
 #include <dlfcn.h>
 #endif
 
+// VAAPI dma-buf import. Android is GLES on a MediaCodec decoder that never produces a VAAPI
+// surface, so it is excluded along with the two platforms that have no libva at all.
+#if !defined(Q_OS_WIN) && !defined(Q_OS_MACOS) && !defined(Q_OS_ANDROID)
+#define DRIFT_VAAPI_IMPORT 1
+#include <unistd.h>
+#endif
+
 // Qt for Android is built against the GLES 2.0 headers so it can still run on ES2-only devices, and
 // qopengl.h includes <GLES2/gl2.h> accordingly. The ES 3.0 *functions* this file uses still resolve,
 // because QOpenGLExtraFunctions looks them up at runtime — but the ES 3.0 *enum constants* are
@@ -336,6 +343,188 @@ bool copyCudaPlaneToTexture(CudaGlApi &api, CUstream stream, CUgraphicsResource 
     return copied;
 }
 #endif
+
+#if defined(DRIFT_VAAPI_IMPORT)
+// libva and the EGL dma-buf import extension, resolved at runtime for the same reason CUDA is:
+// the binary has to start on a host with neither. Only the handful of declarations the import
+// needs are reproduced here — a compile-time dependency on va/va.h and EGL/eglext.h would buy
+// nothing but a build-time failure on machines that never decode with VAAPI.
+
+using VASurfaceID = unsigned int;
+using VAStatus = int;
+
+enum {
+    kVaStatusSuccess = 0,
+    kVaMemTypeDrmPrime2 = 0x40000000,
+    kVaExportReadOnly = 0x0001,
+    kVaExportSeparateLayers = 0x0004,
+};
+
+// Mirrors VADRMPRIMESurfaceDescriptor from va/va_drmcommon.h. The objects[] entry pads to 16
+// bytes (int + uint32_t, then an 8-aligned uint64_t); getting that wrong silently shifts every
+// field after it, which is what the sanity check in importVaapiNv12 exists to catch.
+struct VaDrmPrimeSurfaceDescriptor
+{
+    uint32_t fourcc;
+    uint32_t width;
+    uint32_t height;
+    uint32_t num_objects;
+    struct
+    {
+        int fd;
+        uint32_t size;
+        uint64_t drm_format_modifier;
+    } objects[4];
+    uint32_t num_layers;
+    struct
+    {
+        uint32_t drm_format;
+        uint32_t num_planes;
+        uint32_t object_index[4];
+        uint32_t offset[4];
+        uint32_t pitch[4];
+    } layers[4];
+};
+
+constexpr uint32_t fourcc(char a, char b, char c, char d)
+{
+    return uint32_t(uint8_t(a)) | (uint32_t(uint8_t(b)) << 8) | (uint32_t(uint8_t(c)) << 16)
+        | (uint32_t(uint8_t(d)) << 24);
+}
+
+constexpr uint32_t kDrmFormatR8 = fourcc('R', '8', ' ', ' ');
+constexpr uint32_t kDrmFormatGr88 = fourcc('G', 'R', '8', '8');
+constexpr uint64_t kDrmFormatModInvalid = 0x00ffffffffffffffull;
+
+using EGLDisplayHandle = void *;
+using EGLImageHandle = void *;
+using EGLClientBufferHandle = void *;
+
+enum {
+    kEglExtensions = 0x3055,
+    kEglWidth = 0x3057,
+    kEglHeight = 0x3056,
+    kEglNone = 0x3038,
+    kEglLinuxDmaBufExt = 0x3270,
+    kEglLinuxDrmFourccExt = 0x3271,
+    kEglDmaBufPlane0FdExt = 0x3272,
+    kEglDmaBufPlane0OffsetExt = 0x3273,
+    kEglDmaBufPlane0PitchExt = 0x3274,
+    kEglDmaBufPlane0ModifierLoExt = 0x3443,
+    kEglDmaBufPlane0ModifierHiExt = 0x3444,
+};
+
+struct VaEglApi
+{
+    void *va = nullptr;
+    void *egl = nullptr;
+    VAStatus (*vaExportSurfaceHandle)(void *, VASurfaceID, uint32_t, uint32_t, void *) = nullptr;
+    VAStatus (*vaSyncSurface)(void *, VASurfaceID) = nullptr;
+    EGLDisplayHandle (*eglGetCurrentDisplay)() = nullptr;
+    const char *(*eglQueryString)(EGLDisplayHandle, int) = nullptr;
+    // The KHR entry point takes 32-bit EGLint attributes, not the EGLAttrib (intptr_t) list
+    // EGL 1.5's eglCreateImage takes. That is why the modifier arrives as two halves.
+    EGLImageHandle (*eglCreateImageKHR)(EGLDisplayHandle, void *, unsigned int, EGLClientBufferHandle,
+                                        const int32_t *) = nullptr;
+    unsigned int (*eglDestroyImageKHR)(EGLDisplayHandle, EGLImageHandle) = nullptr;
+    void (*glEGLImageTargetTexture2DOES)(unsigned int, EGLImageHandle) = nullptr;
+    bool ok = false;
+};
+
+VaEglApi &vaEglApi()
+{
+    static VaEglApi api;
+    static std::once_flag once;
+    std::call_once(once, [] {
+        api.va = dlopen("libva.so.2", RTLD_LAZY | RTLD_LOCAL);
+        api.egl = dlopen("libEGL.so.1", RTLD_LAZY | RTLD_LOCAL);
+        if (!api.va || !api.egl)
+            return;
+#define DRIFT_VA_SYM(handle, field, name) \
+    api.field = reinterpret_cast<decltype(api.field)>(dlsym(handle, name)); \
+    if (!api.field) \
+        return;
+        DRIFT_VA_SYM(api.va, vaExportSurfaceHandle, "vaExportSurfaceHandle");
+        DRIFT_VA_SYM(api.va, vaSyncSurface, "vaSyncSurface");
+        DRIFT_VA_SYM(api.egl, eglGetCurrentDisplay, "eglGetCurrentDisplay");
+        DRIFT_VA_SYM(api.egl, eglQueryString, "eglQueryString");
+#undef DRIFT_VA_SYM
+
+        // eglCreateImageKHR is an extension entry point, so it comes from eglGetProcAddress
+        // rather than the library's symbol table. glEGLImageTargetTexture2DOES comes from Qt's
+        // context, which knows which GL implementation is actually current.
+        auto *getProc = reinterpret_cast<void *(*)(const char *)>(dlsym(api.egl, "eglGetProcAddress"));
+        QOpenGLContext *ctx = QOpenGLContext::currentContext();
+        if (!getProc || !ctx)
+            return;
+        api.eglCreateImageKHR =
+            reinterpret_cast<decltype(api.eglCreateImageKHR)>(getProc("eglCreateImageKHR"));
+        api.eglDestroyImageKHR =
+            reinterpret_cast<decltype(api.eglDestroyImageKHR)>(getProc("eglDestroyImageKHR"));
+        api.glEGLImageTargetTexture2DOES =
+            reinterpret_cast<decltype(api.glEGLImageTargetTexture2DOES)>(
+                ctx->getProcAddress("glEGLImageTargetTexture2DOES"));
+        if (!api.eglCreateImageKHR || !api.eglDestroyImageKHR || !api.glEGLImageTargetTexture2DOES)
+            return;
+
+        // Under libglvnd every one of those pointers is a dispatch stub that exists whether or
+        // not the driver implements the entry point, so the extension strings are the only real
+        // availability test.
+        if (!ctx->hasExtension(QByteArrayLiteral("GL_OES_EGL_image")))
+            return;
+        api.ok = true;
+    });
+    return api;
+}
+
+// Reads AVVAAPIDeviceContext::display, whose VADisplay is the first and only member.
+void *vaapiDisplayOf(const AVFrame *frame)
+{
+    if (!frame || !frame->hw_frames_ctx)
+        return nullptr;
+    const auto *fc = reinterpret_cast<const AVHWFramesContext *>(frame->hw_frames_ctx->data);
+    if (!fc || !fc->device_ctx || fc->device_ctx->type != AV_HWDEVICE_TYPE_VAAPI
+        || !fc->device_ctx->hwctx)
+        return nullptr;
+    return *reinterpret_cast<void *const *>(fc->device_ctx->hwctx);
+}
+
+bool vaapiSwFormatIsNv12(const AVFrame *frame)
+{
+    if (!frame || !frame->hw_frames_ctx)
+        return false;
+    const auto *fc = reinterpret_cast<const AVHWFramesContext *>(frame->hw_frames_ctx->data);
+    return fc && fc->sw_format == AV_PIX_FMT_NV12;
+}
+
+// vaExportSurfaceHandle hands over owned fds. They have to be closed on every path out,
+// including the ones that reject the descriptor before an EGLImage is ever created — at 60 fps
+// a leak there exhausts the process fd table in under a minute, and it surfaces as unrelated
+// file-open failures elsewhere in the app.
+struct ExportedSurfaceFds
+{
+    VaDrmPrimeSurfaceDescriptor *desc = nullptr;
+
+    ~ExportedSurfaceFds()
+    {
+        if (!desc)
+            return;
+        const uint32_t count = qMin(desc->num_objects, 4u);
+        for (uint32_t i = 0; i < count; ++i) {
+            if (desc->objects[i].fd >= 0)
+                ::close(desc->objects[i].fd);
+        }
+    }
+};
+
+// A zero-copy path that silently falls back is pixel-identical to one that works, so say once
+// why it did not engage. Anything else leaves "preview did not get faster" unfalsifiable.
+void logVaapiImportOnce(const char *reason)
+{
+    static std::once_flag once;
+    std::call_once(once, [reason] { qInfo("GlRuntime: VAAPI zero-copy import unavailable (%s)", reason); });
+}
+#endif // DRIFT_VAAPI_IMPORT
 
 uint64_t targetPoolKey(int width, int height, bool wantDepth)
 {
@@ -747,6 +936,14 @@ void GlRuntime::destroyVideoUploadState()
             gl->glDeleteTextures(1, &m_videoUV);
             m_videoUV = 0;
         }
+        if (m_importY) {
+            gl->glDeleteTextures(1, &m_importY);
+            m_importY = 0;
+        }
+        if (m_importUV) {
+            gl->glDeleteTextures(1, &m_importUV);
+            m_importUV = 0;
+        }
         if (m_videoPbo[0] || m_videoPbo[1]) {
             gl->glDeleteBuffers(2, m_videoPbo);
             m_videoPbo[0] = m_videoPbo[1] = 0;
@@ -915,6 +1112,181 @@ bool GlRuntime::importCudaNv12(QOpenGLExtraFunctions *gl, const AVFrame *frame)
     CUcontext popped = nullptr;
     api.cuCtxPopCurrent(&popped);
     return ok;
+#endif
+}
+
+bool GlRuntime::ensureImportTextureNames(QOpenGLExtraFunctions *gl)
+{
+    if (!gl)
+        return false;
+    if (m_importY && m_importUV)
+        return true;
+
+    // Lazily, not once at init: destroyVideoUploadState() deletes these, and releaseCaches()
+    // calls it mid-session. Creating them up front would leave the next import binding name 0.
+    for (GLuint *tex : {&m_importY, &m_importUV}) {
+        if (*tex)
+            continue;
+        gl->glGenTextures(1, tex);
+        gl->glBindTexture(GL_TEXTURE_2D, *tex);
+        gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    }
+    // No glTexImage2D: glEGLImageTargetTexture2DOES supplies the storage.
+    return m_importY != 0 && m_importUV != 0;
+}
+
+// VAAPI surface -> dma-buf -> two EGLImages -> the same R8 + RG8 pair the convert shader already
+// samples. Replaces an av_hwframe_transfer_data of the displayed frame on every Intel/AMD host.
+bool GlRuntime::importVaapiNv12(QOpenGLExtraFunctions *gl, const AVFrame *frame)
+{
+#if !defined(DRIFT_VAAPI_IMPORT)
+    Q_UNUSED(gl);
+    Q_UNUSED(frame);
+    return false;
+#else
+    if (m_vaapiImportFailed || !gl || !frame || frame->format != AV_PIX_FMT_VAAPI)
+        return false;
+
+    // Content and configuration mismatches fall through to the PBO path for this frame only.
+    // Marking them sticky would let one 10-bit clip disable zero-copy for every 8-bit clip
+    // beside it on the timeline: scale_vaapi's size-only retry keeps the native sw_format.
+    if (!vaapiSwFormatIsNv12(frame))
+        return false;
+    void *display = vaapiDisplayOf(frame);
+    if (!display)
+        return false;
+
+    // Opt-in, not opt-out. Every *detectable* failure below falls back to the PBO upload, but a
+    // driver that exports a surface we import successfully and sample wrongly shows up as
+    // corrupt preview with nothing to catch. That has been verified on Mesa iris + iHD and
+    // nowhere else, so until other drivers have been through it the default stays off: slower
+    // preview is a far better failure than a broken picture.
+    if (!qEnvironmentVariableIsSet("DRIFT_VAAPI_ZEROCOPY")) {
+        logVaapiImportOnce("set DRIFT_VAAPI_ZEROCOPY=1 to enable");
+        m_vaapiImportFailed = true;
+        return false;
+    }
+
+    VaEglApi &api = vaEglApi();
+    if (!api.ok) {
+        logVaapiImportOnce("libva/EGL entry points or GL_OES_EGL_image missing");
+        m_vaapiImportFailed = true;
+        return false;
+    }
+
+    // Only valid while the context is current, which exec() guarantees. Under Qt's xcb plugin
+    // the GL context is GLX and there is no EGL display to import into at all.
+    EGLDisplayHandle egl = api.eglGetCurrentDisplay();
+    if (!egl) {
+        logVaapiImportOnce("no current EGL display; Qt is probably on GLX rather than EGL");
+        m_vaapiImportFailed = true;
+        return false;
+    }
+    const char *eglExts = api.eglQueryString(egl, kEglExtensions);
+    if (!eglExts || !strstr(eglExts, "EGL_EXT_image_dma_buf_import")) {
+        logVaapiImportOnce("EGL_EXT_image_dma_buf_import missing");
+        m_vaapiImportFailed = true;
+        return false;
+    }
+    // Tiled surfaces need their modifier passed through or the import is refused or garbled,
+    // but sending modifier attribs without this extension is EGL_BAD_ATTRIBUTE.
+    const bool useModifiers = strstr(eglExts, "EGL_EXT_image_dma_buf_import_modifiers") != nullptr;
+
+    const int codedW = frame->width & ~1;
+    const int codedH = frame->height & ~1;
+    if (codedW < 2 || codedH < 2)
+        return false;
+
+    VaDrmPrimeSurfaceDescriptor desc{};
+    for (auto &object : desc.objects)
+        object.fd = -1;
+    const auto surface = VASurfaceID(uintptr_t(frame->data[3]));
+    if (api.vaExportSurfaceHandle(display, surface, kVaMemTypeDrmPrime2,
+                                  kVaExportReadOnly | kVaExportSeparateLayers, &desc)
+        != kVaStatusSuccess) {
+        logVaapiImportOnce("vaExportSurfaceHandle failed");
+        m_vaapiImportFailed = true;
+        return false;
+    }
+    const ExportedSurfaceFds fds{&desc};
+    // The decoder or VPP may still be writing. Failing to sync is not a reason to abandon the
+    // path, so its result is deliberately not checked — this matches mpv.
+    api.vaSyncSurface(display, surface);
+
+    // Guards against a libva ABI change shifting every field past objects[]: without them a
+    // mismatched struct imports plausible-looking garbage instead of failing.
+    if (desc.num_objects < 1 || desc.num_objects > 4 || desc.num_layers != 2)
+        return false;
+    if (desc.layers[0].drm_format != kDrmFormatR8 || desc.layers[1].drm_format != kDrmFormatGr88)
+        return false;
+    for (uint32_t i = 0; i < desc.num_layers; ++i) {
+        if (desc.layers[i].num_planes != 1 || desc.layers[i].object_index[0] >= desc.num_objects
+            || desc.layers[i].pitch[0] == 0)
+            return false;
+    }
+
+    if (!ensureImportTextureNames(gl))
+        return false;
+
+    const GLuint textures[2] = {m_importY, m_importUV};
+    for (uint32_t i = 0; i < 2; ++i) {
+        const auto &layer = desc.layers[i];
+        const auto &object = desc.objects[layer.object_index[0]];
+
+        // The surface allocation is padded (1080 -> 1088); the picture is not. Sizing the image
+        // from the descriptor would sample that padding, and because kQuad puts v=0 at the NDC
+        // bottom it would land as a garbage strip along the visual bottom edge. The pitch
+        // attribute already carries the stride, so the padded height is never needed.
+        int32_t attribs[32];
+        int n = 0;
+        attribs[n++] = kEglWidth;
+        attribs[n++] = i == 0 ? codedW : codedW / 2;
+        attribs[n++] = kEglHeight;
+        attribs[n++] = i == 0 ? codedH : codedH / 2;
+        attribs[n++] = kEglLinuxDrmFourccExt;
+        attribs[n++] = int32_t(layer.drm_format);
+        attribs[n++] = kEglDmaBufPlane0FdExt;
+        attribs[n++] = object.fd;
+        attribs[n++] = kEglDmaBufPlane0OffsetExt;
+        attribs[n++] = int32_t(layer.offset[0]);
+        attribs[n++] = kEglDmaBufPlane0PitchExt;
+        attribs[n++] = int32_t(layer.pitch[0]);
+        if (useModifiers && object.drm_format_modifier != kDrmFormatModInvalid) {
+            attribs[n++] = kEglDmaBufPlane0ModifierLoExt;
+            attribs[n++] = int32_t(object.drm_format_modifier & 0xffffffffu);
+            attribs[n++] = kEglDmaBufPlane0ModifierHiExt;
+            attribs[n++] = int32_t(object.drm_format_modifier >> 32);
+        }
+        attribs[n++] = kEglNone;
+
+        // EGL_NO_CONTEXT is required for EGL_LINUX_DMA_BUF_EXT.
+        EGLImageHandle image =
+            api.eglCreateImageKHR(egl, nullptr, kEglLinuxDmaBufExt, nullptr, attribs);
+        if (!image) {
+            logVaapiImportOnce("eglCreateImageKHR rejected the exported dma-buf");
+            m_vaapiImportFailed = true;
+            return false;
+        }
+        gl->glBindTexture(GL_TEXTURE_2D, textures[i]);
+        api.glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, image);
+        // Destroying the image only orphans the handle; the texture sibling keeps the buffer.
+        // Doing it here rather than after the convert draw means the early returns between the
+        // two cannot leak one.
+        api.eglDestroyImageKHR(egl, image);
+    }
+
+    // The same two texture names are re-targeted every frame, and a crossfade imports twice
+    // within one exec(). That is safe because commands in one context are ordered and the
+    // driver holds a reference to what an already-recorded draw sampled.
+    //
+    // The VA surface itself has to outlive the draw: GpuLayer holds the AVFrame across the
+    // whole exec() lambda, markPresentReady's glFlush submits the batch inside it, and
+    // ClipReader's preview cache holds further refs. Past that — a teardown that clears the
+    // cache mid-flight — this relies on the kernel's implicit fencing on the shared buffer.
+    return true;
 #endif
 }
 
@@ -1254,7 +1626,16 @@ GlTarget promoteVideoFrameToTarget(GlRuntime &rt, QOpenGLExtraFunctions *gl,
     if (codedW < 2 || codedH < 2)
         return {};
 
+    // CUDA copies into the pooled textures; VAAPI binds the decoder's own dma-buf into a
+    // separate pair, so the draw below has to be told which one holds this frame.
+    GLuint texY = rt.m_videoY;
+    GLuint texUV = rt.m_videoUV;
     bool uploaded = rt.importCudaNv12(gl, av);
+    if (!uploaded && rt.importVaapiNv12(gl, av)) {
+        uploaded = true;
+        texY = rt.m_importY;
+        texUV = rt.m_importUV;
+    }
     if (!uploaded) {
         AVFrame *nv12 = rt.ensureSoftwareNv12(av);
         if (!nv12 || nv12->format != AV_PIX_FMT_NV12)
@@ -1267,6 +1648,8 @@ GlTarget promoteVideoFrameToTarget(GlRuntime &rt, QOpenGLExtraFunctions *gl,
             || !rt.uploadPlanePbo(gl, rt.m_videoUV, w / 2, h / 2, GL_RG8, GL_RG, nv12->data[1],
                                   nv12->linesize[1], w))
             return {};
+        texY = rt.m_videoY;
+        texUV = rt.m_videoUV;
     }
 
     const int destW = qMax(2, frame.displayWidth() & ~1);
@@ -1299,9 +1682,9 @@ GlTarget promoteVideoFrameToTarget(GlRuntime &rt, QOpenGLExtraFunctions *gl,
     program->setUniformValue("u_yuvScale", scale);
     program->setUniformValue("u_texMap", texMapForRotation(frame.rotation));
     gl->glActiveTexture(GL_TEXTURE0);
-    gl->glBindTexture(GL_TEXTURE_2D, rt.m_videoY);
+    gl->glBindTexture(GL_TEXTURE_2D, texY);
     gl->glActiveTexture(GL_TEXTURE1);
-    gl->glBindTexture(GL_TEXTURE_2D, rt.m_videoUV);
+    gl->glBindTexture(GL_TEXTURE_2D, texUV);
     gl->glBindVertexArray(rt.vao);
     gl->glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     gl->glBindVertexArray(0);

--- a/src/engine/GlRuntime.cpp
+++ b/src/engine/GlRuntime.cpp
@@ -78,6 +78,45 @@ extern "C" {
 #ifndef GL_MAP_INVALIDATE_BUFFER_BIT
 #define GL_MAP_INVALIDATE_BUFFER_BIT 0x0008
 #endif
+#ifndef GL_PIXEL_PACK_BUFFER
+#define GL_PIXEL_PACK_BUFFER 0x88EB
+#endif
+#ifndef GL_STREAM_READ
+#define GL_STREAM_READ 0x88E1
+#endif
+#ifndef GL_MAP_READ_BIT
+#define GL_MAP_READ_BIT 0x0001
+#endif
+#ifndef GL_PACK_ROW_LENGTH
+#define GL_PACK_ROW_LENGTH 0x0D02
+#endif
+#ifndef GL_PACK_ALIGNMENT
+#define GL_PACK_ALIGNMENT 0x0D05
+#endif
+#ifndef GL_READ_FRAMEBUFFER
+#define GL_READ_FRAMEBUFFER 0x8CA8
+#endif
+#ifndef GL_FRAMEBUFFER
+#define GL_FRAMEBUFFER 0x8D40
+#endif
+#ifndef GL_COLOR_ATTACHMENT0
+#define GL_COLOR_ATTACHMENT0 0x8CE0
+#endif
+#ifndef GL_FRAMEBUFFER_COMPLETE
+#define GL_FRAMEBUFFER_COMPLETE 0x8CD5
+#endif
+#ifndef GL_TIMEOUT_IGNORED
+#define GL_TIMEOUT_IGNORED 0xFFFFFFFFFFFFFFFFull
+#endif
+#ifndef GL_ALREADY_SIGNALED
+#define GL_ALREADY_SIGNALED 0x911A
+#endif
+#ifndef GL_CONDITION_SATISFIED
+#define GL_CONDITION_SATISFIED 0x911C
+#endif
+#ifndef GL_WAIT_FAILED
+#define GL_WAIT_FAILED 0x911D
+#endif
 
 namespace drift {
 
@@ -171,6 +210,37 @@ void main() {
     vec3 yuv = (vec3(y, chroma) - u_yuvOffset) * u_yuvScale;
     vec3 rgb = u_yuvToRgb * yuv;
     fragColor = vec4(clamp(rgb, 0.0, 1.0), 1.0);
+}
+)";
+
+// Premultiplied canvas RGBA → BT.709 limited luma. Matches libswscale
+// SWS_CS_ITU709 with full-range RGB source and limited-range YUV dest.
+constexpr const char *kRgbaToYFragShader = R"(#version 330 core
+in vec2 v_texCoord;
+out vec4 fragColor;
+uniform sampler2D u_src;
+void main() {
+    vec4 c = texture(u_src, v_texCoord);
+    vec3 rgb = (c.a > 0.0001) ? clamp(c.rgb / c.a, 0.0, 1.0) : vec3(0.0);
+    float yFull = dot(rgb, vec3(0.2126, 0.7152, 0.0722));
+    float y = yFull * (219.0 / 255.0) + (16.0 / 255.0);
+    fragColor = vec4(y, 0.0, 0.0, 1.0);
+}
+)";
+
+// Half-res chroma: bilinear sample at the UV texel centre (centre of each 2×2).
+constexpr const char *kRgbaToUvFragShader = R"(#version 330 core
+in vec2 v_texCoord;
+out vec4 fragColor;
+uniform sampler2D u_src;
+void main() {
+    vec4 c = texture(u_src, v_texCoord);
+    vec3 rgb = (c.a > 0.0001) ? clamp(c.rgb / c.a, 0.0, 1.0) : vec3(0.0);
+    float yFull = dot(rgb, vec3(0.2126, 0.7152, 0.0722));
+    float cb = (rgb.b - yFull) / (2.0 * (1.0 - 0.0722));
+    float cr = (rgb.r - yFull) / (2.0 * (1.0 - 0.2126));
+    fragColor = vec4(cb * (224.0 / 255.0) + (128.0 / 255.0),
+                     cr * (224.0 / 255.0) + (128.0 / 255.0), 0.0, 1.0);
 }
 )";
 
@@ -847,6 +917,7 @@ void GlRuntime::releaseCaches()
     exec([this] {
         destroyImageUploadCache();
         destroyVideoUploadState();
+        destroyExportNv12State();
         m_targetPool.clear();
         m_pooledTargets = 0;
         if (auto *gl = functions())
@@ -876,6 +947,7 @@ void GlRuntime::shutdown()
                 }
                 destroyImageUploadCache();
                 destroyVideoUploadState();
+                destroyExportNv12State();
             }
             for (GlTarget &target : m_presentRing)
                 target.fbo.reset();
@@ -967,6 +1039,214 @@ QImage GlRuntime::readTarget(const GlTarget &target)
     if (auto *gl = functions())
         gl->glFinish();
     return target.fbo->toImage(false).convertToFormat(QImage::Format_RGBA8888);
+}
+
+void GlRuntime::destroyExportNv12State()
+{
+    for (int i = 0; i < kExportNv12Slots; ++i)
+        destroyExportNv12Slot(i);
+}
+
+void GlRuntime::destroyExportNv12Slot(int slot)
+{
+    if (slot < 0 || slot >= kExportNv12Slots)
+        return;
+    auto *gl = functions();
+    ExportNv12Slot &s = m_exportNv12[slot];
+    if (gl) {
+        if (s.fence) {
+            gl->glDeleteSync(s.fence);
+            s.fence = nullptr;
+        }
+        if (s.pbo)
+            gl->glDeleteBuffers(1, &s.pbo);
+        if (s.yFbo)
+            gl->glDeleteFramebuffers(1, &s.yFbo);
+        if (s.uvFbo)
+            gl->glDeleteFramebuffers(1, &s.uvFbo);
+        if (s.yTex)
+            gl->glDeleteTextures(1, &s.yTex);
+        if (s.uvTex)
+            gl->glDeleteTextures(1, &s.uvTex);
+    }
+    s = ExportNv12Slot{};
+}
+
+bool GlRuntime::ensureExportNv12Slot(QOpenGLExtraFunctions *gl, int slot, int width, int height)
+{
+    if (!gl || slot < 0 || slot >= kExportNv12Slots || width < 2 || height < 2 || (width % 2)
+        || (height % 2))
+        return false;
+
+    ExportNv12Slot &s = m_exportNv12[slot];
+    const GLsizeiptr pboBytes = GLsizeiptr(width) * height + GLsizeiptr(width) * (height / 2);
+    if (s.yTex && s.uvTex && s.yFbo && s.uvFbo && s.pbo && s.width == width && s.height == height)
+        return true;
+
+    auto deleteTex = [gl](GLuint &t) {
+        if (t) {
+            gl->glDeleteTextures(1, &t);
+            t = 0;
+        }
+    };
+    auto deleteFbo = [gl](GLuint &f) {
+        if (f) {
+            gl->glDeleteFramebuffers(1, &f);
+            f = 0;
+        }
+    };
+    if (s.fence) {
+        gl->glDeleteSync(s.fence);
+        s.fence = nullptr;
+    }
+    if (s.pbo) {
+        gl->glDeleteBuffers(1, &s.pbo);
+        s.pbo = 0;
+    }
+    deleteFbo(s.yFbo);
+    deleteFbo(s.uvFbo);
+    deleteTex(s.yTex);
+    deleteTex(s.uvTex);
+    s.width = 0;
+    s.height = 0;
+
+    auto makePlane = [gl](GLuint *tex, GLuint *fbo, GLenum internal, GLenum format, int w, int h) {
+        gl->glGenTextures(1, tex);
+        gl->glBindTexture(GL_TEXTURE_2D, *tex);
+        gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        gl->glTexImage2D(GL_TEXTURE_2D, 0, internal, w, h, 0, format, GL_UNSIGNED_BYTE, nullptr);
+
+        gl->glGenFramebuffers(1, fbo);
+        gl->glBindFramebuffer(GL_FRAMEBUFFER, *fbo);
+        gl->glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, *tex, 0);
+        const GLenum status = gl->glCheckFramebufferStatus(GL_FRAMEBUFFER);
+        gl->glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        gl->glBindTexture(GL_TEXTURE_2D, 0);
+        return status == GL_FRAMEBUFFER_COMPLETE && *tex && *fbo;
+    };
+
+    if (!makePlane(&s.yTex, &s.yFbo, GL_R8, GL_RED, width, height)
+        || !makePlane(&s.uvTex, &s.uvFbo, GL_RG8, GL_RG, width / 2, height / 2)) {
+        destroyExportNv12Slot(slot);
+        return false;
+    }
+
+    gl->glGenBuffers(1, &s.pbo);
+    gl->glBindBuffer(GL_PIXEL_PACK_BUFFER, s.pbo);
+    gl->glBufferData(GL_PIXEL_PACK_BUFFER, pboBytes, nullptr, GL_STREAM_READ);
+    gl->glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+    if (!s.pbo)
+        return false;
+
+    s.width = width;
+    s.height = height;
+    return true;
+}
+
+bool GlRuntime::packCanvasToNv12Slot(const GlTarget &canvas, int outW, int outH, int slot)
+{
+    auto *gl = functions();
+    if (!gl || !canvas.isValid() || !ensureExportNv12Slot(gl, slot, outW, outH))
+        return false;
+
+    ExportNv12Slot &s = m_exportNv12[slot];
+    if (s.fence) {
+        gl->glClientWaitSync(s.fence, GL_SYNC_FLUSH_COMMANDS_BIT, GLuint64(1'000'000'000));
+        gl->glDeleteSync(s.fence);
+        s.fence = nullptr;
+    }
+
+    auto drawPlane = [&](QOpenGLShaderProgram *program, GLuint fbo, int w, int h) {
+        if (!program)
+            return false;
+        gl->glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+        gl->glViewport(0, 0, w, h);
+        gl->glDisable(GL_BLEND);
+        program->bind();
+        program->setUniformValue("u_src", 0);
+        gl->glActiveTexture(GL_TEXTURE0);
+        gl->glBindTexture(GL_TEXTURE_2D, canvas.texture());
+        gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        gl->glBindVertexArray(vao);
+        gl->glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+        gl->glBindVertexArray(0);
+        program->release();
+        gl->glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        return true;
+    };
+
+    QOpenGLShaderProgram *yProg =
+        builtinProgram(QStringLiteral("__rgba_to_y__"), kQuadVertexShader, kRgbaToYFragShader);
+    QOpenGLShaderProgram *uvProg =
+        builtinProgram(QStringLiteral("__rgba_to_uv__"), kQuadVertexShader, kRgbaToUvFragShader);
+    if (!drawPlane(yProg, s.yFbo, outW, outH) || !drawPlane(uvProg, s.uvFbo, outW / 2, outH / 2))
+        return false;
+
+    gl->glBindBuffer(GL_PIXEL_PACK_BUFFER, s.pbo);
+    gl->glPixelStorei(GL_PACK_ALIGNMENT, 1);
+    gl->glPixelStorei(GL_PACK_ROW_LENGTH, 0);
+
+    gl->glBindFramebuffer(GL_READ_FRAMEBUFFER, s.yFbo);
+    gl->glReadPixels(0, 0, outW, outH, GL_RED, GL_UNSIGNED_BYTE, nullptr);
+
+    gl->glBindFramebuffer(GL_READ_FRAMEBUFFER, s.uvFbo);
+    gl->glReadPixels(0, 0, outW / 2, outH / 2, GL_RG, GL_UNSIGNED_BYTE,
+                     reinterpret_cast<void *>(GLintptr(outW) * outH));
+
+    gl->glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+    gl->glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+    gl->glPixelStorei(GL_PACK_ALIGNMENT, 4);
+
+    gl->glFlush();
+    s.fence = gl->glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+    return s.fence != nullptr;
+}
+
+bool GlRuntime::mapNv12Slot(int slot, uint8_t *y, int yStride, uint8_t *uv, int uvStride, int width,
+                            int height)
+{
+    auto *gl = functions();
+    if (!gl || !y || !uv || yStride < width || uvStride < width || slot < 0
+        || slot >= kExportNv12Slots)
+        return false;
+
+    ExportNv12Slot &s = m_exportNv12[slot];
+    if (!s.pbo || s.width != width || s.height != height)
+        return false;
+
+    if (s.fence) {
+        const GLenum wait =
+            gl->glClientWaitSync(s.fence, GL_SYNC_FLUSH_COMMANDS_BIT, GLuint64(1'000'000'000));
+        gl->glDeleteSync(s.fence);
+        s.fence = nullptr;
+        if (wait == GL_WAIT_FAILED)
+            return false;
+    }
+
+    const GLsizeiptr yBytes = GLsizeiptr(width) * height;
+    gl->glBindBuffer(GL_PIXEL_PACK_BUFFER, s.pbo);
+    auto *mapped = static_cast<const uint8_t *>(
+        gl->glMapBufferRange(GL_PIXEL_PACK_BUFFER, 0, yBytes + GLsizeiptr(width) * (height / 2),
+                             GL_MAP_READ_BIT));
+    if (!mapped) {
+        gl->glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+        return false;
+    }
+
+    const uint8_t *srcY = mapped;
+    const uint8_t *srcUv = mapped + yBytes;
+    for (int row = 0; row < height; ++row)
+        memcpy(y + row * yStride, srcY + row * width, size_t(width));
+    for (int row = 0; row < height / 2; ++row)
+        memcpy(uv + row * uvStride, srcUv + row * width, size_t(width));
+
+    gl->glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
+    gl->glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+    return true;
 }
 
 void GlRuntime::waitPresentFence(int slotIndex)

--- a/src/engine/GlRuntime.h
+++ b/src/engine/GlRuntime.h
@@ -10,6 +10,7 @@
 
 #include "GpuEffectDefinition.h"
 #include "ModelAsset.h"
+#include "PreviewVideoFrame.h"
 #include "core/Time.h"
 
 #include <QByteArray>
@@ -36,6 +37,7 @@
 
 class QOffscreenSurface;
 class QOpenGLContext;
+struct SwsContext;
 
 namespace drift::gl {
 
@@ -222,6 +224,13 @@ private:
     bool initGlObjects();
     void waitPresentFence(int slotIndex);
     void destroyImageUploadCache();
+    void destroyVideoUploadState();
+    bool ensureVideoUploadTextures(QOpenGLExtraFunctions *gl, int width, int height);
+    bool uploadPlanePbo(QOpenGLExtraFunctions *gl, GLuint texture, int texW, int texH, GLenum internalFormat,
+                        GLenum format, const uint8_t *src, int srcPitch, int packedWidth);
+    void unregisterCudaResources();
+    bool importCudaNv12(QOpenGLExtraFunctions *gl, const AVFrame *frame);
+    AVFrame *ensureSoftwareNv12(const AVFrame *src);
 
     QMutex m_initMutex;
     bool m_initTried = false;
@@ -252,7 +261,23 @@ private:
     std::list<CachedUpload> m_imageUploadLru;
     static constexpr size_t kMaxCachedUploads = 48;
 
+    GLuint m_videoY = 0;
+    GLuint m_videoUV = 0;
+    int m_videoTexW = 0;
+    int m_videoTexH = 0;
+    GLuint m_videoPbo[2] = {0, 0};
+    int m_videoPboIndex = 0;
+    AVFrame *m_hwImportStaging = nullptr;
+    ::SwsContext *m_importSws = nullptr;
+    void *m_cudaYResource = nullptr;
+    void *m_cudaUvResource = nullptr;
+    int m_cudaTexW = 0;
+    int m_cudaTexH = 0;
+    bool m_cudaImportFailed = false;
+
     friend GLuint cachedUploadTexture(GlRuntime &rt, QOpenGLExtraFunctions *gl, const QImage &image);
+    friend GlTarget promoteVideoFrameToTarget(GlRuntime &rt, QOpenGLExtraFunctions *gl,
+                                              const PreviewVideoFrame &frame);
 };
 
 GlRuntime &runtime();
@@ -276,10 +301,11 @@ GlTarget promoteImageToTarget(GlRuntime &rt, QOpenGLExtraFunctions *gl, const QI
 GlTarget promoteImageToTargetCached(GlRuntime &rt, QOpenGLExtraFunctions *gl, const QImage &image,
                                     const QSize &fallbackSize);
 
-// NV12 (semi-planar Y + interleaved UV) → RGBA FBO via a convert shader. `nv12`
-// is height*width Y bytes followed by height/2*width UV bytes.
-GlTarget promoteNv12ToTarget(GlRuntime &rt, QOpenGLExtraFunctions *gl, const QByteArray &nv12,
-                             int width, int height);
+// Preview video → RGBA FBO. Hardware CUDA frames copy GPU-to-GPU when the driver
+// allows; everything else uploads NV12 through a pooled PBO. Colour and display
+// rotation are applied in the convert shader.
+GlTarget promoteVideoFrameToTarget(GlRuntime &rt, QOpenGLExtraFunctions *gl,
+                                   const PreviewVideoFrame &frame);
 
 void setPackageUniforms(QOpenGLShaderProgram *program, const QMap<QString, QVariant> &parameters,
                         const QSize &resolution, drift::TimeUs timeUs, double progress);

--- a/src/engine/GlRuntime.h
+++ b/src/engine/GlRuntime.h
@@ -219,6 +219,11 @@ public:
     // Tear down GL objects and stop the GL thread. Called at app exit.
     void shutdown();
 
+    // Last preview import path and VAAPI zero-copy rejection, for the debug report.
+    enum class PreviewUploadPath { None, CudaInterop, VaapiDmaBuf, CpuRoundTrip };
+    static PreviewUploadPath lastPreviewUploadPath();
+    static QString lastVaapiImportReason();
+
 private:
     bool ensureReady();
     bool initGlObjects();
@@ -273,6 +278,7 @@ private:
     GLuint m_videoPbo[2] = {0, 0};
     int m_videoPboIndex = 0;
     AVFrame *m_hwImportStaging = nullptr;
+    AVFrame *m_importNv12 = nullptr;
     ::SwsContext *m_importSws = nullptr;
     void *m_cudaYResource = nullptr;
     void *m_cudaUvResource = nullptr;

--- a/src/engine/GlRuntime.h
+++ b/src/engine/GlRuntime.h
@@ -230,6 +230,11 @@ private:
                         GLenum format, const uint8_t *src, int srcPitch, int packedWidth);
     void unregisterCudaResources();
     bool importCudaNv12(QOpenGLExtraFunctions *gl, const AVFrame *frame);
+    // Texture names for importers whose storage comes from the imported surface rather than
+    // from glTexImage2D. Kept apart from m_videoY/m_videoUV: a later PBO frame reusing those
+    // would glTexSubImage2D straight into the decoder's dma-buf.
+    bool ensureImportTextureNames(QOpenGLExtraFunctions *gl);
+    bool importVaapiNv12(QOpenGLExtraFunctions *gl, const AVFrame *frame);
     AVFrame *ensureSoftwareNv12(const AVFrame *src);
 
     QMutex m_initMutex;
@@ -274,6 +279,9 @@ private:
     int m_cudaTexW = 0;
     int m_cudaTexH = 0;
     bool m_cudaImportFailed = false;
+    GLuint m_importY = 0;
+    GLuint m_importUV = 0;
+    bool m_vaapiImportFailed = false;
 
     friend GLuint cachedUploadTexture(GlRuntime &rt, QOpenGLExtraFunctions *gl, const QImage &image);
     friend GlTarget promoteVideoFrameToTarget(GlRuntime &rt, QOpenGLExtraFunctions *gl,

--- a/src/engine/GlRuntime.h
+++ b/src/engine/GlRuntime.h
@@ -189,6 +189,16 @@ public:
     // tile without this, so two scrubs of the same timestamp would not match.
     QImage readTarget(const GlTarget &target);
 
+    // Export NV12 ring. Convert the composited (premultiplied) canvas to BT.709
+    // limited NV12 and pack into a PIXEL_PACK_BUFFER without waiting. `slot` is
+    // 0 .. kExportNv12Slots-1. The GL context must be current (call from exec()).
+    static constexpr int kExportNv12Slots = 2;
+    bool packCanvasToNv12Slot(const GlTarget &canvas, int outW, int outH, int slot);
+    // Wait for packCanvasToNv12Slot(slot), then copy Y and interleaved UV. Strides
+    // are bytes per row. The GL context must be current.
+    bool mapNv12Slot(int slot, uint8_t *y, int yStride, uint8_t *uv, int uvStride, int width,
+                     int height);
+
     // Presentation ring. The preview's composited frame is handed to the Qt Quick
     // scene graph as a live GL texture rather than read back, so the target it
     // lives in cannot go back to the general pool while the scene graph samples
@@ -230,6 +240,9 @@ private:
     void waitPresentFence(int slotIndex);
     void destroyImageUploadCache();
     void destroyVideoUploadState();
+    void destroyExportNv12State();
+    void destroyExportNv12Slot(int slot);
+    bool ensureExportNv12Slot(QOpenGLExtraFunctions *gl, int slot, int width, int height);
     bool ensureVideoUploadTextures(QOpenGLExtraFunctions *gl, int width, int height);
     bool uploadPlanePbo(QOpenGLExtraFunctions *gl, GLuint texture, int texW, int texH, GLenum internalFormat,
                         GLenum format, const uint8_t *src, int srcPitch, int packedWidth);
@@ -288,6 +301,19 @@ private:
     GLuint m_importY = 0;
     GLuint m_importUV = 0;
     bool m_vaapiImportFailed = false;
+
+    struct ExportNv12Slot
+    {
+        GLuint yTex = 0;
+        GLuint uvTex = 0;
+        GLuint yFbo = 0;
+        GLuint uvFbo = 0;
+        GLuint pbo = 0;
+        GLsync fence = 0;
+        int width = 0;
+        int height = 0;
+    };
+    ExportNv12Slot m_exportNv12[kExportNv12Slots];
 
     friend GLuint cachedUploadTexture(GlRuntime &rt, QOpenGLExtraFunctions *gl, const QImage &image);
     friend GlTarget promoteVideoFrameToTarget(GlRuntime &rt, QOpenGLExtraFunctions *gl,

--- a/src/engine/GpuCompositor.cpp
+++ b/src/engine/GpuCompositor.cpp
@@ -735,4 +735,38 @@ GpuFrameTexture renderToTexture(const GpuScene &scene)
     return out;
 }
 
+static_assert(kExportNv12Slots == GlRuntime::kExportNv12Slots);
+
+bool beginExportNv12(const GpuScene &scene, int outW, int outH, int slot)
+{
+    if (scene.canvasSize.isEmpty() || outW < 2 || outH < 2 || (outW % 2) || (outH % 2)
+        || slot < 0 || slot >= kExportNv12Slots)
+        return false;
+
+    GlRuntime &rt = runtime();
+    bool ok = false;
+    rt.exec([&] {
+        GlTarget canvas = rt.acquireTarget(scene.canvasSize.width(), scene.canvasSize.height());
+        if (!canvas.isValid())
+            return;
+
+        composeOnGlThread(rt, scene, canvas);
+        ok = rt.packCanvasToNv12Slot(canvas, outW, outH, slot);
+        rt.releaseTarget(std::move(canvas));
+    });
+    return ok;
+}
+
+bool finishExportNv12(int slot, uint8_t *y, int yStride, uint8_t *uv, int uvStride, int width,
+                      int height)
+{
+    if (!y || !uv || slot < 0 || slot >= kExportNv12Slots)
+        return false;
+
+    GlRuntime &rt = runtime();
+    bool ok = false;
+    rt.exec([&] { ok = rt.mapNv12Slot(slot, y, yStride, uv, uvStride, width, height); });
+    return ok;
+}
+
 } // namespace GpuCompositor

--- a/src/engine/GpuCompositor.cpp
+++ b/src/engine/GpuCompositor.cpp
@@ -222,8 +222,8 @@ GlTarget buildLayerTarget(GlRuntime &rt, QOpenGLExtraFunctions *gl, const GpuLay
         return {};
 
     GlTarget target;
-    if (!layer.nv12.isEmpty() && layer.nv12Width > 0 && layer.nv12Height > 0) {
-        target = promoteNv12ToTarget(rt, gl, layer.nv12, layer.nv12Width, layer.nv12Height);
+    if (layer.video.isValid()) {
+        target = promoteVideoFrameToTarget(rt, gl, layer.video);
     } else {
         target = promoteImageToTargetCached(rt, gl, layer.source, layer.source.size());
     }
@@ -725,8 +725,8 @@ GpuFrameTexture renderToTexture(const GpuScene &scene)
 
         composeOnGlThread(rt, scene, canvas);
 
-        // Fence + short client wait instead of glFinish: only this present slot's
-        // work must complete before the scene graph samples the texture.
+        // Insert a present fence without waiting: Qt Quick samples on the next
+        // vsync. acquirePresentTarget waits this fence before reusing the slot.
         rt.markPresentReady(canvas);
 
         out.textureId = canvas.texture();

--- a/src/engine/GpuCompositor.h
+++ b/src/engine/GpuCompositor.h
@@ -15,6 +15,8 @@
 #include <QSize>
 #include <QVariant>
 
+#include <cstdint>
+
 namespace drift {
 struct GpuEffectDefinition;
 }
@@ -101,6 +103,13 @@ QImage render(const GpuScene &scene);
 // Composite and leave the result on the GPU. Used by the preview, which hands
 // the texture straight to the scene graph — no readback, no re-upload.
 GpuFrameTexture renderToTexture(const GpuScene &scene);
+
+// Export path: compose, convert to BT.709 limited NV12, pack into an async
+// PBO. `slot` is 0 .. kExportNv12Slots-1. finishExportNv12 waits and copies.
+inline constexpr int kExportNv12Slots = 2;
+bool beginExportNv12(const GpuScene &scene, int outW, int outH, int slot);
+bool finishExportNv12(int slot, uint8_t *y, int yStride, uint8_t *uv, int uvStride, int width,
+                      int height);
 
 bool isAvailable();
 

--- a/src/engine/GpuCompositor.h
+++ b/src/engine/GpuCompositor.h
@@ -5,8 +5,8 @@
 #include "core/Mask.h"
 #include "core/Time.h"
 #include "engine/FaceLandmarker.h"
+#include "engine/PreviewVideoFrame.h"
 
-#include <QByteArray>
 #include <QColor>
 #include <QImage>
 #include <QList>
@@ -20,17 +20,14 @@ struct GpuEffectDefinition;
 }
 
 // A single textured layer: the clip's source pixels plus everything needed to
-// place it on the canvas. Prefer `nv12` when set (half the upload bandwidth vs
-// RGBA); otherwise `source` is CPU RGBA (decoded video, or a QPainter raster of
-// a text/shape clip). The GPU does the scaling, rotation, masking and blending.
+// place it on the canvas. Prefer `video` when set (hardware frames stay on the
+// GPU until the importer); otherwise `source` is CPU RGBA (still image, or a
+// QPainter raster of a text/shape clip). The GPU does the scaling, rotation,
+// masking and blending.
 struct GpuLayer
 {
-    QImage source; // null => fully transparent layer (unless nv12 is set)
-    // Semi-planar NV12: Y plane (w*h) then interleaved UV (w*(h/2)). When
-    // non-empty, the compositor uploads Y/UV and converts on the GPU.
-    QByteArray nv12;
-    int nv12Width = 0;
-    int nv12Height = 0;
+    QImage source; // null => fully transparent layer (unless video is set)
+    PreviewVideoFrame video;
     QList<drift::Effect> effects;
     drift::Mask mask;
     QImage matte; // MaskShape::Matte only: this frame's coverage map, decoded by FrameCompositor
@@ -45,7 +42,7 @@ struct GpuLayer
     QList<drift::FaceAnchors> faceSlots;
     bool valid = false;
 
-    bool hasPixels() const { return !nv12.isEmpty() || !source.isNull(); }
+    bool hasPixels() const { return video.isValid() || !source.isNull(); }
 };
 
 // One drawable in the scene: either a plain layer, or a transition that mixes

--- a/src/engine/PreviewVideoFrame.h
+++ b/src/engine/PreviewVideoFrame.h
@@ -23,9 +23,20 @@ struct PreviewVideoFrame
     int colorspace = AVCOL_SPC_UNSPECIFIED;
     int colorRange = AVCOL_RANGE_UNSPECIFIED;
 
+    // VAAPI and VideoToolbox surfaces live in data[3] and leave data[0] null, so testing
+    // data[0] alone rejected every one of them — and ClipReader reads that rejection as a
+    // decoder failure and disables hardware decode for the rest of the reader's life.
+    //
+    // data[3] is not a pointer either: for VAAPI it is a VASurfaceID cast to one, and id 0 is
+    // a legal surface that iHD hands out first. So what says a hardware frame holds a surface
+    // is the buffer reference, not either data slot.
     bool isValid() const
     {
-        return frame && frame->width > 0 && frame->height > 0 && frame->data[0] != nullptr;
+        if (!frame || frame->width <= 0 || frame->height <= 0)
+            return false;
+        if (isHardware())
+            return frame->buf[0] != nullptr;
+        return frame->data[0] != nullptr;
     }
 
     int codedWidth() const { return frame ? frame->width : 0; }

--- a/src/engine/PreviewVideoFrame.h
+++ b/src/engine/PreviewVideoFrame.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <QMetaType>
+
+#include <memory>
+
+extern "C" {
+#include <libavutil/frame.h>
+#include <libavutil/pixdesc.h>
+#include <libavutil/pixfmt.h>
+}
+
+// A decoded preview frame still owned as an AVFrame: hardware surfaces stay in the
+// decoder pool, software frames stay in their original (or NV12) system-memory
+// buffers. The GL importer samples this on the compositor's GL thread — nothing
+// here is packed for CPU upload.
+struct PreviewVideoFrame
+{
+    std::shared_ptr<AVFrame> frame;
+    // Display-matrix rotation the GL convert shader applies (0/90/180/270). The
+    // stored frame is coded-orientation; displayWidth/Height swap on 90/270.
+    int rotation = 0;
+    int colorspace = AVCOL_SPC_UNSPECIFIED;
+    int colorRange = AVCOL_RANGE_UNSPECIFIED;
+
+    bool isValid() const
+    {
+        return frame && frame->width > 0 && frame->height > 0 && frame->data[0] != nullptr;
+    }
+
+    int codedWidth() const { return frame ? frame->width : 0; }
+    int codedHeight() const { return frame ? frame->height : 0; }
+
+    int displayWidth() const
+    {
+        return (rotation == 90 || rotation == 270) ? codedHeight() : codedWidth();
+    }
+    int displayHeight() const
+    {
+        return (rotation == 90 || rotation == 270) ? codedWidth() : codedHeight();
+    }
+
+    bool isHardware() const
+    {
+        if (!frame)
+            return false;
+        const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(static_cast<AVPixelFormat>(frame->format));
+        return desc && (desc->flags & AV_PIX_FMT_FLAG_HWACCEL);
+    }
+};
+
+inline void avFrameDeleter(AVFrame *f)
+{
+    av_frame_free(&f);
+}
+
+// Clones `src` (refs hardware buffers, copies nothing) and snapshots colour/rotation.
+inline PreviewVideoFrame makePreviewFrame(const AVFrame *src, int rotation)
+{
+    PreviewVideoFrame out;
+    if (!src)
+        return out;
+    AVFrame *clone = av_frame_clone(src);
+    if (!clone)
+        return out;
+    out.frame.reset(clone, avFrameDeleter);
+    out.rotation = rotation;
+    out.colorspace = src->colorspace;
+    out.colorRange = src->color_range;
+    return out;
+}
+
+// Takes ownership of `owned`.
+inline PreviewVideoFrame takePreviewFrame(AVFrame *owned, int rotation)
+{
+    PreviewVideoFrame out;
+    if (!owned)
+        return out;
+    out.frame.reset(owned, avFrameDeleter);
+    out.rotation = rotation;
+    out.colorspace = owned->colorspace;
+    out.colorRange = owned->color_range;
+    return out;
+}
+
+Q_DECLARE_METATYPE(PreviewVideoFrame)

--- a/src/engine/VaapiZeroCopy.h
+++ b/src/engine/VaapiZeroCopy.h
@@ -1,0 +1,15 @@
+#pragma once
+
+// Preview zero-copy VAAPI opt-in. Resolved from DRIFT_VAAPI_ZEROCOPY (wins, unless
+// the value is "0") then QSettings("preview/vaapiZeroCopy"). The settings half is
+// cached after the first call so the GL import path never touches QSettings per frame.
+//
+// applyVaapiZeroCopyXcbEgl() must run after organization/application names are set
+// and before QApplication, so Qt's xcb plugin can pick EGL instead of GLX.
+
+namespace drift {
+
+bool vaapiZeroCopyEnabled();
+void applyVaapiZeroCopyXcbEgl();
+
+} // namespace drift

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include "models/Haptics.h"
 #include "models/LayoutStore.h"
 #include "models/UpdateChecker.h"
+#include "engine/VaapiZeroCopy.h"
 #include "ClipPreviewImageProvider.h"
 #include "DriftImageProvider.h"
 #include "MulticamImageProvider.h"
@@ -226,6 +227,10 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationName("CutWire Drift");
     QCoreApplication::setOrganizationName("CutWire Drift");
     AppController::applyStoredUiScale();
+    // Qt's xcb plugin defaults to GLX, so eglGetCurrentDisplay() is null and
+    // zero-copy sticky-disables. Only force EGL when the user opted in — default
+    // X11 behaviour stays byte-identical. An explicit QT_XCB_GL_INTEGRATION still wins.
+    drift::applyVaapiZeroCopyXcbEgl();
 
     QApplication app(argc, argv);
     if (!QImageReader::supportedImageFormats().contains("svg")) {

--- a/src/models/AppController.cpp
+++ b/src/models/AppController.cpp
@@ -19,6 +19,7 @@
 #include "engine/AudioMixer.h"
 #include "engine/ClipReaderPool.h"
 #include "engine/DebugReport.h"
+#include "engine/HwAccel.h"
 #include "engine/ProjectDependencies.h"
 #include "engine/AudioEffectCatalog.h"
 #include "engine/EffectCatalog.h"
@@ -888,6 +889,7 @@ AppController::AppController(AssetLibrary *assetLibrary, QObject *parent)
     // keyframe, and an animation appears where the user only meant to reposition something.
     m_autoKeyEnabled = settings.value(QStringLiteral("editor/autoKeyEnabled"), false).toBool();
     m_reopenLastProject = settings.value(QStringLiteral("editor/reopenLastProject"), false).toBool();
+    m_vaapiZeroCopy = settings.value(QStringLiteral("preview/vaapiZeroCopy"), false).toBool();
     m_invertTimelineScroll = settings.value(QStringLiteral("timeline/invertScroll"), false).toBool();
     m_uiLanguage = storedUiLanguage();
     m_needsUiLanguagePrompt = needsFirstLaunchLanguagePrompt();
@@ -2889,6 +2891,27 @@ void AppController::setReopenLastProject(bool enabled)
     QSettings settings;
     settings.setValue(QStringLiteral("editor/reopenLastProject"), m_reopenLastProject);
     emit reopenLastProjectChanged();
+}
+
+void AppController::setVaapiZeroCopy(bool enabled)
+{
+    if (m_vaapiZeroCopy == enabled)
+        return;
+    m_vaapiZeroCopy = enabled;
+    QSettings settings;
+    settings.setValue(QStringLiteral("preview/vaapiZeroCopy"), m_vaapiZeroCopy);
+    emit vaapiZeroCopyChanged();
+    setLastMessage(tr("Faster preview takes effect after you restart Drift."),
+                   QStringLiteral("info"));
+}
+
+bool AppController::vaapiZeroCopySupported() const
+{
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+    return drift::hwaccel::availableDecodeBackends().contains(drift::hwaccel::Backend::Vaapi);
+#else
+    return false;
+#endif
 }
 
 void AppController::setInvertTimelineScroll(bool enabled)

--- a/src/models/AppController.h
+++ b/src/models/AppController.h
@@ -97,6 +97,10 @@ class AppController : public QObject
     Q_PROPERTY(bool autoKeyEnabled READ autoKeyEnabled WRITE setAutoKeyEnabled NOTIFY autoKeyEnabledChanged)
     // Opt-in: on launch, restore the last open project (saved .drift or unsaved recovery snapshot).
     Q_PROPERTY(bool reopenLastProject READ reopenLastProject WRITE setReopenLastProject NOTIFY reopenLastProjectChanged)
+    // Opt-in VAAPI dma-buf preview import. Takes effect after restart; hidden when this
+    // machine has no VAAPI decode backend.
+    Q_PROPERTY(bool vaapiZeroCopy READ vaapiZeroCopy WRITE setVaapiZeroCopy NOTIFY vaapiZeroCopyChanged)
+    Q_PROPERTY(bool vaapiZeroCopySupported READ vaapiZeroCopySupported CONSTANT)
     Q_PROPERTY(bool invertTimelineScroll READ invertTimelineScroll WRITE setInvertTimelineScroll
                    NOTIFY invertTimelineScrollChanged)
     // Session-only localhost MCP for agents. Never persisted. Off at every launch.
@@ -308,6 +312,8 @@ public:
     bool mediaGridMode() const { return m_mediaGridMode; }
     bool autoKeyEnabled() const { return m_autoKeyEnabled; }
     bool reopenLastProject() const { return m_reopenLastProject; }
+    bool vaapiZeroCopy() const { return m_vaapiZeroCopy; }
+    bool vaapiZeroCopySupported() const;
     bool invertTimelineScroll() const { return m_invertTimelineScroll; }
     QString uiLanguage() const { return m_uiLanguage; }
     QVariantList uiLanguages() const;
@@ -402,6 +408,7 @@ public:
     void setMediaGridMode(bool enabled);
     void setAutoKeyEnabled(bool enabled);
     void setReopenLastProject(bool enabled);
+    void setVaapiZeroCopy(bool enabled);
     void setInvertTimelineScroll(bool enabled);
     Q_INVOKABLE void setMcpEnabled(bool enabled);
     bool mcpEnabled() const { return mcpRunning(); }
@@ -1119,6 +1126,7 @@ signals:
     void mediaGridModeChanged();
     void autoKeyEnabledChanged();
     void reopenLastProjectChanged();
+    void vaapiZeroCopyChanged();
     void invertTimelineScrollChanged();
     void mcpRunningChanged();
     void mcpErrorChanged();
@@ -1423,6 +1431,7 @@ protected:
     bool m_mediaGridMode = true;
     bool m_autoKeyEnabled = false;
     bool m_reopenLastProject = false;
+    bool m_vaapiZeroCopy = false;
     bool m_invertTimelineScroll = false;
     QString m_uiLanguage;
     bool m_needsUiLanguagePrompt = false;

--- a/src/playback/CompositorService.cpp
+++ b/src/playback/CompositorService.cpp
@@ -140,7 +140,7 @@ FrameCompositor::RenderOptions CompositorService::effectiveOptions(
 {
     if (!m_adaptiveQuality)
         return options;
-    options.previewScale = qBound(0.1, options.previewScale * m_adaptiveScale, 1.0);
+    options.previewScale = qBound(kMinPreviewScale, options.previewScale * m_adaptiveScale, 1.0);
     return options;
 }
 
@@ -191,7 +191,7 @@ void CompositorService::dispatch(drift::TimeUs timeUs, const FrameCompositor::Re
 
 void CompositorService::requestComposite(drift::TimeUs timeUs, FrameCompositor::RenderOptions options)
 {
-    options.previewScale = qBound(0.1, options.previewScale, 1.0);
+    options.previewScale = qBound(kMinPreviewScale, options.previewScale, 1.0);
 
     // The pending scale is published as whole percent, and the catch-up dispatch in
     // onWorkerFrameReady reads it back as percent/100. Dispatching the unrounded value here
@@ -203,7 +203,7 @@ void CompositorService::requestComposite(drift::TimeUs timeUs, FrameCompositor::
     // scale; the adaptive multiplier is a discrete ratchet applied at dispatch, so both paths
     // still derive the same size from it until the ratchet deliberately moves.
     const int previewScalePercent =
-        qBound(10, static_cast<int>(std::lround(options.previewScale * 100.0)), 100);
+        qBound(kMinPreviewScalePercent, static_cast<int>(std::lround(options.previewScale * 100.0)), 100);
     options.previewScale = previewScalePercent / 100.0;
 
     m_pendingTimeUs.store(timeUs, std::memory_order_release);

--- a/src/playback/CompositorService.h
+++ b/src/playback/CompositorService.h
@@ -55,10 +55,9 @@ public:
     void setDropLateFrames(bool drop);
 
     // Automatic preview quality. Off — the default — every frame renders at exactly
-    // the previewScale the caller asked for: choosing Full means Full, whatever the
-    // machine is doing. On, the service walks that scale down while composites
-    // overrun their frame budget and back up once they stop, which only ever
-    // happens during fast-mode playback.
+    // the previewScale the caller asked for (Full/Half/Quarter stay put). On, the
+    // service walks that scale down while composites overrun their frame budget
+    // and back up once they stop, which only ever happens during fast-mode playback.
     void setAdaptiveQuality(bool enabled);
 
     // Realtime playback running. Adaptation measures playback frames only — paused

--- a/src/playback/PlaybackEngine.cpp
+++ b/src/playback/PlaybackEngine.cpp
@@ -80,9 +80,10 @@ constexpr drift::TimeUs kReadAheadUs = 2 * drift::kUsPerSecond;
 // (kMinCurveSpeed..kMaxCurveSpeed), and nothing outside this list is accepted.
 constexpr std::array<double, 6> kPlaybackRates{0.25, 0.5, 1.0, 1.5, 2.0, 4.0};
 
-// "full", "half" and "quarter" are exact: the preview renders at the fraction
-// asked for and nothing changes it underneath. "auto" starts from what "full"
-// would give and lets the compositor trade resolution for cadence.
+// "full", "half" and "quarter" are fractions of the preview panel (device pixels),
+// never of the project: Full matches the panel, Half/Quarter are 1/2 and 1/4 of
+// that, all capped at project resolution. "auto" is Full plus a compositor ratchet
+// that trades remaining resolution for cadence when playback cannot keep up.
 bool isKnownPreviewQuality(const QString &quality)
 {
     return quality == QStringLiteral("full") || quality == QStringLiteral("half")
@@ -431,10 +432,9 @@ void PlaybackEngine::setPreviewRenderSize(int width, int height)
 
     m_previewRenderWidth = width;
     m_previewRenderHeight = height;
-    // Only Auto derives its scale from this size; re-compositing at a fixed
-    // fraction would render the identical frame again on every pixel of a drag.
-    if (!isAutoQuality())
-        return;
+    // Every quality mode sizes the canvas from the panel, so a resize has to
+    // rebuild the frame. Decode size is quantized, which keeps the reader cache
+    // from dropping on every pixel of a drag.
     if (m_playing)
         onCompositeTick();
     else
@@ -635,13 +635,25 @@ void PlaybackEngine::onFrameReady(const GpuFrameTexture &frame)
 FrameCompositor::RenderOptions PlaybackEngine::playbackRenderOptions() const
 {
     FrameCompositor::RenderOptions options;
-    if (m_previewQuality == QStringLiteral("quarter")) {
-        options.previewScale = 0.25;
-    } else if (m_previewQuality == QStringLiteral("half")) {
-        options.previewScale = 0.5;
-    } else {
-        options.previewScale = 1.0;
+    double qualityFraction = 1.0;
+    if (m_previewQuality == QStringLiteral("quarter"))
+        qualityFraction = 0.25;
+    else if (m_previewQuality == QStringLiteral("half"))
+        qualityFraction = 0.5;
+
+    // Fit the project into the panel (device pixels), never larger than 1:1 with
+    // the export frame. Until the panel has reported a size, stay at project
+    // resolution so the first composite is not a stub.
+    double fit = 1.0;
+    if (m_project && m_previewRenderWidth > 0 && m_previewRenderHeight > 0) {
+        const double widthScale =
+            static_cast<double>(m_previewRenderWidth) / qMax(1, m_project->width());
+        const double heightScale =
+            static_cast<double>(m_previewRenderHeight) / qMax(1, m_project->height());
+        fit = qMin(1.0, qMin(widthScale, heightScale));
     }
+    options.previewScale = qBound(kMinPreviewScale, fit * qualityFraction, 1.0);
+
     // During fast playback, cap temporal history so time_echo cannot multiply
     // decode work unboundedly. Paused, scrubbed and quality-mode frames keep the
     // full history: those are exactly the cases where fidelity is the point.
@@ -651,20 +663,6 @@ FrameCompositor::RenderOptions PlaybackEngine::playbackRenderOptions() const
     // actually running: paused and quality-mode frames have no deadline to miss,
     // and read-ahead during editing is thrown away by the next edit.
     options.readAheadUs = m_playing && !isQualityMode() ? kReadAheadUs : 0;
-
-    // Auto is the only mode that looks at how big the preview is on screen: it
-    // renders no more pixels than are actually displayed, and the compositor may
-    // take it further down while playback cannot keep up. Full, Half and Quarter
-    // are fractions of the project resolution and nothing else — Full composites
-    // the same frame the export would, whatever size the panel happens to be.
-    // That matters beyond the video: renderScale also sizes text rasterisation,
-    // shape strokes and every effect's pixel radii, so a canvas fitted to a small
-    // panel renders coarse titles and graphics, not just a smaller picture.
-    if (isAutoQuality() && m_project && m_previewRenderWidth > 0 && m_previewRenderHeight > 0) {
-        const double widthScale = static_cast<double>(m_previewRenderWidth) / qMax(1, m_project->width());
-        const double heightScale = static_cast<double>(m_previewRenderHeight) / qMax(1, m_project->height());
-        options.previewScale = qBound(0.1, qMin(widthScale, heightScale), 1.0);
-    }
 
     // Hide the text clip being edited in place so the QML inline editor stands in
     // for it. Never applies while playing (no inline edit during playback).

--- a/src/qml/PreviewPanel.qml
+++ b/src/qml/PreviewPanel.qml
@@ -166,8 +166,8 @@ PanelFrame {
                         id: preview
                         anchors.fill: parent
 
-                        // Auto quality sizes its canvas from this, so it has to be
-                        // real screen pixels: item geometry is in logical units, and
+                        // Canvas size is derived from this, so it has to be real
+                        // screen pixels: item geometry is in logical units, and
                         // on a scaled display a canvas built from those is upscaled
                         // by the ratio before it ever reaches the screen.
                         readonly property real pixelRatio: Screen.devicePixelRatio

--- a/src/qml/components/assets/SettingsTab.qml
+++ b/src/qml/components/assets/SettingsTab.qml
@@ -158,6 +158,14 @@ Item {
                         }
                     }
                 }
+
+                ThemedSwitch {
+                    visible: EditorState.vaapiZeroCopySupported
+                    checked: EditorState.vaapiZeroCopy
+                    text: qsTr("Faster preview (experimental)")
+                    tooltip: qsTr("Can make playback smoother by keeping video on the graphics card. Turn it off if the picture looks wrong. Takes effect after restart.")
+                    onToggled: EditorState.vaapiZeroCopy = checked
+                }
             }
 
             SettingsSection {

--- a/tests/tst_engine.cpp
+++ b/tests/tst_engine.cpp
@@ -76,6 +76,7 @@ extern "C" {
 #include <libavformat/avformat.h>
 #include <libavutil/hwcontext.h>
 #include <libavutil/pixfmt.h>
+#include <libswscale/swscale.h>
 }
 
 class EngineTest : public QObject
@@ -209,6 +210,7 @@ private slots:
     void exporterProducesPlayableFileWithBackground();
     void exporterProducesAudioOnlyMp3();
     void exporterTagsSdrBt709ColorMetadata();
+    void gpuNv12MatchesSwsBt709();
     void exporterDefaultCrfIsNearLosslessForH264();
     void exporterHardwareCodecsListedForThisOs();
     void exporterHardwarePreferredContainerIsMp4();
@@ -5516,6 +5518,109 @@ void EngineTest::exporterTagsSdrBt709ColorMetadata()
     QCOMPARE(vstream->codecpar->color_space, AVCOL_SPC_BT709);
 
     avformat_close_input(&fmt);
+}
+
+void EngineTest::gpuNv12MatchesSwsBt709()
+{
+    if (!GpuCompositor::isAvailable())
+        QSKIP("OpenGL unavailable");
+
+    const auto convertSws = [](const QImage &img, std::vector<uint8_t> *y, std::vector<uint8_t> *uv) {
+        const int w = img.width();
+        const int h = img.height();
+        y->assign(size_t(w) * h, 0);
+        uv->assign(size_t(w) * (h / 2), 0);
+        SwsContext *sws = sws_getContext(w, h, AV_PIX_FMT_RGBA, w, h, AV_PIX_FMT_NV12, SWS_BICUBIC,
+                                         nullptr, nullptr, nullptr);
+        if (!sws)
+            return false;
+        const int *coeff = sws_getCoefficients(SWS_CS_ITU709);
+        if (sws_setColorspaceDetails(sws, coeff, 1, coeff, 0, 0, 1 << 16, 1 << 16) < 0) {
+            sws_freeContext(sws);
+            return false;
+        }
+        uint8_t *dstData[4] = {y->data(), uv->data(), nullptr, nullptr};
+        int dstStride[4] = {w, w, 0, 0};
+        const uint8_t *srcData[4] = {img.constBits(), nullptr, nullptr, nullptr};
+        const int srcStride[4] = {int(img.bytesPerLine()), 0, 0, 0};
+        sws_scale(sws, srcData, srcStride, 0, h, dstData, dstStride);
+        sws_freeContext(sws);
+        return true;
+    };
+
+    const auto convertGpu = [](const QImage &img, std::vector<uint8_t> *y, std::vector<uint8_t> *uv) {
+        const int w = img.width();
+        const int h = img.height();
+        GpuScene scene;
+        scene.canvasSize = QSize(w, h);
+        scene.backgroundColor = Qt::black;
+        GpuItem item;
+        item.layer.valid = true;
+        item.layer.source = img;
+        item.layer.rect = QRectF(0, 0, w, h);
+        item.layer.opacity = 1.0;
+        scene.items.append(item);
+        y->assign(size_t(w) * h, 0);
+        uv->assign(size_t(w) * (h / 2), 0);
+        if (!GpuCompositor::beginExportNv12(scene, w, h, 0))
+            return false;
+        return GpuCompositor::finishExportNv12(0, y->data(), w, uv->data(), w, w, h);
+    };
+
+    const auto maxAbs = [](const std::vector<uint8_t> &a, const std::vector<uint8_t> &b) {
+        int m = 0;
+        for (size_t i = 0; i < a.size(); ++i)
+            m = qMax(m, qAbs(int(a[i]) - int(b[i])));
+        return m;
+    };
+
+    const QRgb solids[] = {qRgba(0, 0, 0, 255),       qRgba(255, 255, 255, 255),
+                           qRgba(255, 0, 0, 255),     qRgba(0, 255, 0, 255),
+                           qRgba(0, 0, 255, 255),     qRgba(128, 128, 128, 255)};
+    for (QRgb color : solids) {
+        QImage img(32, 32, QImage::Format_RGBA8888);
+        img.fill(color);
+        std::vector<uint8_t> gy, gu, sy, su;
+        QVERIFY(convertGpu(img, &gy, &gu));
+        QVERIFY(convertSws(img, &sy, &su));
+        QVERIFY2(maxAbs(gy, sy) <= 1, "solid Y");
+        QVERIFY2(maxAbs(gu, su) <= 2, "solid UV");
+    }
+
+    constexpr int kW = 64;
+    constexpr int kH = 64;
+    QImage img(kW, kH, QImage::Format_RGBA8888);
+    const QRgb tiles[] = {
+        qRgba(0, 0, 0, 255),     qRgba(255, 255, 255, 255), qRgba(255, 0, 0, 255),
+        qRgba(0, 255, 0, 255),   qRgba(0, 0, 255, 255),     qRgba(128, 128, 128, 255),
+        qRgba(255, 255, 0, 255), qRgba(0, 255, 255, 255),
+    };
+    for (int y = 0; y < kH; ++y) {
+        for (int x = 0; x < kW; ++x) {
+            const int tile = (y / 16) * 4 + (x / 16);
+            img.setPixel(x, y, tiles[tile % 8]);
+        }
+    }
+
+    std::vector<uint8_t> gpuY, gpuUv, swsY, swsUv;
+    QVERIFY(convertGpu(img, &gpuY, &gpuUv));
+    QVERIFY(convertSws(img, &swsY, &swsUv));
+    QVERIFY2(maxAbs(gpuY, swsY) <= 1,
+             qPrintable(QStringLiteral("tiled Y delta %1").arg(maxAbs(gpuY, swsY))));
+
+    int maxUv = 0;
+    for (int cy = 2; cy < kH / 2 - 2; ++cy) {
+        for (int cx = 2; cx < kW / 2 - 2; ++cx) {
+            const int px = cx * 2;
+            const int py = cy * 2;
+            if ((px % 16) < 2 || (px % 16) > 13 || (py % 16) < 2 || (py % 16) > 13)
+                continue;
+            const int i = cy * kW + cx * 2;
+            maxUv = qMax(maxUv, qAbs(int(gpuUv[size_t(i)]) - int(swsUv[size_t(i)])));
+            maxUv = qMax(maxUv, qAbs(int(gpuUv[size_t(i) + 1]) - int(swsUv[size_t(i) + 1])));
+        }
+    }
+    QVERIFY2(maxUv <= 2, qPrintable(QStringLiteral("tiled interior UV delta %1").arg(maxUv)));
 }
 
 void EngineTest::exporterDefaultCrfIsNearLosslessForH264()

--- a/tests/tst_engine.cpp
+++ b/tests/tst_engine.cpp
@@ -123,6 +123,9 @@ private slots:
     void clipReaderAppliesDisplayRotation_data();
     void clipReaderAppliesDisplayRotation();
     void hwAccelBackendIdsRoundTrip();
+    void previewFrameAcceptsHardwareSurfaces();
+    void vaapiPreviewMatchesSoftwareDecode();
+    void hardwareDecodeSurvivesScrubbing();
     void clipReaderPicksHwAv1Decoder();
     void clipReaderStaysOnSoftwareWhenHardwareDisabled();
     void clipReaderAutoKeepsCheapClipsOnSoftware();
@@ -256,6 +259,7 @@ private slots:
 private:
     static QString makeColorSegmentsVideo(QTemporaryDir &dir);
     static QString makeRotatedHalvesVideo(QTemporaryDir &dir, int displayDegrees);
+    static QString makeHdHalvesVideo(QTemporaryDir &dir);
     static QString makeAv1ColorVideo(QTemporaryDir &dir);
     static QString makeToneAudio(QTemporaryDir &dir);
     static QString makeSweepAudio(QTemporaryDir &dir);
@@ -2043,6 +2047,35 @@ void EngineTest::clipReaderSequentialAndSeek()
 // 64x32 landscape, red left half / blue right half, tagged with a display matrix.
 // `displayDegrees` is the clockwise turn a player should apply, i.e. what
 // displayRotationOf() reports; the matrix stores its negation.
+// 1080p, so the VAAPI surface is padded to 1088 and a wrongly-sized dma-buf import shows up as
+// a garbage strip along the bottom edge rather than as a clean failure.
+QString EngineTest::makeHdHalvesVideo(QTemporaryDir &dir)
+{
+    const QString ffmpeg = QStandardPaths::findExecutable(QStringLiteral("ffmpeg"));
+    if (ffmpeg.isEmpty())
+        return {};
+
+    const QString out = dir.filePath(QStringLiteral("hd-halves.mp4"));
+    QStringList args{
+        QStringLiteral("-y"),
+        QStringLiteral("-f"), QStringLiteral("lavfi"), QStringLiteral("-i"),
+        QStringLiteral("color=c=red:s=960x1080:r=25:d=1"),
+        QStringLiteral("-f"), QStringLiteral("lavfi"), QStringLiteral("-i"),
+        QStringLiteral("color=c=blue:s=960x1080:r=25:d=1"),
+        QStringLiteral("-filter_complex"), QStringLiteral("[0][1]hstack=inputs=2[v]"),
+        QStringLiteral("-map"), QStringLiteral("[v]"),
+        QStringLiteral("-c:v"), QStringLiteral("libx264"),
+        QStringLiteral("-pix_fmt"), QStringLiteral("yuv420p"),
+        out,
+    };
+
+    QProcess proc;
+    proc.start(ffmpeg, args);
+    if (!proc.waitForFinished(60000) || proc.exitCode() != 0)
+        return {};
+    return QFileInfo::exists(out) ? out : QString{};
+}
+
 QString EngineTest::makeRotatedHalvesVideo(QTemporaryDir &dir, int displayDegrees)
 {
     const QString ffmpeg = QStandardPaths::findExecutable(QStringLiteral("ffmpeg"));
@@ -2188,6 +2221,203 @@ QString EngineTest::makeAv1ColorVideo(QTemporaryDir &dir)
 
 // The picker and the saved setting both key off these ids, so a backend whose id does
 // not round-trip would silently become Auto on the next launch.
+// A VAAPI or VideoToolbox surface lives in data[3], not data[0], and for VAAPI data[3] is a
+// VASurfaceID cast to a pointer — surface id 0 is legal and iHD hands it out first. Testing
+// either data slot therefore rejects real frames, and ClipReader reads that rejection as a
+// decoder failure and drops the whole reader to software for good.
+void EngineTest::previewFrameAcceptsHardwareSurfaces()
+{
+    auto hardwareFrame = [](AVPixelFormat format, uintptr_t surface) {
+        AVFrame *raw = av_frame_alloc();
+        raw->format = format;
+        raw->width = 1920;
+        raw->height = 1080;
+        raw->data[3] = reinterpret_cast<uint8_t *>(surface);
+        // What actually keeps the surface alive; the pool buffer's payload is the id itself.
+        raw->buf[0] = av_buffer_alloc(1);
+        PreviewVideoFrame out;
+        out.frame.reset(raw, [](AVFrame *f) {
+            f->data[3] = nullptr;
+            av_frame_free(&f);
+        });
+        return out;
+    };
+
+    for (const AVPixelFormat format : {AV_PIX_FMT_VAAPI, AV_PIX_FMT_VIDEOTOOLBOX}) {
+        // Surface id 0 is the regression that matters: it makes data[3] a null pointer.
+        for (const uintptr_t surface : {uintptr_t(0), uintptr_t(7)}) {
+            const PreviewVideoFrame frame = hardwareFrame(format, surface);
+            QVERIFY(frame.isValid());
+            QVERIFY(frame.isHardware());
+            QCOMPARE(frame.displayWidth(), 1920);
+            QCOMPARE(frame.displayHeight(), 1080);
+        }
+    }
+
+    // A hardware frame with no surface reference at all is still invalid.
+    PreviewVideoFrame empty;
+    QVERIFY(!empty.isValid());
+    AVFrame *bare = av_frame_alloc();
+    bare->format = AV_PIX_FMT_VAAPI;
+    bare->width = 1920;
+    bare->height = 1080;
+    empty.frame.reset(bare, avFrameDeleter);
+    QVERIFY(!empty.isValid());
+
+    // And a software frame still needs its pixels.
+    PreviewVideoFrame blank;
+    AVFrame *sw = av_frame_alloc();
+    sw->format = AV_PIX_FMT_NV12;
+    sw->width = 64;
+    sw->height = 64;
+    blank.frame.reset(sw, avFrameDeleter);
+    QVERIFY(!blank.isValid());
+}
+
+// Preview hardware decode had never actually run before the isValid() fix, so this covers the
+// path that fix switched on — not the dma-buf importer, which is off by default. Two overlapping
+// clips of one file share a reader and halve the hardware preview cache, which is the case most
+// likely to exhaust the decoder's surface pool.
+void EngineTest::hardwareDecodeSurvivesScrubbing()
+{
+    if (!drift::hwaccel::availableDecodeBackends().contains(drift::hwaccel::Backend::Vaapi))
+        QSKIP("no vaapi");
+    if (!GpuCompositor::isAvailable())
+        QSKIP("no gl");
+    QTemporaryDir dir;
+    const QString path = makeHdHalvesVideo(dir);
+    if (path.isEmpty())
+        QSKIP("no ffmpeg");
+
+    ClipReader::setHardwareDecodeMode(ClipReader::HardwareDecodeMode::Hardware,
+                                      drift::hwaccel::Backend::Vaapi);
+    drift::Project project;
+    project.setResolution(1920, 1080);
+    project.setFps(25);
+    project.tracks().clear();
+    // Two overlapping clips of one file: shares a reader, halves the hw preview cache.
+    project.tracks().append(drift::Track{.type = drift::TrackType::Video});
+    project.tracks().append(drift::Track{.type = drift::TrackType::Video});
+    for (int t = 0; t < 2; ++t) {
+        drift::Clip c;
+        c.id = QStringLiteral("c%1").arg(t);
+        c.type = drift::ClipType::Video;
+        c.path = path;
+        c.timelineStart = 0;
+        c.timelineDuration = drift::secondsToUs(1.0);
+        if (t == 1)
+            c.opacity.setKeyframe(0, 0.5);
+        project.tracks()[t].clips.append(c);
+    }
+    FrameCompositor compositor;
+    compositor.setProject(&project);
+
+    const quint64 before = ClipReader::hardwareFallbackCount();
+    // Forward playback, reverse playback, then out-of-order scrubs.
+    for (int pass = 0; pass < 4; ++pass) {
+        for (int i = 0; i < 25; ++i) {
+            const drift::TimeUs at = (pass % 3 == 0)   ? i * 40'000
+                                     : (pass % 3 == 1) ? (24 - i) * 40'000
+                                                       : ((i * 7) % 25) * 40'000;
+            const QImage img = compositor.compositeAt(at);
+            QVERIFY2(!img.isNull(), qPrintable(QStringLiteral("null at pass %1 t=%2").arg(pass).arg(at)));
+            QCOMPARE(img.size(), QSize(1920, 1080));
+            QVERIFY(qRed(img.pixel(200, 540)) > qBlue(img.pixel(200, 540)));
+            QVERIFY(qBlue(img.pixel(1700, 540)) > qRed(img.pixel(1700, 540)));
+        }
+    }
+    // A demotion to software would still render correctly, so the picture checks alone cannot
+    // tell whether hardware decode actually held up across the scrubbing.
+    QCOMPARE(ClipReader::hardwareFallbackCount(), before);
+    ClipReader::setHardwareDecodeMode(ClipReader::HardwareDecodeMode::Auto,
+                                      drift::hwaccel::Backend::None);
+}
+
+void EngineTest::vaapiPreviewMatchesSoftwareDecode()
+{
+    if (!drift::hwaccel::availableDecodeBackends().contains(drift::hwaccel::Backend::Vaapi))
+        QSKIP("No VAAPI device");
+    if (!GpuCompositor::isAvailable())
+        QSKIP("OpenGL offscreen context unavailable");
+
+    // The importer is off by default; opting in here is what a user would do, and it keeps this
+    // test meaningful rather than silently measuring the PBO path against itself.
+    qputenv("DRIFT_VAAPI_ZEROCOPY", "1");
+
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString path = makeHdHalvesVideo(dir);
+    if (path.isEmpty())
+        QSKIP("ffmpeg not available to generate a 1080p test clip");
+
+    const QSize size(1920, 1080);
+    auto composite = [&](ClipReader::HardwareDecodeMode mode, drift::hwaccel::Backend backend,
+                         drift::TimeUs at) {
+        ClipReader::setHardwareDecodeMode(mode, backend);
+
+        drift::Project project;
+        project.setResolution(size.width(), size.height());
+        project.setFps(25);
+        project.tracks().clear();
+        project.tracks().append(drift::Track{.type = drift::TrackType::Video});
+
+        drift::Clip clip;
+        clip.id = QStringLiteral("hd");
+        clip.type = drift::ClipType::Video;
+        clip.path = path;
+        clip.timelineStart = 0;
+        clip.timelineDuration = drift::secondsToUs(1.0);
+        project.tracks()[0].clips.append(clip);
+
+        FrameCompositor compositor;
+        compositor.setProject(&project);
+        return compositor.compositeAt(at);
+    };
+
+    // t=0 first: that frame lands on the first surface the driver allocates, whose VASurfaceID
+    // is 0 — the case that makes AVFrame::data[3] a null pointer.
+    for (const drift::TimeUs at : {drift::TimeUs(0), drift::TimeUs(400'000)}) {
+        const quint64 fallbacksBefore = ClipReader::hardwareFallbackCount();
+        const QImage hardware =
+            composite(ClipReader::HardwareDecodeMode::Hardware, drift::hwaccel::Backend::Vaapi, at);
+        // Without this the test would still pass on the PBO fallback, which is pixel-identical:
+        // a reader that demoted itself to software proves nothing about the import.
+        QCOMPARE(ClipReader::hardwareFallbackCount(), fallbacksBefore);
+        const QImage software =
+            composite(ClipReader::HardwareDecodeMode::Software, drift::hwaccel::Backend::None, at);
+
+        QVERIFY(!hardware.isNull());
+        QVERIFY(!software.isNull());
+        QCOMPARE(hardware.size(), size);
+        QCOMPARE(software.size(), size);
+
+        // Sample the bottom rows too: a dma-buf import sized from the padded 1088-tall surface
+        // instead of the 1080-tall picture leaks decoder padding into exactly that band.
+        const QList<QPoint> probes{{200, 40},   {1700, 40},   {200, 540}, {1700, 540},
+                                   {200, 1074}, {1700, 1074}, {960, 1078}};
+        for (const QPoint &probe : probes) {
+            const QRgb hw = hardware.pixel(probe);
+            const QRgb sw = software.pixel(probe);
+            QVERIFY2(qAbs(qRed(hw) - qRed(sw)) <= 6 && qAbs(qGreen(hw) - qGreen(sw)) <= 6
+                         && qAbs(qBlue(hw) - qBlue(sw)) <= 6,
+                     qPrintable(QStringLiteral("t=%1 at %2,%3: hw #%4 sw #%5")
+                                    .arg(at)
+                                    .arg(probe.x())
+                                    .arg(probe.y())
+                                    .arg(hw, 8, 16, QLatin1Char('0'))
+                                    .arg(sw, 8, 16, QLatin1Char('0'))));
+        }
+
+        // And that the picture is the one we encoded, not two matching shades of wrong.
+        QVERIFY(qRed(hardware.pixel(200, 540)) > qBlue(hardware.pixel(200, 540)));
+        QVERIFY(qBlue(hardware.pixel(1700, 540)) > qRed(hardware.pixel(1700, 540)));
+    }
+
+    ClipReader::setHardwareDecodeMode(ClipReader::HardwareDecodeMode::Auto,
+                                      drift::hwaccel::Backend::None);
+    qunsetenv("DRIFT_VAAPI_ZEROCOPY");
+}
+
 void EngineTest::hwAccelBackendIdsRoundTrip()
 {
     const QList<drift::hwaccel::Backend> order = drift::hwaccel::decodeBackendOrder();

--- a/tests/tst_engine.cpp
+++ b/tests/tst_engine.cpp
@@ -55,6 +55,7 @@
 #include "engine/EmojiCatalog.h"
 #include "engine/FontCatalog.h"
 #include "engine/FrameCompositor.h"
+#include "engine/GpuCompositor.h"
 #include "engine/TextRaster.h"
 #include "engine/GpuEffectExecutor.h"
 #include "engine/GpuPackageParse.h"
@@ -125,6 +126,7 @@ private slots:
     void hwAccelBackendIdsRoundTrip();
     void previewFrameAcceptsHardwareSurfaces();
     void vaapiPreviewMatchesSoftwareDecode();
+    void p010PreviewConvertsThroughSoftwarePath();
     void hardwareDecodeSurvivesScrubbing();
     void clipReaderPicksHwAv1Decoder();
     void clipReaderStaysOnSoftwareWhenHardwareDisabled();
@@ -2418,6 +2420,60 @@ void EngineTest::vaapiPreviewMatchesSoftwareDecode()
     qunsetenv("DRIFT_VAAPI_ZEROCOPY");
 }
 
+// Locks in the two-frame invariant in ensureSoftwareNv12: a software P010 frame
+// (the shape of a hwframe transfer that kept a 10-bit format) must sws into a
+// separate destination, not into itself after realloc. Does not reproduce the
+// original aliasing, which needs a hardware frame whose transfer yields P010.
+void EngineTest::p010PreviewConvertsThroughSoftwarePath()
+{
+    if (!GpuCompositor::isAvailable())
+        QSKIP("OpenGL offscreen context unavailable");
+
+    AVFrame *raw = av_frame_alloc();
+    QVERIFY(raw);
+    raw->format = AV_PIX_FMT_P010LE;
+    raw->width = 64;
+    raw->height = 64;
+    raw->colorspace = AVCOL_SPC_BT709;
+    raw->color_range = AVCOL_RANGE_JPEG;
+    QVERIFY(av_frame_get_buffer(raw, 0) >= 0);
+
+    const uint16_t y10 = uint16_t(1023u << 6);
+    const uint16_t uv10 = uint16_t(512u << 6);
+    for (int y = 0; y < raw->height; ++y) {
+        auto *row = reinterpret_cast<uint16_t *>(raw->data[0] + y * raw->linesize[0]);
+        for (int x = 0; x < raw->width; ++x)
+            row[x] = y10;
+    }
+    for (int y = 0; y < raw->height / 2; ++y) {
+        auto *row = reinterpret_cast<uint16_t *>(raw->data[1] + y * raw->linesize[1]);
+        for (int x = 0; x < raw->width; ++x)
+            row[x] = uv10;
+    }
+
+    GpuLayer layer;
+    layer.video = takePreviewFrame(raw, 0);
+    layer.rect = QRectF(0, 0, 64, 64);
+    layer.valid = true;
+
+    GpuItem item;
+    item.layer = layer;
+
+    GpuScene scene;
+    scene.canvasSize = QSize(64, 64);
+    scene.backgroundColor = Qt::black;
+    scene.items.append(item);
+
+    const QImage out = GpuCompositor::render(scene);
+    QVERIFY(!out.isNull());
+    QCOMPARE(out.size(), QSize(64, 64));
+
+    const QRgb centre = out.pixel(32, 32);
+    QVERIFY2(qRed(centre) > 230 && qGreen(centre) > 230 && qBlue(centre) > 230,
+             qPrintable(QStringLiteral("expected near-white, got #%1")
+                            .arg(centre, 8, 16, QLatin1Char('0'))));
+}
+
 void EngineTest::hwAccelBackendIdsRoundTrip()
 {
     const QList<drift::hwaccel::Backend> order = drift::hwaccel::decodeBackendOrder();
@@ -2555,6 +2611,15 @@ void EngineTest::debugReportListsCommonCodecs()
     QVERIFY(!info.value(QStringLiteral("system")).toList().isEmpty());
     QVERIFY(!info.value(QStringLiteral("package")).toString().isEmpty());
     QVERIFY(info.contains(QStringLiteral("hardwareDecodeAvailable")));
+
+    QStringList systemLabels;
+    for (const QVariant &entry : info.value(QStringLiteral("system")).toList())
+        systemLabels.append(entry.toMap().value(QStringLiteral("label")).toString());
+    QVERIFY(systemLabels.contains(QStringLiteral("Preview decode")));
+    QVERIFY(systemLabels.contains(QStringLiteral("Active decode")));
+    QVERIFY(systemLabels.contains(QStringLiteral("Window platform")));
+    QVERIFY(systemLabels.contains(QStringLiteral("Preview upload")));
+    QVERIFY(systemLabels.contains(QStringLiteral("Zero-copy")));
 
     const QVariantList encoders = info.value(QStringLiteral("encoders")).toList();
     QCOMPARE(encoders.size(), 5);

--- a/tests/tst_engine.cpp
+++ b/tests/tst_engine.cpp
@@ -2126,15 +2126,39 @@ void EngineTest::clipReaderAppliesDisplayRotation()
     QVERIFY(qRed(red) > qBlue(red));
     QVERIFY(qBlue(blue) > qRed(blue));
 
-    // The preview path converts to NV12 separately and needs the same treatment.
-    Nv12Frame nv12;
-    QVERIFY(reader.readVideoFrameAtNv12(500'000, nv12, expectedSize.width(), expectedSize.height()));
-    QCOMPARE(QSize(nv12.width, nv12.height), expectedSize);
-    // Red is markedly brighter than blue, so luma alone shows the halves are upright.
-    const auto lumaAt = [&](QPoint p) {
-        return uchar(nv12.data.at(qsizetype(p.y()) * nv12.width + p.x()));
-    };
-    QVERIFY(lumaAt(redAt) > lumaAt(blueAt));
+    // Preview keeps coded orientation and applies rotation in the GL shader.
+    PreviewVideoFrame preview;
+    QVERIFY(reader.readPreviewVideoFrame(500'000, preview, expectedSize.width(), expectedSize.height()));
+    QVERIFY(preview.isValid());
+    QCOMPARE(preview.rotation, displayDegrees);
+    QCOMPARE(QSize(preview.displayWidth(), preview.displayHeight()), expectedSize);
+
+    if (!GpuCompositor::isAvailable())
+        return;
+
+    drift::Project project;
+    project.setResolution(expectedSize.width(), expectedSize.height());
+    project.setFps(30);
+    project.tracks().clear();
+    project.tracks().append(drift::Track{.type = drift::TrackType::Video});
+
+    drift::Clip clip;
+    clip.id = QStringLiteral("rot");
+    clip.type = drift::ClipType::Video;
+    clip.path = path;
+    clip.timelineStart = 0;
+    clip.timelineDuration = drift::secondsToUs(1.0);
+    project.tracks()[0].clips.append(clip);
+
+    FrameCompositor compositor;
+    compositor.setProject(&project);
+    const QImage composited = compositor.compositeAt(500'000);
+    QVERIFY(!composited.isNull());
+    QCOMPARE(composited.size(), expectedSize);
+    const QRgb cred = composited.pixel(redAt);
+    const QRgb cblue = composited.pixel(blueAt);
+    QVERIFY(qRed(cred) > qBlue(cred));
+    QVERIFY(qBlue(cblue) > qRed(cblue));
 }
 
 QString EngineTest::makeAv1ColorVideo(QTemporaryDir &dir)
@@ -2468,10 +2492,10 @@ void EngineTest::videoStreamsDoNotReseekPerFrame()
     const quint64 twoFileBefore = ClipReader::videoFramesDecoded();
     for (int i = 0; i < kFrames; ++i) {
         QVERIFY(ClipReaderPool::instance()
-                    .readVideoFrameNv12(path, 101, drift::TimeUs(i) * kStep, 640, 360)
+                    .readPreviewVideoFrame(path, 101, drift::TimeUs(i) * kStep, 640, 360)
                     .isValid());
         QVERIFY(ClipReaderPool::instance()
-                    .readVideoFrameNv12(copy, 202, kSecondStart + drift::TimeUs(i) * kStep, 640, 360)
+                    .readPreviewVideoFrame(copy, 202, kSecondStart + drift::TimeUs(i) * kStep, 640, 360)
                     .isValid());
     }
     const quint64 twoFileDecoded = ClipReader::videoFramesDecoded() - twoFileBefore;
@@ -2480,10 +2504,10 @@ void EngineTest::videoStreamsDoNotReseekPerFrame()
     const quint64 oneFileBefore = ClipReader::videoFramesDecoded();
     for (int i = 0; i < kFrames; ++i) {
         QVERIFY(ClipReaderPool::instance()
-                    .readVideoFrameNv12(path, 303, drift::TimeUs(i) * kStep, 640, 360)
+                    .readPreviewVideoFrame(path, 303, drift::TimeUs(i) * kStep, 640, 360)
                     .isValid());
         QVERIFY(ClipReaderPool::instance()
-                    .readVideoFrameNv12(path, 404, kSecondStart + drift::TimeUs(i) * kStep, 640, 360)
+                    .readPreviewVideoFrame(path, 404, kSecondStart + drift::TimeUs(i) * kStep, 640, 360)
                     .isValid());
     }
     const quint64 oneFileDecoded = ClipReader::videoFramesDecoded() - oneFileBefore;

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -24,6 +24,12 @@ target_link_libraries(benchcomposite PRIVATE Qt6::Core Qt6::Gui driftengine drif
 drift_copy_effects(benchcomposite)
 drift_copy_transitions(benchcomposite)
 
+add_executable(benchexport benchexport.cpp)
+target_include_directories(benchexport PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(benchexport PRIVATE Qt6::Core Qt6::Gui driftengine driftcore)
+drift_copy_effects(benchexport)
+drift_copy_transitions(benchexport)
+
 add_executable(transitionthumbs transitionthumbs.cpp)
 target_include_directories(transitionthumbs PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(transitionthumbs PRIVATE Qt6::Core Qt6::Gui driftengine driftcore)

--- a/tools/benchcomposite.cpp
+++ b/tools/benchcomposite.cpp
@@ -132,13 +132,45 @@ int main(int argc, char *argv[])
 
     // DRIFT_BENCH_TEXTURE=1 times the preview path (composite to a GL texture,
     // no readback) instead of the export path (composite and read back).
+    // DRIFT_BENCH_NV12=1 times compose + GPU RGBA→NV12 + async PBO map.
     const bool texturePath = qEnvironmentVariableIsSet("DRIFT_BENCH_TEXTURE");
+    const bool nv12Path = qEnvironmentVariableIsSet("DRIFT_BENCH_NV12");
 
     QElapsedTimer timer;
+    std::vector<uint8_t> nv12Y;
+    std::vector<uint8_t> nv12Uv;
+    int nv12Slot = 0;
+    if (nv12Path) {
+        nv12Y.resize(size_t(project.width()) * size_t(project.height()));
+        nv12Uv.resize(size_t(project.width()) * size_t(project.height() / 2));
+    }
+
     for (int i = 0; i < frames; ++i) {
         const drift::TimeUs t = static_cast<drift::TimeUs>(i) * step;
         timer.start();
-        if (texturePath) {
+        if (nv12Path) {
+            GpuScene scene;
+            if (!compositor.buildSceneAt(t, options, &scene)) {
+                err << "null scene at " << t << "\n";
+                return 1;
+            }
+            const int slot = nv12Slot;
+            nv12Slot ^= 1;
+            if (!GpuCompositor::beginExportNv12(scene, project.width(), project.height(), slot)) {
+                err << "nv12 pack failed at " << t << "\n";
+                return 1;
+            }
+            if (i > 0) {
+                const int prev = slot ^ 1;
+                if (!GpuCompositor::finishExportNv12(prev, nv12Y.data(), project.width(),
+                                                     nv12Uv.data(), project.width(), project.width(),
+                                                     project.height())) {
+                    err << "nv12 map failed at " << t << "\n";
+                    return 1;
+                }
+            }
+            samples.push_back(timer.nsecsElapsed() / 1e6);
+        } else if (texturePath) {
             const GpuFrameTexture frame = compositor.compositeToTextureAt(t, options);
             samples.push_back(timer.nsecsElapsed() / 1e6);
             if (!frame.isValid()) {
@@ -152,6 +184,15 @@ int main(int argc, char *argv[])
                 err << "null frame at " << t << "\n";
                 return 1;
             }
+        }
+    }
+
+    if (nv12Path) {
+        const int last = nv12Slot ^ 1;
+        if (!GpuCompositor::finishExportNv12(last, nv12Y.data(), project.width(), nv12Uv.data(),
+                                             project.width(), project.width(), project.height())) {
+            err << "nv12 map failed on drain\n";
+            return 1;
         }
     }
 

--- a/tools/benchexport.cpp
+++ b/tools/benchexport.cpp
@@ -1,0 +1,178 @@
+// Side-by-side export timing: GPU NV12 pipeline vs serial RGBA + sws_scale.
+//
+//   benchexport <video> [out_dir]
+#include "core/Clip.h"
+#include "core/Project.h"
+#include "core/Track.h"
+#include "engine/ClipReaderPool.h"
+#include "engine/EffectCatalog.h"
+#include "engine/Exporter.h"
+#include "engine/FontCatalog.h"
+#include "engine/FrameCompositor.h"
+#include "engine/GpuCompositor.h"
+#include "engine/MediaProbe.h"
+
+#include <QElapsedTimer>
+#include <QFileInfo>
+#include <QGuiApplication>
+#include <QTextStream>
+
+#include <cstdio>
+
+namespace {
+
+drift::Effect makeEffect(const QString &catalogId)
+{
+    drift::Effect effect;
+    effect.catalogId = catalogId;
+    return effect;
+}
+
+bool runTimedExport(const drift::Project &project, const ExportSettings &settings, const QString &outPath,
+                    const QString &label, QTextStream &out, QTextStream &err)
+{
+    out << label << "…\n";
+    out.flush();
+
+    QElapsedTimer timer;
+    timer.start();
+    QString error;
+    int lastPct = -1;
+    const bool ok = Exporter::run(project, settings, outPath, &error, [&](double p) {
+        const int pct = int(p * 100.0);
+        if (pct != lastPct && pct % 10 == 0) {
+            std::fprintf(stderr, "  %s %d%%\n", qUtf8Printable(label), pct);
+            lastPct = pct;
+        }
+        return true;
+    });
+    const qint64 ms = timer.elapsed();
+
+    if (!ok) {
+        err << label << " failed: " << error << "\n";
+        return false;
+    }
+
+    const QFileInfo info(outPath);
+    const double sec = ms / 1000.0;
+    const double timelineSec = project.durationUs() / 1e6;
+    out << Qt::fixed;
+    out.setRealNumberPrecision(2);
+    out << "  wall   " << sec << " s\n";
+    out << "  speed  " << (timelineSec / sec) << "× realtime\n";
+    out << "  size   " << (info.size() / (1024.0 * 1024.0)) << " MiB  " << outPath << "\n";
+    out.flush();
+    return true;
+}
+
+} // namespace
+
+int main(int argc, char *argv[])
+{
+    QGuiApplication app(argc, argv);
+    reloadFontCatalog();
+    reloadEffectCatalog();
+
+    QTextStream out(stdout);
+    QTextStream err(stderr);
+    const QStringList args = app.arguments();
+    if (args.size() < 2) {
+        err << "usage: benchexport <video> [out_dir]\n";
+        return 1;
+    }
+
+    const QString path = args.at(1);
+    const QString outDir = args.size() > 2 ? args.at(2) : QStringLiteral("/tmp");
+
+    const QVariantMap vaapi = Exporter::videoCodecById(QStringLiteral("h264_vaapi"));
+    if (!vaapi.value(QStringLiteral("available")).toBool()) {
+        err << "h264_vaapi is not available on this machine\n";
+        return 1;
+    }
+
+    const MediaInfo media = MediaProbe::probe(path);
+    if (!media.ok || media.durationUs <= 0) {
+        err << "could not probe " << path << ": " << media.errorString << "\n";
+        return 1;
+    }
+
+    int srcW = 0;
+    int srcH = 0;
+    double fps = 30.0;
+    for (const StreamInfo &s : media.streams) {
+        if (s.type == StreamInfo::Type::Video && !s.attachedPicture) {
+            srcW = s.width;
+            srcH = s.height;
+            if (s.fps > 1.0)
+                fps = s.fps;
+            break;
+        }
+    }
+    if (srcW <= 0 || srcH <= 0) {
+        err << "no video stream in " << path << "\n";
+        return 1;
+    }
+
+    // Portrait 1080p keeps this 9:16 clip filling the frame (2160×3840 → 1080×1920).
+    int outW = 1080;
+    int outH = 1920;
+    if (srcW > srcH) {
+        outW = 1920;
+        outH = 1080;
+    }
+
+    drift::Project project;
+    project.setResolution(outW, outH);
+    project.setFps(qMax(1, int(fps + 0.5)));
+    project.tracks().clear();
+
+    drift::Track video;
+    video.type = drift::TrackType::Video;
+    drift::Clip clip;
+    clip.id = QStringLiteral("src");
+    clip.type = drift::ClipType::Video;
+    clip.path = path;
+    clip.timelineStart = 0;
+    clip.timelineDuration = media.durationUs;
+    clip.srcIn = 0;
+    clip.srcOut = media.durationUs;
+    clip.effects.append(makeEffect(QStringLiteral("adjust.contrast")));
+    clip.effects.append(makeEffect(QStringLiteral("stylize.vignette")));
+    clip.effects.append(makeEffect(QStringLiteral("rgb_split")));
+    video.clips << clip;
+    project.tracks() << video;
+
+    ExportSettings settings = Exporter::defaultSettings();
+    settings.targetHeight = 0;
+    settings.videoCodecId = QStringLiteral("h264_vaapi");
+    settings.audioCodecId = QStringLiteral("aac");
+    settings.rateControl = QStringLiteral("crf");
+    settings.crf = 23;
+
+    out << "source  " << srcW << "×" << srcH << "  " << (media.durationUs / 1e6) << " s  " << fps
+        << " fps\n";
+    out << "output  " << outW << "×" << outH << "  h264_vaapi  contrast+vignette+rgb_split\n";
+    out << "gpu     " << (GpuCompositor::isAvailable() ? "yes" : "no") << "\n\n";
+    out.flush();
+
+    FrameCompositor compositor;
+    compositor.setProject(&project);
+    for (int i = 0; i < 3; ++i)
+        compositor.compositeAt(drift::TimeUs(i) * 200'000);
+    ClipReaderPool::instance().releaseAll();
+
+    const QString gpuOut = outDir + QStringLiteral("/benchexport-gpu-nv12.mp4");
+    const QString cpuOut = outDir + QStringLiteral("/benchexport-cpu-sws.mp4");
+
+    qunsetenv("DRIFT_EXPORT_SWSCALE");
+    if (!runTimedExport(project, settings, gpuOut, QStringLiteral("GPU NV12 pipeline"), out, err))
+        return 1;
+
+    ClipReaderPool::instance().releaseAll();
+
+    qputenv("DRIFT_EXPORT_SWSCALE", "1");
+    if (!runTimedExport(project, settings, cpuOut, QStringLiteral("CPU RGBA + sws_scale"), out, err))
+        return 1;
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

Playback and export keep video on the graphics card instead of copying it to the CPU and back every frame. Preview is smoother, and export is no longer stuck waiting on colour conversion before the encoder.

Closes #127
Closes #107

## Preview

- Decoded frames stay on the GPU. The preview draws them there instead of downloading a full image to the CPU each time.
- Hardware decode was accidentally treated as “no picture,” so Drift fell back to software. That is fixed.
- **Faster preview** in Settings (off by default) keeps Intel/AMD VAAPI video on the GPU end to end. Turn it off if the picture looks wrong. It needs a restart. Checked on Intel; other GPUs may differ.
- Full / Half / Quarter now match the **preview window**, not the project size. A 4K timeline in a small panel no longer renders a 4K frame and then shrinks it. Auto is the same as Full, then drops further if playback cannot keep up.

## Export

- While one frame is being encoded, the next is already being drawn.
- The GPU converts the picture to the format the encoder wants, so the CPU no longer does that conversion on every frame (normal 8-bit exports).
- Encoders still receive a normal memory buffer. Direct GPU-to-encoder sharing is not in this PR.
- GIF, audio-only, and 10-bit exports use the old conversion path.

## Benchmarks

Clip: 4K portrait (2160×3840) AV1, 30 fps, 16.7 seconds. Intel laptop GPU.

**Export** to 1080p portrait with a few effects, VAAPI H.264:

| | Time | vs realtime |
|---|---|---|
| New path | 16.8 s | about 1× (realtime) |
| Old path (CPU conversion) | 21.5 s | 0.78× |

About **22% faster**. The encoder was not the slow part; preparing each frame was.

**Preview** on the same clip, before Full was tied to the panel size:

| | Per frame | Rough fps |
|---|---|---|
| Hardware decode | 2.7 ms | ~370 |
| Software decode | 15–20 ms | ~50–65 |
| Draw preview (GPU, no extra copy) | ~21 ms | ~48 |
| Draw preview (copy through CPU) | ~29 ms | ~35 |

Decode was already fast enough. The hitch vs mpv was drawing a full 4K preview into a small window. Full now draws at window size instead.
