### PR TITLE
feat: add multi-select and range selection to the media bin

### DIFF
--- a/i18n/drift.ts
+++ b/i18n/drift.ts
@@ -2836,6 +2836,24 @@
         <source>Media moved</source>
         <translation type="unfinished"></translation>
     </message>
+    <message numerus="yes">
+        <source>%n items removed</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items moved</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Clips added</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -2938,13 +2956,6 @@
     </message>
     <message numerus="yes">
         <source>Could not import any of the %n selected files.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>“%1” is still used by %n clips on the timeline.</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
@@ -3160,6 +3171,35 @@
     <message>
         <source>Create a new folder here</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>“%1” is still used by clips on the timeline.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n of the selected items are still used by clips on the timeline.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Remove these items?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>Removed %n items.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -5023,6 +5063,31 @@
     <message>
         <source>Delete</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>Add %n items to timeline</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Add to timeline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>Move %n items to folder…</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Remove %n items from project</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_es.ts
+++ b/i18n/drift_es.ts
@@ -2836,6 +2836,24 @@
         <source>Media moved</source>
         <translation>Medio movido</translation>
     </message>
+    <message numerus="yes">
+        <source>%n items removed</source>
+        <translation>
+            <numerusform>%n elemento eliminado</numerusform>
+            <numerusform>%n elementos eliminados</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items moved</source>
+        <translation>
+            <numerusform>%n elemento movido</numerusform>
+            <numerusform>%n elementos movidos</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Clips added</source>
+        <translation>Clips añadidos</translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -2941,13 +2959,6 @@
         <translation>
             <numerusform>No se pudo importar el archivo seleccionado (%n).</numerusform>
             <numerusform>No se pudo importar ninguno de los %n archivos seleccionados.</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>“%1” is still used by %n clips on the timeline.</source>
-        <translation>
-            <numerusform>“%1” todavía se usa en %n clip de la línea de tiempo.</numerusform>
-            <numerusform>“%1” todavía se usa en %n clips de la línea de tiempo.</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -3160,6 +3171,35 @@
     <message>
         <source>Create a new folder here</source>
         <translation>Crea una carpeta nueva aquí</translation>
+    </message>
+    <message>
+        <source>“%1” is still used by clips on the timeline.</source>
+        <translation>“%1” todavía es utilizado por clips en la línea de tiempo.</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n of the selected items are still used by clips on the timeline.</source>
+        <translation>
+            <numerusform>%n de los elementos seleccionados todavía es utilizado por clips en la línea de tiempo.</numerusform>
+            <numerusform>%n de los elementos seleccionados todavía son utilizados por clips en la línea de tiempo.</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items</source>
+        <translation>
+            <numerusform>%n elemento</numerusform>
+            <numerusform>%n elementos</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Remove these items?</source>
+        <translation>¿Eliminar estos elementos?</translation>
+    </message>
+    <message numerus="yes">
+        <source>Removed %n items.</source>
+        <translation>
+            <numerusform>%n elemento eliminado.</numerusform>
+            <numerusform>%n elementos eliminados.</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -5023,6 +5063,31 @@
     <message>
         <source>Delete</source>
         <translation>Eliminar</translation>
+    </message>
+    <message numerus="yes">
+        <source>Add %n items to timeline</source>
+        <translation>
+            <numerusform>Añadir %n elemento a la línea de tiempo</numerusform>
+            <numerusform>Añadir %n elementos a la línea de tiempo</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Add to timeline</source>
+        <translation>Añadir a la línea de tiempo</translation>
+    </message>
+    <message numerus="yes">
+        <source>Move %n items to folder…</source>
+        <translation>
+            <numerusform>Mover %n elemento a la carpeta…</numerusform>
+            <numerusform>Mover %n elementos a la carpeta…</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Remove %n items from project</source>
+        <translation>
+            <numerusform>Eliminar %n elemento del proyecto</numerusform>
+            <numerusform>Eliminar %n elementos del proyecto</numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_fr_CA.ts
+++ b/i18n/drift_fr_CA.ts
@@ -2824,19 +2824,37 @@
     </message>
     <message>
         <source>Folder created</source>
-        <translation type="unfinished"></translation>
+        <translation>Dossier créé</translation>
     </message>
     <message>
         <source>Folder renamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Dossier renommé</translation>
     </message>
     <message>
         <source>Folder deleted</source>
-        <translation type="unfinished"></translation>
+        <translation>Dossier supprimé</translation>
     </message>
     <message>
         <source>Media moved</source>
-        <translation type="unfinished"></translation>
+        <translation>Média déplacé</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items removed</source>
+        <translation>
+            <numerusform>%n élément supprimé</numerusform>
+            <numerusform>%n éléments supprimés</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items moved</source>
+        <translation>
+            <numerusform>%n élément déplacé</numerusform>
+            <numerusform>%n éléments déplacés</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Clips added</source>
+        <translation>Clips ajoutés</translation>
     </message>
 </context>
 <context>
@@ -2943,13 +2961,6 @@
         <translation>
             <numerusform>Impossible d&apos;importer aucun du %n fichier sélectionné.</numerusform>
             <numerusform>Impossible d&apos;importer aucun des %n fichiers sélectionnés.</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>“%1” is still used by %n clips on the timeline.</source>
-        <translation>
-            <numerusform>“%1” est toujours utilisé par %n clip sur la timeline.</numerusform>
-            <numerusform>“%1” est toujours utilisé par %n clips sur la timeline.</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -3137,31 +3148,60 @@
     </message>
     <message>
         <source>New folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Nouveau dossier</translation>
     </message>
     <message>
         <source>Create</source>
-        <translation type="unfinished">Créer</translation>
+        <translation>Créer</translation>
     </message>
     <message>
         <source>Folder name</source>
-        <translation type="unfinished"></translation>
+        <translation>Nom du dossier</translation>
     </message>
     <message>
         <source>Rename folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Renommer le dossier</translation>
     </message>
     <message>
         <source>Move to folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Déplacer vers un dossier</translation>
     </message>
     <message>
         <source>New Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Nouveau dossier</translation>
     </message>
     <message>
         <source>Create a new folder here</source>
-        <translation type="unfinished"></translation>
+        <translation>Créer un nouveau dossier ici</translation>
+    </message>
+    <message>
+        <source>“%1” is still used by clips on the timeline.</source>
+        <translation>« %1 » est encore utilisé par des clips sur la ligne du temps.</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n of the selected items are still used by clips on the timeline.</source>
+        <translation>
+            <numerusform>%n des éléments sélectionnés est encore utilisé par des clips sur la ligne du temps.</numerusform>
+            <numerusform>%n des éléments sélectionnés sont encore utilisés par des clips sur la ligne du temps.</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items</source>
+        <translation>
+            <numerusform>%n élément</numerusform>
+            <numerusform>%n éléments</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Remove these items?</source>
+        <translation>Supprimer ces éléments?</translation>
+    </message>
+    <message numerus="yes">
+        <source>Removed %n items.</source>
+        <translation>
+            <numerusform>%n élément supprimé.</numerusform>
+            <numerusform>%n éléments supprimés.</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3391,7 +3431,7 @@
     <name>BinBreadcrumb</name>
     <message>
         <source>Media</source>
-        <translation type="unfinished">Média</translation>
+        <translation>Média</translation>
     </message>
 </context>
 <context>
@@ -5009,23 +5049,48 @@
     </message>
     <message>
         <source>Move to folder…</source>
-        <translation type="unfinished"></translation>
+        <translation>Déplacer vers un dossier…</translation>
     </message>
     <message>
         <source>This folder is empty</source>
-        <translation type="unfinished"></translation>
+        <translation>Ce dossier est vide</translation>
     </message>
     <message>
         <source>Drag media here, or import more.</source>
-        <translation type="unfinished"></translation>
+        <translation>Glissez des médias ici ou importez-en d&apos;autres.</translation>
     </message>
     <message>
         <source>Open</source>
-        <translation type="unfinished">Ouvrir</translation>
+        <translation>Ouvrir</translation>
     </message>
     <message>
         <source>Delete</source>
-        <translation type="unfinished">Supprimer</translation>
+        <translation>Supprimer</translation>
+    </message>
+    <message numerus="yes">
+        <source>Add %n items to timeline</source>
+        <translation>
+            <numerusform>Ajouter %n élément à la ligne du temps</numerusform>
+            <numerusform>Ajouter %n éléments à la ligne du temps</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Add to timeline</source>
+        <translation>Ajouter à la ligne du temps</translation>
+    </message>
+    <message numerus="yes">
+        <source>Move %n items to folder…</source>
+        <translation>
+            <numerusform>Déplacer %n élément vers un dossier…</numerusform>
+            <numerusform>Déplacer %n éléments vers un dossier…</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Remove %n items from project</source>
+        <translation>
+            <numerusform>Supprimer %n élément du projet</numerusform>
+            <numerusform>Supprimer %n éléments du projet</numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_it.ts
+++ b/i18n/drift_it.ts
@@ -2822,19 +2822,37 @@
     </message>
     <message>
         <source>Folder created</source>
-        <translation type="unfinished"></translation>
+        <translation>Cartella creata</translation>
     </message>
     <message>
         <source>Folder renamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Cartella rinominata</translation>
     </message>
     <message>
         <source>Folder deleted</source>
-        <translation type="unfinished"></translation>
+        <translation>Cartella eliminata</translation>
     </message>
     <message>
         <source>Media moved</source>
-        <translation type="unfinished"></translation>
+        <translation>Elemento multimediale spostato</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items removed</source>
+        <translation>
+            <numerusform>%n elemento rimosso</numerusform>
+            <numerusform>%n elementi rimossi</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items moved</source>
+        <translation>
+            <numerusform>%n elemento spostato</numerusform>
+            <numerusform>%n elementi spostati</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Clips added</source>
+        <translation>Clip aggiunte</translation>
     </message>
 </context>
 <context>
@@ -2941,13 +2959,6 @@
         <translation>
             <numerusform>Impossibile importare %n file selezionato.</numerusform>
             <numerusform>Impossibile importare nessuno dei %n file selezionati.</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>“%1” is still used by %n clips on the timeline.</source>
-        <translation>
-            <numerusform>“%1” è ancora utilizzato da %n clip sulla timeline.</numerusform>
-            <numerusform>“%1” è ancora utilizzato da %n clip sulla timeline.</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -3135,31 +3146,60 @@
     </message>
     <message>
         <source>New folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Nuova cartella</translation>
     </message>
     <message>
         <source>Create</source>
-        <translation type="unfinished">Crea</translation>
+        <translation>Crea</translation>
     </message>
     <message>
         <source>Folder name</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome della cartella</translation>
     </message>
     <message>
         <source>Rename folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Rinomina cartella</translation>
     </message>
     <message>
         <source>Move to folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Sposta nella cartella</translation>
     </message>
     <message>
         <source>New Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Nuova cartella</translation>
     </message>
     <message>
         <source>Create a new folder here</source>
-        <translation type="unfinished"></translation>
+        <translation>Crea una nuova cartella qui</translation>
+    </message>
+    <message>
+        <source>“%1” is still used by clips on the timeline.</source>
+        <translation>“%1” è ancora utilizzato da clip nella timeline.</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n of the selected items are still used by clips on the timeline.</source>
+        <translation>
+            <numerusform>%n degli elementi selezionati è ancora utilizzato da clip nella timeline.</numerusform>
+            <numerusform>%n degli elementi selezionati sono ancora utilizzati da clip nella timeline.</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items</source>
+        <translation>
+            <numerusform>%n elemento</numerusform>
+            <numerusform>%n elementi</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Remove these items?</source>
+        <translation>Rimuovere questi elementi?</translation>
+    </message>
+    <message numerus="yes">
+        <source>Removed %n items.</source>
+        <translation>
+            <numerusform>%n elemento rimosso.</numerusform>
+            <numerusform>%n elementi rimossi.</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3389,7 +3429,7 @@
     <name>BinBreadcrumb</name>
     <message>
         <source>Media</source>
-        <translation type="unfinished">Elementi multimediali</translation>
+        <translation>Elementi multimediali</translation>
     </message>
 </context>
 <context>
@@ -5006,23 +5046,48 @@
     </message>
     <message>
         <source>Move to folder…</source>
-        <translation type="unfinished"></translation>
+        <translation>Sposta nella cartella…</translation>
     </message>
     <message>
         <source>This folder is empty</source>
-        <translation type="unfinished"></translation>
+        <translation>Questa cartella è vuota</translation>
     </message>
     <message>
         <source>Drag media here, or import more.</source>
-        <translation type="unfinished"></translation>
+        <translation>Trascina qui gli elementi multimediali oppure importane altri.</translation>
     </message>
     <message>
         <source>Open</source>
-        <translation type="unfinished">Apri</translation>
+        <translation>Apri</translation>
     </message>
     <message>
         <source>Delete</source>
-        <translation type="unfinished">Elimina</translation>
+        <translation>Elimina</translation>
+    </message>
+    <message numerus="yes">
+        <source>Add %n items to timeline</source>
+        <translation>
+            <numerusform>Aggiungi %n elemento alla timeline</numerusform>
+            <numerusform>Aggiungi %n elementi alla timeline</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Add to timeline</source>
+        <translation>Aggiungi alla timeline</translation>
+    </message>
+    <message numerus="yes">
+        <source>Move %n items to folder…</source>
+        <translation>
+            <numerusform>Sposta %n elemento nella cartella…</numerusform>
+            <numerusform>Sposta %n elementi nella cartella…</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Remove %n items from project</source>
+        <translation>
+            <numerusform>Rimuovi %n elemento dal progetto</numerusform>
+            <numerusform>Rimuovi %n elementi dal progetto</numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_pt_BR.ts
+++ b/i18n/drift_pt_BR.ts
@@ -2822,19 +2822,37 @@
     </message>
     <message>
         <source>Folder created</source>
-        <translation type="unfinished"></translation>
+        <translation>Pasta criada</translation>
     </message>
     <message>
         <source>Folder renamed</source>
-        <translation type="unfinished"></translation>
+        <translation>Pasta renomeada</translation>
     </message>
     <message>
         <source>Folder deleted</source>
-        <translation type="unfinished"></translation>
+        <translation>Pasta excluída</translation>
     </message>
     <message>
         <source>Media moved</source>
-        <translation type="unfinished"></translation>
+        <translation>Mídia movida</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items removed</source>
+        <translation>
+            <numerusform>%n item removido</numerusform>
+            <numerusform>%n itens removidos</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items moved</source>
+        <translation>
+            <numerusform>%n item movido</numerusform>
+            <numerusform>%n itens movidos</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Clips added</source>
+        <translation>Clipes adicionados</translation>
     </message>
 </context>
 <context>
@@ -2941,13 +2959,6 @@
         <translation>
             <numerusform>%n arquivo selecionado não pôde ser importado.</numerusform>
             <numerusform>Nenhum dos %n arquivos selecionados pôde ser importado.</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>“%1” is still used by %n clips on the timeline.</source>
-        <translation>
-            <numerusform>“%1” ainda é usado por %n clipe na linha do tempo.</numerusform>
-            <numerusform>“%1” ainda é usado por %n clipes na linha do tempo.</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -3135,31 +3146,60 @@
     </message>
     <message>
         <source>New folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Nova pasta</translation>
     </message>
     <message>
         <source>Create</source>
-        <translation type="unfinished">Criar</translation>
+        <translation>Criar</translation>
     </message>
     <message>
         <source>Folder name</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome da pasta</translation>
     </message>
     <message>
         <source>Rename folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Renomear pasta</translation>
     </message>
     <message>
         <source>Move to folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Mover para pasta</translation>
     </message>
     <message>
         <source>New Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Nova pasta</translation>
     </message>
     <message>
         <source>Create a new folder here</source>
-        <translation type="unfinished"></translation>
+        <translation>Criar uma nova pasta aqui</translation>
+    </message>
+    <message>
+        <source>“%1” is still used by clips on the timeline.</source>
+        <translation>“%1” ainda está sendo usado por clipes na linha do tempo.</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n of the selected items are still used by clips on the timeline.</source>
+        <translation>
+            <numerusform>%n dos itens selecionados ainda está sendo usado por clipes na linha do tempo.</numerusform>
+            <numerusform>%n dos itens selecionados ainda estão sendo usados por clipes na linha do tempo.</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items</source>
+        <translation>
+            <numerusform>%n item</numerusform>
+            <numerusform>%n itens</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Remove these items?</source>
+        <translation>Remover estes itens?</translation>
+    </message>
+    <message numerus="yes">
+        <source>Removed %n items.</source>
+        <translation>
+            <numerusform>%n item removido.</numerusform>
+            <numerusform>%n itens removidos.</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3389,7 +3429,7 @@
     <name>BinBreadcrumb</name>
     <message>
         <source>Media</source>
-        <translation type="unfinished">Mídia</translation>
+        <translation>Mídia</translation>
     </message>
 </context>
 <context>
@@ -5006,23 +5046,48 @@
     </message>
     <message>
         <source>Move to folder…</source>
-        <translation type="unfinished"></translation>
+        <translation>Mover para pasta…</translation>
     </message>
     <message>
         <source>This folder is empty</source>
-        <translation type="unfinished"></translation>
+        <translation>Esta pasta está vazia</translation>
     </message>
     <message>
         <source>Drag media here, or import more.</source>
-        <translation type="unfinished"></translation>
+        <translation>Arraste mídia para cá ou importe mais.</translation>
     </message>
     <message>
         <source>Open</source>
-        <translation type="unfinished">Abrir</translation>
+        <translation>Abrir</translation>
     </message>
     <message>
         <source>Delete</source>
-        <translation type="unfinished">Excluir</translation>
+        <translation>Excluir</translation>
+    </message>
+    <message numerus="yes">
+        <source>Add %n items to timeline</source>
+        <translation>
+            <numerusform>Adicionar %n item à linha do tempo</numerusform>
+            <numerusform>Adicionar %n itens à linha do tempo</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Add to timeline</source>
+        <translation>Adicionar à linha do tempo</translation>
+    </message>
+    <message numerus="yes">
+        <source>Move %n items to folder…</source>
+        <translation>
+            <numerusform>Mover %n item para pasta…</numerusform>
+            <numerusform>Mover %n itens para pasta…</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Remove %n items from project</source>
+        <translation>
+            <numerusform>Remover %n item do projeto</numerusform>
+            <numerusform>Remover %n itens do projeto</numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_si.ts
+++ b/i18n/drift_si.ts
@@ -2822,19 +2822,37 @@
     </message>
     <message>
         <source>Folder created</source>
-        <translation type="unfinished"></translation>
+        <translation>ෆෝල්ඩරය සාදන ලදී</translation>
     </message>
     <message>
         <source>Folder renamed</source>
-        <translation type="unfinished"></translation>
+        <translation>ෆෝල්ඩරයේ නම වෙනස් කරන ලදී</translation>
     </message>
     <message>
         <source>Folder deleted</source>
-        <translation type="unfinished"></translation>
+        <translation>ෆෝල්ඩරය මකා දමන ලදී</translation>
     </message>
     <message>
         <source>Media moved</source>
-        <translation type="unfinished"></translation>
+        <translation>මාධ්‍යය ගෙන යන ලදී</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items removed</source>
+        <translation>
+            <numerusform>අයිතම %n ක් ඉවත් කරන ලදී</numerusform>
+            <numerusform>අයිතම %n ක් ඉවත් කරන ලදී</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items moved</source>
+        <translation>
+            <numerusform>අයිතම %n ක් ගෙන යන ලදී</numerusform>
+            <numerusform>අයිතම %n ක් ගෙන යන ලදී</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Clips added</source>
+        <translation>ක්ලිප් එක් කරන ලදී</translation>
     </message>
 </context>
 <context>
@@ -2941,13 +2959,6 @@
         <translation>
             <numerusform>තෝරාගත් ගොනු %nන් කිසිවක් ආයාත කිරීමට නොහැකි විය.</numerusform>
             <numerusform>තෝරාගත් ගොනු %nන් කිසිවක් ආයාත කිරීමට නොහැකි විය.</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>“%1” is still used by %n clips on the timeline.</source>
-        <translation>
-            <numerusform>“%1” තවමත් කාලරේඛාවේ ක්ලිප් %nක් මඟින් භාවිත කෙරේ.</numerusform>
-            <numerusform>“%1” තවමත් කාලරේඛාවේ ක්ලිප් %nක් මඟින් භාවිත කෙරේ.</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -3135,31 +3146,60 @@
     </message>
     <message>
         <source>New folder</source>
-        <translation type="unfinished"></translation>
+        <translation>නව ෆෝල්ඩරය</translation>
     </message>
     <message>
         <source>Create</source>
-        <translation type="unfinished">සාදන්න</translation>
+        <translation>සාදන්න</translation>
     </message>
     <message>
         <source>Folder name</source>
-        <translation type="unfinished"></translation>
+        <translation>ෆෝල්ඩර නම</translation>
     </message>
     <message>
         <source>Rename folder</source>
-        <translation type="unfinished"></translation>
+        <translation>ෆෝල්ඩරයේ නම වෙනස් කරන්න</translation>
     </message>
     <message>
         <source>Move to folder</source>
-        <translation type="unfinished"></translation>
+        <translation>ෆෝල්ඩරයට ගෙන යන්න</translation>
     </message>
     <message>
         <source>New Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>නව ෆෝල්ඩරය</translation>
     </message>
     <message>
         <source>Create a new folder here</source>
-        <translation type="unfinished"></translation>
+        <translation>මෙහි නව ෆෝල්ඩරයක් සාදන්න</translation>
+    </message>
+    <message>
+        <source>“%1” is still used by clips on the timeline.</source>
+        <translation>“%1” තවමත් කාලරේඛාවේ ක්ලිප් මගින් භාවිතා වේ.</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n of the selected items are still used by clips on the timeline.</source>
+        <translation>
+            <numerusform>තෝරාගත් අයිතමවලින් %n ක් තවමත් කාලරේඛාවේ ක්ලිප් මගින් භාවිතා වේ.</numerusform>
+            <numerusform>තෝරාගත් අයිතමවලින් %n ක් තවමත් කාලරේඛාවේ ක්ලිප් මගින් භාවිතා වේ.</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items</source>
+        <translation>
+            <numerusform>අයිතම %n ක්</numerusform>
+            <numerusform>අයිතම %n ක්</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Remove these items?</source>
+        <translation>මෙම අයිතම ඉවත් කරන්නද?</translation>
+    </message>
+    <message numerus="yes">
+        <source>Removed %n items.</source>
+        <translation>
+            <numerusform>අයිතම %n ක් ඉවත් කරන ලදී.</numerusform>
+            <numerusform>අයිතම %n ක් ඉවත් කරන ලදී.</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3389,7 +3429,7 @@
     <name>BinBreadcrumb</name>
     <message>
         <source>Media</source>
-        <translation type="unfinished">මාධ්‍ය</translation>
+        <translation>මාධ්‍ය</translation>
     </message>
 </context>
 <context>
@@ -5006,23 +5046,48 @@
     </message>
     <message>
         <source>Move to folder…</source>
-        <translation type="unfinished"></translation>
+        <translation>ෆෝල්ඩරයට ගෙන යන්න…</translation>
     </message>
     <message>
         <source>This folder is empty</source>
-        <translation type="unfinished"></translation>
+        <translation>මෙම ෆෝල්ඩරය හිස්ය</translation>
     </message>
     <message>
         <source>Drag media here, or import more.</source>
-        <translation type="unfinished"></translation>
+        <translation>මාධ්‍ය මෙහි අදින්න, නැතහොත් තවත් ආයාත කරන්න.</translation>
     </message>
     <message>
         <source>Open</source>
-        <translation type="unfinished">විවෘත කරන්න</translation>
+        <translation>විවෘත කරන්න</translation>
     </message>
     <message>
         <source>Delete</source>
-        <translation type="unfinished">මකන්න</translation>
+        <translation>මකන්න</translation>
+    </message>
+    <message numerus="yes">
+        <source>Add %n items to timeline</source>
+        <translation>
+            <numerusform>අයිතම %n ක් කාලරේඛාවට එක් කරන්න</numerusform>
+            <numerusform>අයිතම %n ක් කාලරේඛාවට එක් කරන්න</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Add to timeline</source>
+        <translation>කාලරේඛාවට එක් කරන්න</translation>
+    </message>
+    <message numerus="yes">
+        <source>Move %n items to folder…</source>
+        <translation>
+            <numerusform>අයිතම %n ක් ෆෝල්ඩරයට ගෙන යන්න…</numerusform>
+            <numerusform>අයිතම %n ක් ෆෝල්ඩරයට ගෙන යන්න…</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Remove %n items from project</source>
+        <translation>
+            <numerusform>අයිතම %n ක් ව්‍යාපෘතියෙන් ඉවත් කරන්න</numerusform>
+            <numerusform>අයිතම %n ක් ව්‍යාපෘතියෙන් ඉවත් කරන්න</numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_zh_Hans.ts
+++ b/i18n/drift_zh_Hans.ts
@@ -2831,6 +2831,22 @@
         <source>Media moved</source>
         <translation type="unfinished"></translation>
     </message>
+    <message numerus="yes">
+        <source>%n items removed</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items moved</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Clips added</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -2932,12 +2948,6 @@
     </message>
     <message numerus="yes">
         <source>Could not import any of the %n selected files.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>“%1” is still used by %n clips on the timeline.</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
@@ -3151,6 +3161,32 @@
     <message>
         <source>Create a new folder here</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>“%1” is still used by clips on the timeline.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n of the selected items are still used by clips on the timeline.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n items</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Remove these items?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>Removed %n items.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -5013,6 +5049,28 @@
     <message>
         <source>Delete</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>Add %n items to timeline</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Add to timeline</source>
+        <translation>加入进轨道内</translation>
+    </message>
+    <message numerus="yes">
+        <source>Move %n items to folder…</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Remove %n items from project</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/src/models/AppController.cpp
+++ b/src/models/AppController.cpp
@@ -2262,6 +2262,40 @@ bool AppController::removeAsset(int assetIndex)
     return true;
 }
 
+int AppController::removeAssets(const QStringList &assetIds)
+{
+    if (!m_assetLibrary || assetIds.isEmpty())
+        return 0;
+
+    // Refuse the whole batch if any id is still referenced by a clip — checked up front so
+    // this stays atomic (no partial removal) and holds even for a caller that bypasses the
+    // QML confirmation flow's own in-use check (AssetsPanel.qml's requestRemoveAsset).
+    for (const QString &id : assetIds) {
+        const int index = m_assetLibrary->indexOfId(id);
+        if (index >= 0 && clipCountForAsset(index) > 0)
+            return 0;
+    }
+
+    const drift::Project before = m_project;
+    int removed = 0;
+    for (const QString &id : assetIds) {
+        // Resolved fresh per id rather than upfront: removeAssetAt shifts every row after the
+        // one it removes, so an index captured before the loop started would drift out from
+        // under the ids that come after it.
+        const int index = m_assetLibrary->indexOfId(id);
+        if (index < 0)
+            continue;
+        if (m_assetLibrary->removeAssetAt(index))
+            ++removed;
+    }
+    if (removed == 0)
+        return 0;
+
+    setDraggingAssetIndex(-1);
+    pushProjectEdit(before, removed == 1 ? tr("Media removed") : tr("%n items removed", "", removed));
+    return removed;
+}
+
 bool AppController::renameAsset(int assetIndex, const QString &name)
 {
     if (!m_assetLibrary)
@@ -2363,6 +2397,27 @@ bool AppController::moveAssetToFolder(int assetIndex, const QString &folderId)
 
     pushProjectEdit(before, tr("Media moved"));
     return true;
+}
+
+int AppController::moveAssetsToFolder(const QStringList &assetIds, const QString &folderId)
+{
+    if (!m_assetLibrary || assetIds.isEmpty())
+        return 0;
+
+    const drift::Project before = m_project;
+    int moved = 0;
+    for (const QString &id : assetIds) {
+        const int index = m_assetLibrary->indexOfId(id);
+        if (index < 0)
+            continue;
+        if (m_assetLibrary->moveAssetToFolder(index, folderId))
+            ++moved;
+    }
+    if (moved == 0)
+        return 0;
+
+    pushProjectEdit(before, moved == 1 ? tr("Media moved") : tr("%n items moved", "", moved));
+    return moved;
 }
 
 bool AppController::replaceAssetSource(int assetIndex, const QUrl &url)
@@ -3555,6 +3610,75 @@ void AppController::addClipFromAsset(int assetIndex)
     pushProjectEdit(before, tr("Clip added"));
     finishEdit(tr("Clip added"));
     selectClip(trackIndex, track.clips.size() - 1);
+}
+
+void AppController::addClipsFromAssets(const QStringList &assetIds)
+{
+    if (!m_assetLibrary || assetIds.isEmpty())
+        return;
+
+    const drift::Project before = m_project;
+    // Advances by each clip's duration as it's placed, so the batch reads as one sequence
+    // rather than every clip landing at the playhead on top of each other. Shared across
+    // tracks: two clips of the same kind stay back to back; a kind change (video, then audio)
+    // still keeps its place in the sequence rather than resetting to the playhead.
+    drift::TimeUs cursor = m_playheadUs;
+    int lastTrackIndex = -1;
+    int lastClipIndex = -1;
+
+    for (const QString &id : assetIds) {
+        const int assetIndex = m_assetLibrary->indexOfId(id);
+        if (assetIndex < 0)
+            continue;
+
+        const QVariantMap asset = m_assetLibrary->assetAt(assetIndex);
+        if (asset.isEmpty())
+            continue;
+
+        const drift::ClipType clipType = drift::clipTypeFromString(asset.value(QStringLiteral("kind")).toString());
+        int trackIndex = drift::defaultTrackForClipType(m_project, clipType);
+        if (trackIndex < 0)
+            trackIndex = drift::ensureTrackForClipType(m_project, clipType, false);
+        if (trackIndex < 0)
+            continue;
+
+        drift::Track &track = m_project.tracks()[trackIndex];
+        if (!track.allowsClipType(clipType))
+            continue;
+
+        m_assetLibrary->ensureMedia(assetIndex);
+        const QString thumbnailPath = m_assetLibrary->thumbnailAt(assetIndex);
+        const QString filmstripPath = m_assetLibrary->filmstripAt(assetIndex);
+        const drift::TimeUs duration = clipDurationForAssetIndex(assetIndex);
+        const drift::TimeUs start =
+            drift::resolveClipStart(m_project, track, -1, cursor, duration, m_snapEnabled, cursor);
+
+        drift::Clip clip;
+        clip.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+        clip.assetId = m_assetLibrary->assetIdAt(assetIndex);
+        clip.type = clipType;
+        clip.name = asset.value(QStringLiteral("name")).toString();
+        clip.path = asset.value(QStringLiteral("path")).toString();
+        clip.thumbnailPath = thumbnailPath;
+        clip.filmstripPath = filmstripPath;
+        clip.timelineStart = start;
+        clip.timelineDuration = duration;
+        clip.srcIn = 0;
+        clip.srcOut = duration;
+        applyAssetLayout(clip, asset, m_project.width(), m_project.height());
+
+        track.clips.append(clip);
+        lastTrackIndex = trackIndex;
+        lastClipIndex = track.clips.size() - 1;
+        cursor = start + duration;
+    }
+
+    if (lastTrackIndex < 0)
+        return;
+
+    pushProjectEdit(before, tr("Clips added"));
+    finishEdit(tr("Clips added"));
+    selectClip(lastTrackIndex, lastClipIndex);
 }
 
 bool AppController::trackAcceptsAsset(int trackIndex, int assetIndex) const

--- a/src/models/AppController.h
+++ b/src/models/AppController.h
@@ -528,6 +528,11 @@ public:
     void setGuideType(const QString &type);
 
     Q_INVOKABLE void addClipFromAsset(int assetIndex);
+    // Multi-select "Add to timeline": each asset lands on its own kind-appropriate default
+    // track (creating one if needed, exactly like addClipFromAsset), placed back to back in
+    // the given order starting at the playhead — not all stacked on top of each other at the
+    // same start time. One undo step for the whole batch.
+    Q_INVOKABLE void addClipsFromAssets(const QStringList &assetIds);
     Q_INVOKABLE void addClipFromAssetAt(int assetIndex, int trackIndex, double atSeconds);
     Q_INVOKABLE void addClipFromAssetOnNewTrack(int assetIndex, double atSeconds);
     // Same, but the new track goes at insertIndex rather than always on top, so
@@ -535,6 +540,12 @@ public:
     Q_INVOKABLE void addClipFromAssetOnNewTrackAt(int assetIndex, int insertIndex, double atSeconds);
     Q_INVOKABLE int clipCountForAsset(int assetIndex) const;
     Q_INVOKABLE bool removeAsset(int assetIndex);
+    // Multi-select bulk removal, one undo step for the whole batch. Like removeAsset, refuses
+    // the whole batch if any id is still referenced by a clip (see clipCountForAsset) — the
+    // guard is enforced here, not just by the QML confirmation flow, so a caller that skips
+    // that flow can't orphan a timeline clip. Ids that no longer resolve are skipped.
+    // Returns how many were actually removed.
+    Q_INVOKABLE int removeAssets(const QStringList &assetIds);
     // Bin label only — does not rename the file on disk or rewrite clip names.
     Q_INVOKABLE bool renameAsset(int assetIndex, const QString &name);
     // Bin folder CRUD. parentId empty = bin root; nesting is arbitrary depth.
@@ -544,6 +555,8 @@ public:
     // removes it. Never blocks and never recurses into deleting contents.
     Q_INVOKABLE bool deleteBinFolder(const QString &folderId);
     Q_INVOKABLE bool moveAssetToFolder(int assetIndex, const QString &folderId);
+    // Multi-select bulk move, one undo step for the whole batch. Returns how many were moved.
+    Q_INVOKABLE int moveAssetsToFolder(const QStringList &assetIds, const QString &folderId);
     // Points an existing bin row at a different file, keeping every clip that uses it where it
     // is — its position, trim, effects and transitions all survive. Asynchronous: true only means
     // the probe started, and the outcome arrives as assetReplaceFinished.

--- a/src/qml/AssetsPanel.qml
+++ b/src/qml/AssetsPanel.qml
@@ -93,28 +93,78 @@ PanelFrame {
     // True while an import is running, so the panel can show progress.
     readonly property bool importing: AssetLibrary.importing
 
-    // Asset awaiting confirmation in confirmAssetRemoval. The name is held
-    // separately because the row is gone by the time the toast reports it.
-    property int pendingRemovalIndex: -1
-    property string pendingRemovalName: ""
+    // A single id goes through the existing single-asset add so that case is byte-for-byte the
+    // behavior it always was; only an actual multi-selection goes through the batch add, which
+    // places each clip back to back in selection order instead of stacking them all at the
+    // playhead.
+    function requestAddToTimeline(assetIds) {
+        if (assetIds.length === 0)
+            return
 
-    // Removing an asset a clip still points at would leave that clip playing
-    // but unable to trim past its cut or merge, so refuse rather than confirm.
-    function requestRemoveAsset(assetIndex) {
-        const inUse = EditorState.clipCountForAsset(assetIndex)
-        const name = AssetLibrary.assetAt(assetIndex).name
-        if (inUse > 0) {
-            Toasts.warning(qsTr("“%1” is still used by %n clips on the timeline.", "", inUse).arg(name))
+        function runAdd() {
+            if (assetIds.length === 1)
+                EditorState.addClipFromAsset(AssetLibrary.indexOfId(assetIds[0]))
+            else
+                EditorState.addClipsFromAssets(assetIds)
+        }
+
+        // On a pristine project, the first video/image clip offers to set up the canvas
+        // (resolution/orientation) — same flow as dragging onto the timeline (see
+        // TimelinePanel.qml/AndroidTimeline.qml). For a multi-selection, offer it from the
+        // first asset that actually needs it, not always assetIds[0].
+        if (typeof Window === "undefined" || !Window.window || !Window.window.configureAndAddAsset) {
+            runAdd()
             return
         }
-        root.pendingRemovalIndex = assetIndex
-        root.pendingRemovalName = name
+        for (const id of assetIds) {
+            const index = AssetLibrary.indexOfId(id)
+            if (index >= 0 && EditorState.shouldConfigureProjectForAsset(index)) {
+                Window.window.configureAndAddAsset(index, runAdd)
+                return
+            }
+        }
+        runAdd()
+    }
+
+    // Asset ids awaiting confirmation in confirmAssetRemoval — a single-element array for a
+    // plain right-click, or the whole multi-selection. The label is held separately because
+    // the rows are gone by the time the toast reports on them.
+    property var pendingRemovalIds: []
+    property string pendingRemovalLabel: ""
+
+    // Removing an asset a clip still points at would leave that clip playing but unable to
+    // trim past its cut or merge, so refuse rather than confirm — for a bulk removal, refusing
+    // the whole batch over one in-use item beats silently dropping it and surprising the user
+    // with a smaller removal than they asked for.
+    function requestRemoveAsset(assetIds) {
+        const names = []
+        const inUseNames = []
+        for (const id of assetIds) {
+            const index = AssetLibrary.indexOfId(id)
+            if (index < 0)
+                continue
+            const name = AssetLibrary.assetAt(index).name
+            names.push(name)
+            if (EditorState.clipCountForAsset(index) > 0)
+                inUseNames.push(name)
+        }
+        if (inUseNames.length > 0) {
+            Toasts.warning(inUseNames.length === 1
+                ? qsTr("“%1” is still used by clips on the timeline.").arg(inUseNames[0])
+                : qsTr("%n of the selected items are still used by clips on the timeline.",
+                       "", inUseNames.length))
+            return
+        }
+        if (names.length === 0)
+            return
+        root.pendingRemovalIds = assetIds
+        root.pendingRemovalLabel = names.length === 1 ? names[0] : qsTr("%n items", "", names.length)
         confirmAssetRemoval.open()
     }
 
     ThemedDialog {
         id: confirmAssetRemoval
-        title: qsTr("Remove this media?")
+        title: root.pendingRemovalIds.length === 1 ? qsTr("Remove this media?") : qsTr("Remove these items?")
         acceptText: qsTr("Remove")
         acceptVariant: "destructive"
         preferredWidth: Theme.dialogWidthSm
@@ -126,15 +176,19 @@ PanelFrame {
             wrapMode: Text.WordWrap
             size: "sm"
             text: qsTr("“%1” will be removed from this project. The file on disk is not deleted.")
-                  .arg(root.pendingRemovalName)
+                  .arg(root.pendingRemovalLabel)
         }
 
         onAccepted: {
-            if (EditorState.removeAsset(root.pendingRemovalIndex))
-                Toasts.success(qsTr("Removed “%1”.").arg(root.pendingRemovalName))
-            root.pendingRemovalIndex = -1
+            const removed = EditorState.removeAssets(root.pendingRemovalIds)
+            if (removed > 0) {
+                Toasts.success(removed === 1
+                    ? qsTr("Removed “%1”.").arg(root.pendingRemovalLabel)
+                    : qsTr("Removed %n items.", "", removed))
+            }
+            root.pendingRemovalIds = []
         }
-        onRejected: root.pendingRemovalIndex = -1
+        onRejected: root.pendingRemovalIds = []
     }
 
     property int pendingRenameIndex: -1
@@ -263,15 +317,18 @@ PanelFrame {
         onRejected: root.pendingFolderRenameId = ""
     }
 
-    // The "move to folder" path — right-click on a card, choose a destination from a flat list.
-    property int pendingMoveAssetIndex: -1
-    // The folder the asset is in right now, so the picker can omit it — moving it "into" the
-    // folder it's already in isn't a real destination.
+    // The "move to folder" path — right-click on a card (or a multi-selection), choose a
+    // destination from a flat list.
+    property var pendingMoveAssetIds: []
+    // The folder every selected asset is in right now, so the picker can omit it — moving them
+    // "into" the folder they're already in isn't a real destination. A single common value is
+    // safe here (not a per-asset lookup): MediaAssetsTab's grid only ever shows one folder's
+    // contents at a time, so anything selectable there already shares this folder.
     property string pendingMoveAssetCurrentFolderId: ""
 
-    function requestMoveAssetToFolder(assetIndex) {
-        root.pendingMoveAssetIndex = assetIndex
-        root.pendingMoveAssetCurrentFolderId = AssetLibrary.assetAt(assetIndex).folderId || ""
+    function requestMoveAssetToFolder(assetIds) {
+        root.pendingMoveAssetIds = assetIds
+        root.pendingMoveAssetCurrentFolderId = EditorState.currentBinFolderId
         folderPickerDialog.open()
     }
 
@@ -358,9 +415,9 @@ PanelFrame {
                         }
 
                         onClicked: {
-                            if (root.pendingMoveAssetIndex >= 0)
-                                EditorState.moveAssetToFolder(root.pendingMoveAssetIndex, optionRow.modelData.id)
-                            root.pendingMoveAssetIndex = -1
+                            if (root.pendingMoveAssetIds.length > 0)
+                                EditorState.moveAssetsToFolder(root.pendingMoveAssetIds, optionRow.modelData.id)
+                            root.pendingMoveAssetIds = []
                             folderPickerDialog.close()
                         }
                     }
@@ -1172,6 +1229,7 @@ PanelFrame {
 
             // Shared media browser used by the Media tab.
             MediaAssetsTab {
+                id: mediaAssetsTab
                 visible: kindsForTab(tabsModel.get(activeTab).tabId).length > 0
                 width: parent.width
                 opacity: root.tabOpacity
@@ -1183,12 +1241,13 @@ PanelFrame {
                     if (typeof Window !== "undefined" && Window.window && Window.window.openMediaPreview)
                         Window.window.openMediaPreview(assetIndex)
                 }
-                onRemoveRequested: (assetIndex) => root.requestRemoveAsset(assetIndex)
+                onAddToTimelineRequested: (assetIds) => root.requestAddToTimeline(assetIds)
+                onRemoveRequested: (assetIds) => root.requestRemoveAsset(assetIds)
                 onReplaceRequested: (assetIndex) => root.requestReplaceAsset(assetIndex)
                 onRenameRequested: (assetIndex) => root.requestRenameAsset(assetIndex)
                 onExportRequested: (assetIndex) => root.requestExportAsset(assetIndex)
                 onImportRequested: root.importMedia()
-                onMoveToFolderRequested: (assetIndex) => root.requestMoveAssetToFolder(assetIndex)
+                onMoveToFolderRequested: (assetIds) => root.requestMoveAssetToFolder(assetIds)
                 onFolderRenameRequested: (folderId, folderName) => root.requestRenameFolder(folderId, folderName)
             }
         }

--- a/src/qml/components/assets/MediaAssetsTab.qml
+++ b/src/qml/components/assets/MediaAssetsTab.qml
@@ -63,6 +63,7 @@ Item {
     }
     function clearAssetSelection() {
         root.selectedAssetIds = []
+        root.selectionAnchorId = ""
     }
     function toggleAssetSelection(assetId) {
         const at = root.selectedAssetIds.indexOf(assetId)
@@ -81,13 +82,58 @@ Item {
             root.selectOnlyAsset(assetId)
     }
 
+    // Anchor for Shift-click range selection: the asset id from the last plain or Ctrl/Cmd
+    // click. A Shift-click itself doesn't move it, so a run of Shift-clicks grows or shrinks
+    // the same range instead of walking it forward each time.
+    property string selectionAnchorId: ""
+
+    // combinedItems in visual/tab order, assets only — folders can't be range-selected and
+    // never appear in selectedAssetIds.
+    function orderedAssetIds() {
+        const ids = []
+        for (let i = 0; i < root.combinedItems.length; ++i) {
+            const item = root.combinedItems[i]
+            if (!item.isFolder)
+                ids.push(item.assetId)
+        }
+        return ids
+    }
+
+    // Adds every asset between anchorId and targetId (inclusive of both ends) to the
+    // selection, in whatever order they currently render in. Purely additive — ids already
+    // selected outside the range are left alone, matching how every other selection tool
+    // in this bin (Ctrl-click, bulk menu actions) never silently drops a prior pick.
+    function selectAssetRange(anchorId, targetId) {
+        const order = root.orderedAssetIds()
+        const anchorAt = order.indexOf(anchorId)
+        const targetAt = order.indexOf(targetId)
+        if (anchorAt < 0 || targetAt < 0) {
+            // No valid anchor to range from — fall back to a plain-click selection, and
+            // promote the target to the new anchor so the next Shift-click ranges from
+            // here instead of silently repeating this fallback.
+            root.selectOnlyAsset(targetId)
+            root.selectionAnchorId = targetId
+            return
+        }
+        const lo = Math.min(anchorAt, targetAt)
+        const hi = Math.max(anchorAt, targetAt)
+        const next = root.selectedAssetIds.slice()
+        for (let i = lo; i <= hi; ++i) {
+            if (next.indexOf(order[i]) < 0)
+                next.push(order[i])
+        }
+        root.selectedAssetIds = next
+    }
+
     // Prunes ids that dropped out of view — removed, moved to a different folder, filtered out
     // by search/kind, or the folder was navigated away from (combinedItems is scoped to the
-    // current folder, so leaving it empties out every id that was in it). Reassigning only when
-    // something actually changed avoids spamming dependents of selectedAssetIds on every
-    // unrelated combinedItems recompute.
+    // current folder, so leaving it empties out every id that was in it). Also drops the range
+    // anchor if it dropped out along with them — left stale, it would make every future
+    // Shift-click silently fall back to a single-item selection instead of a range. Reassigning
+    // only when something actually changed avoids spamming dependents on every unrelated
+    // combinedItems recompute.
     onCombinedItemsChanged: {
-        if (root.selectedAssetIds.length === 0)
+        if (root.selectedAssetIds.length === 0 && root.selectionAnchorId.length === 0)
             return
         const present = {}
         for (let i = 0; i < root.combinedItems.length; ++i) {
@@ -98,6 +144,8 @@ Item {
         const pruned = root.selectedAssetIds.filter(id => present[id] === true)
         if (pruned.length !== root.selectedAssetIds.length)
             root.selectedAssetIds = pruned
+        if (root.selectionAnchorId.length > 0 && present[root.selectionAnchorId] !== true)
+            root.selectionAnchorId = ""
     }
 
     // Bumped on every project edit (rename, folder create/delete/reparent, move-to-folder,
@@ -417,10 +465,16 @@ Item {
                             return
                         // Qt remaps ControlModifier to Cmd on macOS, so this is already the
                         // right "system key" on every desktop platform without branching.
-                        if ((leftTap.point.modifiers & Qt.ControlModifier) !== 0)
+                        const mods = leftTap.point.modifiers
+                        if ((mods & Qt.ShiftModifier) !== 0) {
+                            root.selectAssetRange(root.selectionAnchorId || cardRoot.assetId, cardRoot.assetId)
+                        } else if ((mods & Qt.ControlModifier) !== 0) {
                             root.toggleAssetSelection(cardRoot.assetId)
-                        else
+                            root.selectionAnchorId = cardRoot.assetId
+                        } else {
                             root.selectOnlyAsset(cardRoot.assetId)
+                            root.selectionAnchorId = cardRoot.assetId
+                        }
                     }
                     onDoubleTapped: if (cardRoot.isFolder) EditorState.currentBinFolderId = cardRoot.folderId
                     onLongPressed: cardRoot.isFolder ? folderMenu.popup() : cardMenu.popup()
@@ -741,10 +795,16 @@ Item {
                     onTapped: {
                         if (listRow.isFolder)
                             return
-                        if ((leftRowTap.point.modifiers & Qt.ControlModifier) !== 0)
+                        const mods = leftRowTap.point.modifiers
+                        if ((mods & Qt.ShiftModifier) !== 0) {
+                            root.selectAssetRange(root.selectionAnchorId || listRow.assetId, listRow.assetId)
+                        } else if ((mods & Qt.ControlModifier) !== 0) {
                             root.toggleAssetSelection(listRow.assetId)
-                        else
+                            root.selectionAnchorId = listRow.assetId
+                        } else {
                             root.selectOnlyAsset(listRow.assetId)
+                            root.selectionAnchorId = listRow.assetId
+                        }
                     }
                     onDoubleTapped: if (listRow.isFolder) EditorState.currentBinFolderId = listRow.folderId
                     onLongPressed: listRow.isFolder ? folderRowMenu.popup() : rowMenu.popup()

--- a/src/qml/components/assets/MediaAssetsTab.qml
+++ b/src/qml/components/assets/MediaAssetsTab.qml
@@ -18,11 +18,16 @@ Item {
     property var assetVisibleFn: function(kind) { return true }
     readonly property string query: search.text.trim().toLowerCase()
 
+    // Emitted from the card/row context menu — adds the selected asset(s) to the timeline in
+    // selection order. The parent routes a single id to the existing single-asset add so that
+    // case behaves exactly as it always has; a multi-selection goes through the batch add.
+    signal addToTimelineRequested(var assetIds)
     // Emitted from the card/row context menu. Opens the preview/edit window.
     signal previewRequested(int assetIndex)
-    // Emitted from the card/row context menu. The parent owns the in-use
-    // check and the confirmation.
-    signal removeRequested(int assetIndex)
+    // Emitted from the card/row context menu. Carries every selected asset's id, not just the
+    // one clicked — see selectedAssetIds below. The parent owns the in-use check and the
+    // confirmation.
+    signal removeRequested(var assetIds)
     // Emitted from the card/row context menu. The parent owns the file picker.
     signal replaceRequested(int assetIndex)
     // Emitted from the card/row context menu. The parent owns the rename dialog.
@@ -32,11 +37,68 @@ Item {
     // Emitted when the empty-state action asks to import media.
     signal importRequested()
     // Emitted from the card/row context menu — the only way to move an asset into a folder;
-    // there is no drag-onto-a-folder-tile path on desktop or touch. The parent owns the
+    // there is no drag-onto-a-folder-tile path on desktop or touch. Carries every selected
+    // asset's id, not just the one clicked — see selectedAssetIds below. The parent owns the
     // folder-picker dialog.
-    signal moveToFolderRequested(int assetIndex)
+    signal moveToFolderRequested(var assetIds)
     // Emitted from a folder tile's context menu. The parent owns the rename dialog.
     signal folderRenameRequested(string folderId, string folderName)
+
+    // Multi-select, by asset id rather than position: assetIndex is a live row position that
+    // shifts on removal/reorder, so an id survives everything except the asset itself going
+    // away. Folders are never selectable — only individual media items are, per the request
+    // this was built for. Plain click replaces the selection with just that card; Ctrl/Cmd+click
+    // (Qt remaps ControlModifier to Cmd on macOS already, so no platform branch is needed) toggles
+    // one card in or out of it. Right-click (or touch's tap-for-menu) on a card already in the
+    // selection keeps the whole selection and extends the bulk menu items to it; on a card that
+    // isn't, it replaces the selection with just that card first, matching how the timeline's
+    // clip selection already treats a right-click (TimelineClipItem.qml).
+    property var selectedAssetIds: []
+
+    function isAssetSelected(assetId) {
+        return assetId.length > 0 && root.selectedAssetIds.indexOf(assetId) >= 0
+    }
+    function selectOnlyAsset(assetId) {
+        root.selectedAssetIds = [assetId]
+    }
+    function clearAssetSelection() {
+        root.selectedAssetIds = []
+    }
+    function toggleAssetSelection(assetId) {
+        const at = root.selectedAssetIds.indexOf(assetId)
+        if (at < 0) {
+            root.selectedAssetIds = root.selectedAssetIds.concat([assetId])
+        } else {
+            const next = root.selectedAssetIds.slice()
+            next.splice(at, 1)
+            root.selectedAssetIds = next
+        }
+    }
+    // Ensures `assetId` is part of the selection before a menu opens on it, without disturbing
+    // an existing multi-selection it's already a member of.
+    function ensureAssetSelected(assetId) {
+        if (!root.isAssetSelected(assetId))
+            root.selectOnlyAsset(assetId)
+    }
+
+    // Prunes ids that dropped out of view — removed, moved to a different folder, filtered out
+    // by search/kind, or the folder was navigated away from (combinedItems is scoped to the
+    // current folder, so leaving it empties out every id that was in it). Reassigning only when
+    // something actually changed avoids spamming dependents of selectedAssetIds on every
+    // unrelated combinedItems recompute.
+    onCombinedItemsChanged: {
+        if (root.selectedAssetIds.length === 0)
+            return
+        const present = {}
+        for (let i = 0; i < root.combinedItems.length; ++i) {
+            const item = root.combinedItems[i]
+            if (!item.isFolder)
+                present[item.assetId] = true
+        }
+        const pruned = root.selectedAssetIds.filter(id => present[id] === true)
+        if (pruned.length !== root.selectedAssetIds.length)
+            root.selectedAssetIds = pruned
+    }
 
     // Bumped on every project edit (rename, folder create/delete/reparent, move-to-folder,
     // undo/redo — anything that goes through pushProjectEdit) and on every async metadata
@@ -87,6 +149,7 @@ Item {
             items.push({
                 isFolder: true,
                 folderId: folder.id,
+                assetId: "",
                 name: folder.name,
                 assetIndex: -1,
                 kind: "",
@@ -109,6 +172,7 @@ Item {
             items.push({
                 isFolder: false,
                 folderId: "",
+                assetId: asset.id,
                 name: asset.name,
                 assetIndex: asset.assetIndex,
                 kind: asset.kind,
@@ -139,6 +203,7 @@ Item {
 
             required property bool isFolder
             required property string folderId
+            required property string assetId
             required property string name
             required property string kind
             required property string duration
@@ -147,6 +212,8 @@ Item {
             required property string thumbnailPath
             required property string filmstripPath
             required property int assetIndex
+
+            readonly property bool selected: !isFolder && root.isAssetSelected(assetId)
 
             // Lift on grab: dims and grows slightly, so the card reads as
             // picked up rather than just sitting there while a ghost moves.
@@ -195,7 +262,9 @@ Item {
                 radius: Theme.radiusSm
                 color: Theme.panelAccent
                 clip: true
-                border.width: cardHover.hovered ? Theme.borderWidth : 0
+                // Hover ring only here; the selection ring is a separate overlay
+                // (below) so it always paints on top of the thumbnail image.
+                border.width: (!cardRoot.selected && cardHover.hovered) ? Theme.borderWidth : 0
                 border.color: Theme.primary
                 scale: (!cardRoot.isFolder && cardHover.hovered) ? 1.03 : 1.0
 
@@ -311,6 +380,24 @@ Item {
                     }
                 }
 
+                // A dedicated overlay for the selection ring, painted above the
+                // thumbnail image and busy scrim (both earlier siblings) so it
+                // is never covered by them. Square corners on purpose — a
+                // rounded ring here reads chunkier than the thumbnail's own
+                // radius at this border width.
+                Rectangle {
+                    z: 2
+                    anchors.fill: parent
+                    radius: 0
+                    color: "transparent"
+                    border.width: cardRoot.selected ? Theme.clipSelectionRingWidth : 0
+                    border.color: Theme.primary
+
+                    Behavior on border.width {
+                        NumberAnimation { duration: Theme.durationFast; easing.type: Theme.easing }
+                    }
+                }
+
                 // Both handlers live on this child, not on the Column
                 // that owns the Drag attached property. With them on the
                 // Column, QDrag::exec() ungrabs the very item Drag.active
@@ -320,10 +407,21 @@ Item {
                 // property active", and the drag dies mid-flight.
                 // EffectBrowser and ShapesTab already nest them this way.
                 TapHandler {
+                    id: leftTap
                     acceptedButtons: Qt.LeftButton
                     // Touch keeps press-and-hold for the lift below — the menu
                     // is a tap there.
                     enabled: !Theme.touchUi && !assetDrag.active
+                    onTapped: {
+                        if (cardRoot.isFolder)
+                            return
+                        // Qt remaps ControlModifier to Cmd on macOS, so this is already the
+                        // right "system key" on every desktop platform without branching.
+                        if ((leftTap.point.modifiers & Qt.ControlModifier) !== 0)
+                            root.toggleAssetSelection(cardRoot.assetId)
+                        else
+                            root.selectOnlyAsset(cardRoot.assetId)
+                    }
                     onDoubleTapped: if (cardRoot.isFolder) EditorState.currentBinFolderId = cardRoot.folderId
                     onLongPressed: cardRoot.isFolder ? folderMenu.popup() : cardMenu.popup()
                 }
@@ -351,7 +449,19 @@ Item {
                 }
                 TapHandler {
                     acceptedButtons: Qt.RightButton
-                    onTapped: cardRoot.isFolder ? folderMenu.popup() : cardMenu.popup()
+                    onTapped: {
+                        if (cardRoot.isFolder) {
+                            folderMenu.popup()
+                            return
+                        }
+                        // Right-clicking a card that's part of the current multi-selection
+                        // extends the bulk menu items to all of it; right-clicking anything
+                        // else replaces the selection with just that card first — same
+                        // "select if not already selected" rule the timeline's clip right-click
+                        // already uses (TimelineClipItem.qml).
+                        root.ensureAssetSelected(cardRoot.assetId)
+                        cardMenu.popup()
+                    }
                 }
 
                 // Hold to carry the asset onto the timeline, tap for the menu. The phone's
@@ -369,12 +479,30 @@ Item {
                     glyph: kind === "audio" ? Theme.icons.music
                             : kind === "image" ? Theme.icons.image
                             : Theme.icons.film
-                    onLiftTapped: cardRoot.isFolder ? folderMenu.popup() : cardMenu.popup()
+                    onLiftTapped: {
+                        if (cardRoot.isFolder) {
+                            folderMenu.popup()
+                            return
+                        }
+                        // Touch has no modifier-key multi-select, so a lift-tap always means
+                        // "just this card" unless it's already part of a selection built some
+                        // other way (there isn't one yet, but this keeps the same rule as the
+                        // desktop right-click rather than special-casing touch).
+                        root.ensureAssetSelected(cardRoot.assetId)
+                        cardMenu.popup()
+                    }
                 }
 
                 ThemedContextMenu {
                     id: cardMenu
 
+                    ThemedMenuItem {
+                        text: root.selectedAssetIds.length > 1
+                              ? qsTr("Add %n items to timeline", "", root.selectedAssetIds.length)
+                              : qsTr("Add to timeline")
+                        icon.name: Theme.icons.plus
+                        onTriggered: root.addToTimelineRequested(root.selectedAssetIds)
+                    }
                     ThemedMenuItem {
                         text: qsTr("Preview and edit…")
                         icon.name: Theme.icons.eye
@@ -383,18 +511,24 @@ Item {
                     ThemedMenuItem {
                         text: qsTr("Rename…")
                         icon.name: Theme.icons.pencil
+                        visible: root.selectedAssetIds.length <= 1
                         onTriggered: root.renameRequested(assetIndex)
                     }
                     ThemedMenuItem {
                         text: qsTr("Replace media…")
                         icon.name: Theme.icons.refresh
+                        visible: root.selectedAssetIds.length <= 1
                         onTriggered: root.replaceRequested(assetIndex)
                     }
                     ThemedMenuItem {
-                        text: qsTr("Move to folder…")
+                        // "the selection" once it covers more than the clicked card — matches
+                        // the count the bulk actions below will actually act on.
+                        text: root.selectedAssetIds.length > 1
+                              ? qsTr("Move %n items to folder…", "", root.selectedAssetIds.length)
+                              : qsTr("Move to folder…")
                         icon.name: Theme.icons.folder
                         visible: BinFolderModel.count > 0
-                        onTriggered: root.moveToFolderRequested(assetIndex)
+                        onTriggered: root.moveToFolderRequested(root.selectedAssetIds)
                     }
                     ThemedMenuItem {
                         text: qsTr("Export image…")
@@ -403,9 +537,11 @@ Item {
                         onTriggered: root.exportRequested(assetIndex)
                     }
                     ThemedMenuItem {
-                        text: qsTr("Remove from project")
+                        text: root.selectedAssetIds.length > 1
+                              ? qsTr("Remove %n items from project", "", root.selectedAssetIds.length)
+                              : qsTr("Remove from project")
                         icon.name: Theme.icons.trash
-                        onTriggered: root.removeRequested(assetIndex)
+                        onTriggered: root.removeRequested(root.selectedAssetIds)
                     }
                 }
 
@@ -450,6 +586,9 @@ Item {
             height: 48
             radius: Theme.radiusSm
             color: rowHover.hovered ? Theme.popoverHover : Theme.panelAccent
+            // Matches the grid card's selection ring.
+            border.width: listRow.selected ? Theme.clipSelectionRingWidth : 0
+            border.color: Theme.primary
             opacity: rowDrag.active ? 0.85 : 1
             scale: rowDrag.active ? 1.02 : 1.0
 
@@ -462,9 +601,13 @@ Item {
             Behavior on scale {
                 NumberAnimation { duration: Theme.durationFast; easing.type: Theme.easing }
             }
+            Behavior on border.width {
+                NumberAnimation { duration: Theme.durationFast; easing.type: Theme.easing }
+            }
 
             required property bool isFolder
             required property string folderId
+            required property string assetId
             required property string name
             required property string kind
             required property string duration
@@ -473,6 +616,7 @@ Item {
             readonly property bool replaceBusy:
                 !isFolder && EditorState.replacingAssetId.length > 0
                 && EditorState.replacingAssetId === AssetLibrary.assetIdAt(assetIndex)
+            readonly property bool selected: !isFolder && root.isAssetSelected(assetId)
 
             Drag.active: !isFolder && rowDrag.active
             Drag.dragType: Drag.Automatic
@@ -591,8 +735,17 @@ Item {
                 enabled: !replaceBusy
 
                 TapHandler {
+                    id: leftRowTap
                     acceptedButtons: Qt.LeftButton
                     enabled: !Theme.touchUi && !rowDrag.active
+                    onTapped: {
+                        if (listRow.isFolder)
+                            return
+                        if ((leftRowTap.point.modifiers & Qt.ControlModifier) !== 0)
+                            root.toggleAssetSelection(listRow.assetId)
+                        else
+                            root.selectOnlyAsset(listRow.assetId)
+                    }
                     onDoubleTapped: if (listRow.isFolder) EditorState.currentBinFolderId = listRow.folderId
                     onLongPressed: listRow.isFolder ? folderRowMenu.popup() : rowMenu.popup()
                 }
@@ -614,7 +767,14 @@ Item {
                 }
                 TapHandler {
                     acceptedButtons: Qt.RightButton
-                    onTapped: listRow.isFolder ? folderRowMenu.popup() : rowMenu.popup()
+                    onTapped: {
+                        if (listRow.isFolder) {
+                            folderRowMenu.popup()
+                            return
+                        }
+                        root.ensureAssetSelected(listRow.assetId)
+                        rowMenu.popup()
+                    }
                 }
 
                 // See the grid card: hold lifts, tap opens the menu — also a folder row's
@@ -628,13 +788,27 @@ Item {
                     glyph: kind === "audio" ? Theme.icons.music
                             : kind === "image" ? Theme.icons.image
                             : Theme.icons.film
-                    onLiftTapped: listRow.isFolder ? folderRowMenu.popup() : rowMenu.popup()
+                    onLiftTapped: {
+                        if (listRow.isFolder) {
+                            folderRowMenu.popup()
+                            return
+                        }
+                        root.ensureAssetSelected(listRow.assetId)
+                        rowMenu.popup()
+                    }
                 }
             }
 
             ThemedContextMenu {
                 id: rowMenu
 
+                ThemedMenuItem {
+                    text: root.selectedAssetIds.length > 1
+                          ? qsTr("Add %n items to timeline", "", root.selectedAssetIds.length)
+                          : qsTr("Add to timeline")
+                    icon.name: Theme.icons.plus
+                    onTriggered: root.addToTimelineRequested(root.selectedAssetIds)
+                }
                 ThemedMenuItem {
                     text: qsTr("Preview and edit…")
                     icon.name: Theme.icons.eye
@@ -643,18 +817,22 @@ Item {
                 ThemedMenuItem {
                     text: qsTr("Rename…")
                     icon.name: Theme.icons.pencil
+                    visible: root.selectedAssetIds.length <= 1
                     onTriggered: root.renameRequested(assetIndex)
                 }
                 ThemedMenuItem {
                     text: qsTr("Replace media…")
                     icon.name: Theme.icons.refresh
+                    visible: root.selectedAssetIds.length <= 1
                     onTriggered: root.replaceRequested(assetIndex)
                 }
                 ThemedMenuItem {
-                    text: qsTr("Move to folder…")
+                    text: root.selectedAssetIds.length > 1
+                          ? qsTr("Move %n items to folder…", "", root.selectedAssetIds.length)
+                          : qsTr("Move to folder…")
                     icon.name: Theme.icons.folder
                     visible: BinFolderModel.count > 0
-                    onTriggered: root.moveToFolderRequested(assetIndex)
+                    onTriggered: root.moveToFolderRequested(root.selectedAssetIds)
                 }
                 ThemedMenuItem {
                     text: qsTr("Export image…")
@@ -663,9 +841,11 @@ Item {
                     onTriggered: root.exportRequested(assetIndex)
                 }
                 ThemedMenuItem {
-                    text: qsTr("Remove from project")
+                    text: root.selectedAssetIds.length > 1
+                          ? qsTr("Remove %n items from project", "", root.selectedAssetIds.length)
+                          : qsTr("Remove from project")
                     icon.name: Theme.icons.trash
-                    onTriggered: root.removeRequested(assetIndex)
+                    onTriggered: root.removeRequested(root.selectedAssetIds)
                 }
             }
 

--- a/tests/tst_editorstate.cpp
+++ b/tests/tst_editorstate.cpp
@@ -62,6 +62,10 @@ private slots:
     void importUnreadableUrlReportsFailed();
     void moveAssetToFolderAndUndo();
     void deleteBinFolderMovesChildrenAndUndo();
+    void removeAssetsIsOneUndoStep();
+    void removeAssetsRefusesBatchWithInUseAsset();
+    void moveAssetsToFolderIsOneUndoStep();
+    void addClipsFromAssetsPlacesThemSequentially();
     void moveTrackReordersAndRemapsSelection();
     void addTrackInsertsEmptyTrackByType();
     void projectPersistenceRoundTrip();
@@ -527,6 +531,154 @@ void EditorStateTest::deleteBinFolderMovesChildrenAndUndo()
     state.undo();
     QCOMPARE(state.binFolderModel()->count(), 2);
     QCOMPARE(library.assetAt(0).value(QStringLiteral("folderId")).toString(), childId);
+}
+
+void EditorStateTest::removeAssetsIsOneUndoStep()
+{
+    AssetLibrary library;
+    AppController state(&library);
+
+    for (int i = 0; i < 3; ++i) {
+        drift::MediaAsset asset;
+        asset.id = QStringLiteral("asset-%1").arg(i);
+        asset.name = QStringLiteral("clip-%1.mp4").arg(i);
+        asset.path = QStringLiteral("/tmp/clip-%1.mp4").arg(i);
+        asset.kind = drift::MediaKind::Video;
+        state.project()->assets().insert(asset.id, asset);
+        state.project()->assetOrder().append(asset.id);
+    }
+    library.syncToProject();
+    QCOMPARE(library.count(), 3);
+
+    // Removed out of position order deliberately — removeAssets must resolve each id fresh
+    // rather than trusting indices captured before earlier removals shifted the rest down.
+    const int removed = state.removeAssets({QStringLiteral("asset-2"), QStringLiteral("asset-0")});
+    QCOMPARE(removed, 2);
+    QCOMPARE(library.count(), 1);
+    QCOMPARE(library.assetAt(0).value(QStringLiteral("id")).toString(), QStringLiteral("asset-1"));
+
+    // One undo step restores both, not one step per asset.
+    state.undo();
+    QCOMPARE(library.count(), 3);
+}
+
+void EditorStateTest::removeAssetsRefusesBatchWithInUseAsset()
+{
+    AssetLibrary library;
+    AppController state(&library);
+    drift::Project &project = *state.project();
+
+    for (int i = 0; i < 3; ++i) {
+        drift::MediaAsset asset;
+        asset.id = QStringLiteral("asset-%1").arg(i);
+        asset.name = QStringLiteral("clip-%1.mp4").arg(i);
+        asset.path = QStringLiteral("/tmp/clip-%1.mp4").arg(i);
+        asset.kind = drift::MediaKind::Video;
+        project.assets().insert(asset.id, asset);
+        project.assetOrder().append(asset.id);
+    }
+
+    // asset-1 is still referenced by a clip on the timeline.
+    drift::Clip clip;
+    clip.id = QStringLiteral("clip-0");
+    clip.assetId = QStringLiteral("asset-1");
+    clip.type = drift::ClipType::Video;
+    clip.timelineStart = 0;
+    clip.timelineDuration = drift::secondsToUs(2.0);
+    drift::Track track{.type = drift::TrackType::Video};
+    track.clips.append(clip);
+    project.tracks().append(track);
+    library.syncToProject();
+    QCOMPARE(library.count(), 3);
+
+    // One in-use id anywhere in the batch must refuse the whole removal, not just skip
+    // that one id — otherwise a caller that bypasses the QML confirmation flow's own
+    // in-use check (AssetsPanel.qml's requestRemoveAsset) could orphan the clip above.
+    const int removed = state.removeAssets(
+        {QStringLiteral("asset-0"), QStringLiteral("asset-1"), QStringLiteral("asset-2")});
+    QCOMPARE(removed, 0);
+    QCOMPARE(library.count(), 3);
+}
+
+void EditorStateTest::moveAssetsToFolderIsOneUndoStep()
+{
+    AssetLibrary library;
+    AppController state(&library);
+
+    const QString folderId = state.createBinFolder(QStringLiteral("B-Roll"), QString());
+    for (int i = 0; i < 2; ++i) {
+        drift::MediaAsset asset;
+        asset.id = QStringLiteral("asset-%1").arg(i);
+        asset.name = QStringLiteral("clip-%1.mp4").arg(i);
+        asset.path = QStringLiteral("/tmp/clip-%1.mp4").arg(i);
+        asset.kind = drift::MediaKind::Video;
+        state.project()->assets().insert(asset.id, asset);
+        state.project()->assetOrder().append(asset.id);
+    }
+    library.syncToProject();
+
+    const int moved = state.moveAssetsToFolder(
+        {QStringLiteral("asset-0"), QStringLiteral("asset-1")}, folderId);
+    QCOMPARE(moved, 2);
+    QCOMPARE(library.assetAt(0).value(QStringLiteral("folderId")).toString(), folderId);
+    QCOMPARE(library.assetAt(1).value(QStringLiteral("folderId")).toString(), folderId);
+
+    state.undo();
+    QCOMPARE(library.assetAt(0).value(QStringLiteral("folderId")).toString(), QString());
+    QCOMPARE(library.assetAt(1).value(QStringLiteral("folderId")).toString(), QString());
+}
+
+void EditorStateTest::addClipsFromAssetsPlacesThemSequentially()
+{
+    AssetLibrary library;
+    AppController state(&library);
+    state.setPlayheadSeconds(0.0);
+
+    drift::MediaAsset first;
+    first.id = QStringLiteral("asset-0");
+    first.name = QStringLiteral("first.mp4");
+    first.path = QStringLiteral("/tmp/first.mp4");
+    first.kind = drift::MediaKind::Video;
+    first.durationUs = drift::secondsToUs(4.0);
+    state.project()->assets().insert(first.id, first);
+    state.project()->assetOrder().append(first.id);
+
+    drift::MediaAsset second;
+    second.id = QStringLiteral("asset-1");
+    second.name = QStringLiteral("second.mp4");
+    second.path = QStringLiteral("/tmp/second.mp4");
+    second.kind = drift::MediaKind::Video;
+    second.durationUs = drift::secondsToUs(2.0);
+    state.project()->assets().insert(second.id, second);
+    state.project()->assetOrder().append(second.id);
+    library.syncToProject();
+
+    state.addClipsFromAssets({QStringLiteral("asset-0"), QStringLiteral("asset-1")});
+
+    // Both land on the same default video track, back to back in the order given — not both
+    // sitting at the playhead on top of each other.
+    int videoTrack = -1;
+    for (int i = 0; i < state.project()->tracks().size(); ++i) {
+        if (state.project()->tracks().at(i).clips.size() == 2) {
+            videoTrack = i;
+            break;
+        }
+    }
+    QVERIFY(videoTrack >= 0);
+    const drift::Track &track = state.project()->tracks().at(videoTrack);
+    QCOMPARE(track.clips[0].assetId, QStringLiteral("asset-0"));
+    QCOMPARE(track.clips[1].assetId, QStringLiteral("asset-1"));
+    QCOMPARE(track.clips[0].timelineStart, drift::TimeUs(0));
+    QCOMPARE(track.clips[1].timelineStart, track.clips[0].timelineEnd());
+
+    // One undo step removes both clips added by the batch.
+    state.undo();
+    bool anyClipsLeft = false;
+    for (const drift::Track &t : state.project()->tracks()) {
+        if (!t.clips.isEmpty())
+            anyClipsLeft = true;
+    }
+    QVERIFY(!anyClipsLeft);
 }
 
 void EditorStateTest::moveTrackReordersAndRemapsSelection()


### PR DESCRIPTION
## Summary
- Ctrl/Cmd-click to select multiple assets in the media bin, and Shift-click to select a
  contiguous range from the last-clicked item — additive in both cases, so existing picks
  are never silently dropped.
- Selection extends "Remove from project" and "Move to folder…" to the whole selection, and
  adds a new "Add to timeline" action: a single item behaves exactly as before, multiple
  items land back to back on the timeline in the order they were selected. On a pristine
  project this now also offers project setup (resolution/orientation), matching the existing
  timeline-drop flow.
- Bulk removal refuses the whole batch atomically if any selected asset is still referenced
  by a clip on the timeline — same guard as single-item removal, enforced in the controller
  rather than only in the confirmation dialog.
- Multi-select context menus hide Rename/Replace (single-item-only actions) when more than
  one asset is selected.
- Translated the new strings across es/fr_CA/it/pt_BR/si.

## Test plan
- [x] `EditorState` ctest passes, including new coverage: `removeAssetsIsOneUndoStep`,
      `removeAssetsRefusesBatchWithInUseAsset`, `moveAssetsToFolderIsOneUndoStep`,
      `addClipsFromAssetsPlacesThemSequentially`
- [x] `Translations` ctest passes
- [x] Manual: Ctrl/Cmd-click and Shift-click selection (both directions) in grid and list view
- [x] Manual: bulk remove/move/add-to-timeline, including refusing removal of an in-use asset
- [x] Manual: "Add to timeline" prompts for project setup on a pristine project
