### PR TITLE
fix: guard folder cycles/separator and allow moving folders into folders

### DIFF
--- a/i18n/drift.ts
+++ b/i18n/drift.ts
@@ -2866,6 +2866,10 @@
         <source>Clips added</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Folder moved</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>

--- a/i18n/drift_es.ts
+++ b/i18n/drift_es.ts
@@ -2866,6 +2866,10 @@
         <source>Clips added</source>
         <translation>Clips añadidos</translation>
     </message>
+    <message>
+        <source>Folder moved</source>
+        <translation>Carpeta movida</translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>

--- a/i18n/drift_fr_CA.ts
+++ b/i18n/drift_fr_CA.ts
@@ -2868,6 +2868,10 @@
         <source>Clips added</source>
         <translation>Clips ajoutés</translation>
     </message>
+    <message>
+        <source>Folder moved</source>
+        <translation>Dossier déplacé</translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>

--- a/i18n/drift_it.ts
+++ b/i18n/drift_it.ts
@@ -2866,6 +2866,10 @@
         <source>Clips added</source>
         <translation>Clip aggiunte</translation>
     </message>
+    <message>
+        <source>Folder moved</source>
+        <translation>Cartella spostata</translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>

--- a/i18n/drift_pt_BR.ts
+++ b/i18n/drift_pt_BR.ts
@@ -2866,6 +2866,10 @@
         <source>Clips added</source>
         <translation>Clipes adicionados</translation>
     </message>
+    <message>
+        <source>Folder moved</source>
+        <translation>Pasta movida</translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>

--- a/i18n/drift_si.ts
+++ b/i18n/drift_si.ts
@@ -2866,6 +2866,10 @@
         <source>Clips added</source>
         <translation>ක්ලිප් එක් කරන ලදී</translation>
     </message>
+    <message>
+        <source>Folder moved</source>
+        <translation>ෆෝල්ඩරය ගෙන යන ලදී</translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>

--- a/i18n/drift_zh_Hans.ts
+++ b/i18n/drift_zh_Hans.ts
@@ -2859,6 +2859,10 @@
         <source>Clips added</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Folder moved</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>

--- a/src/models/AppController.cpp
+++ b/src/models/AppController.cpp
@@ -2417,6 +2417,20 @@ bool AppController::renameBinFolder(const QString &folderId, const QString &name
     return true;
 }
 
+bool AppController::moveBinFolder(const QString &folderId, const QString &newParentId)
+{
+    // Plain copy, not detachedCopy(): nothing here runs off the GUI thread, so there's no
+    // concurrent reader to race — the same reasoning removeAsset already relies on. A full
+    // detach walks every clip's keyframes/masks/effects across the whole timeline, which is
+    // real, perceptible latency on a project of any size for an edit that touches none of it.
+    const drift::Project before = m_project;
+    if (!m_binFolderModel.moveFolder(folderId, newParentId))
+        return false;
+
+    pushProjectEdit(before, tr("Folder moved"));
+    return true;
+}
+
 bool AppController::deleteBinFolder(const QString &folderId)
 {
     // Plain copy, not detachedCopy(): nothing here runs off the GUI thread, so there's no

--- a/src/models/AppController.h
+++ b/src/models/AppController.h
@@ -551,6 +551,10 @@ public:
     // Bin folder CRUD. parentId empty = bin root; nesting is arbitrary depth.
     Q_INVOKABLE QString createBinFolder(const QString &name, const QString &parentId);
     Q_INVOKABLE bool renameBinFolder(const QString &folderId, const QString &name);
+    // Reparents the folder itself, keeping its own assets and subfolders — they stay pointed
+    // at it, so they move along without being touched individually. Refuses moving a folder
+    // into itself or into one of its own descendants.
+    Q_INVOKABLE bool moveBinFolder(const QString &folderId, const QString &newParentId);
     // Moves the folder's direct children (assets and subfolders) up to its own parent, then
     // removes it. Never blocks and never recurses into deleting contents.
     Q_INVOKABLE bool deleteBinFolder(const QString &folderId);

--- a/src/models/BinFolderListModel.cpp
+++ b/src/models/BinFolderListModel.cpp
@@ -2,6 +2,7 @@
 
 #include "core/Project.h"
 
+#include <QSet>
 #include <QUuid>
 
 BinFolderListModel::BinFolderListModel(QObject *parent)
@@ -224,6 +225,47 @@ bool BinFolderListModel::renameFolder(const QString &id, const QString &name)
 
     folder->name = name;
     emitFolderRowChanged(index, {NameRole});
+    snapshotFolders();
+    return true;
+}
+
+bool BinFolderListModel::isFolderOrDescendant(const QString &candidateId, const QString &ancestorId) const
+{
+    QSet<QString> visited;
+    QString id = candidateId;
+    while (!id.isEmpty()) {
+        if (id == ancestorId)
+            return true;
+        if (visited.contains(id))
+            break;
+        visited.insert(id);
+        const drift::BinFolder *folder = m_project ? m_project->binFolder(id) : nullptr;
+        id = folder ? folder->parentId : QString{};
+    }
+    return false;
+}
+
+bool BinFolderListModel::moveFolder(const QString &id, const QString &newParentId)
+{
+    if (!m_project)
+        return false;
+
+    const int index = indexOfId(id);
+    drift::BinFolder *folder = folderAtIndex(index);
+    if (!folder || folder->parentId == newParentId)
+        return false;
+    // A non-empty newParentId that names no real folder (stale id, or a caller passing junk —
+    // this is QML-invokable) would otherwise be assigned as-is, silently detaching id and
+    // everything under it from the root hierarchy.
+    if (!newParentId.isEmpty() && !m_project->binFolder(newParentId))
+        return false;
+    // Refuses id == newParentId (folder into itself) and newParentId being one of id's own
+    // descendants — either would make id its own ancestor once the pointer is applied.
+    if (isFolderOrDescendant(newParentId, id))
+        return false;
+
+    folder->parentId = newParentId;
+    emitFolderRowChanged(index, {ParentIdRole});
     snapshotFolders();
     return true;
 }

--- a/src/models/BinFolderListModel.h
+++ b/src/models/BinFolderListModel.h
@@ -48,6 +48,11 @@ public:
     // the undo snapshot.
     QString createFolder(const QString &name, const QString &parentId);
     bool renameFolder(const QString &id, const QString &name);
+    // Reparents the folder itself; its own children (assets and subfolders) keep pointing at
+    // it, so they move along for free. Refuses a no-op (already there), moving into itself, or
+    // moving into one of its own descendants — the last would otherwise disconnect that whole
+    // branch from the root by making it its own ancestor.
+    bool moveFolder(const QString &id, const QString &newParentId);
     // Removes the folder row. Any other folder whose parentId == id is reparented to this
     // folder's own parentId (moved up one level, not deleted). Does not touch assets — the
     // caller reparents those separately via AssetLibrary::reparentAssetsInFolder.
@@ -68,6 +73,10 @@ private:
     drift::BinFolder *folderAtIndex(int index);
     QList<QString> currentParentIds() const;
     QList<QString> currentNames() const;
+    // True if candidateId is ancestorId itself or nested anywhere under it — walking up
+    // candidateId's own parentId chain. Guards against a corrupt (cyclic) chain the same way
+    // BinBreadcrumb.qml's trail walk does, since this reads the same project data.
+    bool isFolderOrDescendant(const QString &candidateId, const QString &ancestorId) const;
 
     drift::Project *m_project = nullptr;
     QList<QString> m_syncedOrder;

--- a/src/qml/AssetsPanel.qml
+++ b/src/qml/AssetsPanel.qml
@@ -318,18 +318,47 @@ PanelFrame {
     }
 
     // The "move to folder" path — right-click on a card (or a multi-selection), choose a
-    // destination from a flat list.
+    // destination from a flat list. Also doubles as the folder-move picker (pendingMoveFolderId)
+    // for reparenting a folder itself; the two are mutually exclusive, never both set.
     property var pendingMoveAssetIds: []
     // The folder every selected asset is in right now, so the picker can omit it — moving them
     // "into" the folder they're already in isn't a real destination. A single common value is
     // safe here (not a per-asset lookup): MediaAssetsTab's grid only ever shows one folder's
     // contents at a time, so anything selectable there already shares this folder.
     property string pendingMoveAssetCurrentFolderId: ""
+    // Non-empty while the picker is choosing a new parent for this folder rather than a
+    // destination for assets.
+    property string pendingMoveFolderId: ""
 
     function requestMoveAssetToFolder(assetIds) {
+        root.pendingMoveFolderId = ""
         root.pendingMoveAssetIds = assetIds
         root.pendingMoveAssetCurrentFolderId = EditorState.currentBinFolderId
         folderPickerDialog.open()
+    }
+
+    function requestMoveFolder(folderId) {
+        root.pendingMoveAssetIds = []
+        root.pendingMoveFolderId = folderId
+        folderPickerDialog.open()
+    }
+
+    // True if candidateId is folderId itself or nested anywhere inside it — walked the same
+    // way BinBreadcrumb.qml walks a trail, with the same cycle guard folderPath() uses, since
+    // this runs on the same possibly-malformed parentId chains.
+    function isFolderOrDescendant(candidateId, folderId) {
+        const visited = new Set()
+        let id = candidateId
+        while (id !== "" && !visited.has(id)) {
+            if (id === folderId)
+                return true
+            visited.add(id)
+            const folder = BinFolderModel.folderById(id)
+            if (!folder || Object.keys(folder).length === 0)
+                break
+            id = folder.parentId
+        }
+        return false
     }
 
     // Matches BinBreadcrumb.qml's own separator glyph, so a folder's path reads the same way
@@ -363,7 +392,7 @@ PanelFrame {
         showFooter: false
         preferredWidth: Theme.dialogWidthSm
 
-        // Flat list, root first, minus the folder the asset is already in. Each entry shows
+        // Flat list, root first, minus destinations that aren't real moves. Each entry shows
         // its full path rather than just its own name, so two folders that happen to share a
         // name (nested under different parents) still read as distinct destinations.
         //
@@ -373,8 +402,26 @@ PanelFrame {
         // NOTIFY is undoStackChanged, which fires after every project edit including a rename.
         readonly property var folderOptions: {
             void EditorState.undoAvailable
-            const currentFolderId = root.pendingMoveAssetCurrentFolderId
+            const movingFolderId = root.pendingMoveFolderId
             const out = []
+            if (movingFolderId !== "") {
+                // Moving a folder itself: exclude the folder, anything already its parent (no-op),
+                // and every one of its own descendants — landing there would create a cycle.
+                const currentParentId = BinFolderModel.folderById(movingFolderId).parentId || ""
+                if (currentParentId !== "")
+                    out.push({ id: "", name: qsTr("Media"), path: qsTr("Media") })
+                for (let i = 0; i < BinFolderModel.count; ++i) {
+                    const folder = BinFolderModel.folderAt(i)
+                    if (folder.id === currentParentId)
+                        continue
+                    if (root.isFolderOrDescendant(folder.id, movingFolderId))
+                        continue
+                    out.push({ id: folder.id, name: folder.name, path: root.folderPath(folder.id) })
+                }
+                return out
+            }
+
+            const currentFolderId = root.pendingMoveAssetCurrentFolderId
             if (currentFolderId !== "")
                 out.push({ id: "", name: qsTr("Media"), path: qsTr("Media") })
             for (let i = 0; i < BinFolderModel.count; ++i) {
@@ -440,10 +487,19 @@ PanelFrame {
                         }
 
                         onClicked: {
-                            if (root.pendingMoveAssetIds.length > 0)
-                                EditorState.moveAssetsToFolder(root.pendingMoveAssetIds, optionRow.modelData.id)
-                            root.pendingMoveAssetIds = []
+                            // Closed before the move runs, not after: moving a folder changes
+                            // undoAvailable, which folderOptions depends on, which swaps the
+                            // ListView's model out from under this very delegate — closing
+                            // first avoids racing that live update instead of fighting it.
+                            const targetId = optionRow.modelData.id
                             folderPickerDialog.close()
+                            if (root.pendingMoveFolderId !== "") {
+                                EditorState.moveBinFolder(root.pendingMoveFolderId, targetId)
+                                root.pendingMoveFolderId = ""
+                            } else if (root.pendingMoveAssetIds.length > 0) {
+                                EditorState.moveAssetsToFolder(root.pendingMoveAssetIds, targetId)
+                                root.pendingMoveAssetIds = []
+                            }
                         }
                     }
                 }
@@ -1274,6 +1330,7 @@ PanelFrame {
                 onImportRequested: root.importMedia()
                 onMoveToFolderRequested: (assetIds) => root.requestMoveAssetToFolder(assetIds)
                 onFolderRenameRequested: (folderId, folderName) => root.requestRenameFolder(folderId, folderName)
+                onFolderMoveRequested: (folderId) => root.requestMoveFolder(folderId)
             }
         }
     }

--- a/src/qml/AssetsPanel.qml
+++ b/src/qml/AssetsPanel.qml
@@ -332,15 +332,40 @@ PanelFrame {
         folderPickerDialog.open()
     }
 
+    // Matches BinBreadcrumb.qml's own separator glyph, so a folder's path reads the same way
+    // here as it does in the "where you are" trail above the grid.
+    readonly property string folderPathSeparator: ">"
+
+    // Full path from the bin root down to folderId, e.g. "Interviews > B-Roll" — walks
+    // parentId the same way BinBreadcrumb.qml does, since a flat name alone can't
+    // distinguish two same-named folders nested under different parents.
+    function folderPath(folderId) {
+        const names = []
+        const visited = new Set()
+        let id = folderId
+        // Project deserialization doesn't reject a self- or mutually-parented folder, and
+        // this runs once per folder every time the picker opens — an undetected cycle would
+        // spin this loop forever and hang the UI, so bail the moment an id repeats.
+        while (id !== "" && !visited.has(id)) {
+            visited.add(id)
+            const folder = BinFolderModel.folderById(id)
+            if (!folder || Object.keys(folder).length === 0)
+                break
+            names.unshift(folder.name)
+            id = folder.parentId
+        }
+        return names.join(" " + root.folderPathSeparator + " ")
+    }
+
     ThemedDialog {
         id: folderPickerDialog
         title: qsTr("Move to folder")
         showFooter: false
         preferredWidth: Theme.dialogWidthSm
 
-        // Flat list, root first, minus the folder the asset is already in — nesting depth is
-        // not shown, matching the breadcrumb's "where you are" rather than "the whole tree"
-        // framing.
+        // Flat list, root first, minus the folder the asset is already in. Each entry shows
+        // its full path rather than just its own name, so two folders that happen to share a
+        // name (nested under different parents) still read as distinct destinations.
         //
         // folderAt() is a plain invokable call, not a property read, so it isn't by itself
         // enough to make this binding re-evaluate after a rename (BinFolderModel.count doesn't
@@ -351,11 +376,11 @@ PanelFrame {
             const currentFolderId = root.pendingMoveAssetCurrentFolderId
             const out = []
             if (currentFolderId !== "")
-                out.push({ id: "", name: qsTr("Media") })
+                out.push({ id: "", name: qsTr("Media"), path: qsTr("Media") })
             for (let i = 0; i < BinFolderModel.count; ++i) {
                 const folder = BinFolderModel.folderAt(i)
                 if (folder.id !== currentFolderId)
-                    out.push(folder)
+                    out.push({ id: folder.id, name: folder.name, path: root.folderPath(folder.id) })
             }
             return out
         }
@@ -407,7 +432,7 @@ PanelFrame {
                             anchors.leftMargin: 12
                             anchors.rightMargin: 12
                             verticalAlignment: Text.AlignVCenter
-                            text: optionRow.modelData.name
+                            text: optionRow.modelData.path
                             elide: Text.ElideRight
                             color: Theme.panelForeground
                             font.family: Theme.fontFamily

--- a/src/qml/components/assets/BinBreadcrumb.qml
+++ b/src/qml/components/assets/BinBreadcrumb.qml
@@ -31,8 +31,12 @@ Row {
     readonly property var trail: {
         void root._refreshTick
         const chain = []
+        const visited = new Set()
         let id = root.currentFolderId
-        while (id !== "") {
+        // Project deserialization doesn't reject a self- or mutually-parented folder; an
+        // undetected cycle here would spin forever and hang the UI, so bail on a repeat id.
+        while (id !== "" && !visited.has(id)) {
+            visited.add(id)
             const folder = BinFolderModel.folderById(id)
             if (!folder || Object.keys(folder).length === 0)
                 break

--- a/src/qml/components/assets/MediaAssetsTab.qml
+++ b/src/qml/components/assets/MediaAssetsTab.qml
@@ -43,6 +43,9 @@ Item {
     signal moveToFolderRequested(var assetIds)
     // Emitted from a folder tile's context menu. The parent owns the rename dialog.
     signal folderRenameRequested(string folderId, string folderName)
+    // Emitted from a folder tile's context menu. The parent owns the folder-picker dialog —
+    // the same one moveToFolderRequested above opens for assets.
+    signal folderMoveRequested(string folderId)
 
     // Multi-select, by asset id rather than position: assetIndex is a live row position that
     // shifts on removal/reorder, so an id survives everything except the asset itself going
@@ -612,6 +615,11 @@ Item {
                         icon.name: Theme.icons.pencil
                         onTriggered: root.folderRenameRequested(cardRoot.folderId, cardRoot.name)
                     }
+                    ThemedMenuItem {
+                        text: qsTr("Move to folder…")
+                        icon.name: Theme.icons.folder
+                        onTriggered: root.folderMoveRequested(cardRoot.folderId)
+                    }
                     ThemedMenuSeparator { }
                     ThemedMenuItem {
                         text: qsTr("Delete")
@@ -921,6 +929,11 @@ Item {
                     text: qsTr("Rename…")
                     icon.name: Theme.icons.pencil
                     onTriggered: root.folderRenameRequested(listRow.folderId, listRow.name)
+                }
+                ThemedMenuItem {
+                    text: qsTr("Move to folder…")
+                    icon.name: Theme.icons.folder
+                    onTriggered: root.folderMoveRequested(listRow.folderId)
                 }
                 ThemedMenuSeparator { }
                 ThemedMenuItem {

--- a/tests/tst_editorstate.cpp
+++ b/tests/tst_editorstate.cpp
@@ -62,6 +62,9 @@ private slots:
     void importIntoDeletedFolderFallsBackToRoot();
     void importUnreadableUrlReportsFailed();
     void moveAssetToFolderAndUndo();
+    void moveBinFolderReparentsAndUndo();
+    void moveBinFolderRefusesCycle();
+    void moveBinFolderRefusesNonexistentParent();
     void deleteBinFolderMovesChildrenAndUndo();
     void removeAssetsIsOneUndoStep();
     void removeAssetsRefusesBatchWithInUseAsset();
@@ -506,6 +509,64 @@ void EditorStateTest::moveAssetToFolderAndUndo()
 
     state.undo();
     QCOMPARE(library.assetAt(0).value(QStringLiteral("folderId")).toString(), QString());
+}
+
+void EditorStateTest::moveBinFolderReparentsAndUndo()
+{
+    AssetLibrary library;
+    AppController state(&library);
+
+    const QString interviewsId = state.createBinFolder(QStringLiteral("Interviews"), QString());
+    const QString day1Id = state.createBinFolder(QStringLiteral("Day 1"), QString());
+    const QString clipId = state.createBinFolder(QStringLiteral("Close-ups"), day1Id);
+
+    // Reparent "Day 1" (and everything under it) into "Interviews".
+    QVERIFY(state.moveBinFolder(day1Id, interviewsId));
+    QCOMPARE(state.binFolderModel()->folderById(day1Id).value(QStringLiteral("parentId")).toString(),
+             interviewsId);
+    // The child folder never had its own parentId touched — it moved along for free.
+    QCOMPARE(state.binFolderModel()->folderById(clipId).value(QStringLiteral("parentId")).toString(),
+             day1Id);
+
+    state.undo();
+    QCOMPARE(state.binFolderModel()->folderById(day1Id).value(QStringLiteral("parentId")).toString(),
+             QString());
+}
+
+void EditorStateTest::moveBinFolderRefusesCycle()
+{
+    AssetLibrary library;
+    AppController state(&library);
+
+    const QString parentId = state.createBinFolder(QStringLiteral("Interviews"), QString());
+    const QString childId = state.createBinFolder(QStringLiteral("Day 1"), parentId);
+    const QString grandchildId = state.createBinFolder(QStringLiteral("Close-ups"), childId);
+
+    // Into itself, and into its own descendant at any depth — either would disconnect the
+    // whole branch from the root by making "Interviews" its own ancestor.
+    QVERIFY(!state.moveBinFolder(parentId, parentId));
+    QVERIFY(!state.moveBinFolder(parentId, childId));
+    QVERIFY(!state.moveBinFolder(parentId, grandchildId));
+    QCOMPARE(state.binFolderModel()->folderById(parentId).value(QStringLiteral("parentId")).toString(),
+             QString());
+
+    // Already there is refused too — not a cycle, just not an actual move.
+    QVERIFY(!state.moveBinFolder(childId, parentId));
+}
+
+void EditorStateTest::moveBinFolderRefusesNonexistentParent()
+{
+    AssetLibrary library;
+    AppController state(&library);
+
+    const QString folderId = state.createBinFolder(QStringLiteral("Interviews"), QString());
+
+    // A stale or fabricated id (moveBinFolder is QML-invokable, so a caller could pass
+    // anything) must not be assigned as-is — that would silently detach the folder and
+    // everything under it from the root hierarchy instead of failing loudly.
+    QVERIFY(!state.moveBinFolder(folderId, QStringLiteral("no-such-folder")));
+    QCOMPARE(state.binFolderModel()->folderById(folderId).value(QStringLiteral("parentId")).toString(),
+             QString());
 }
 
 void EditorStateTest::deleteBinFolderMovesChildrenAndUndo()


### PR DESCRIPTION
## Summary
- Guard against a cyclic folder parent chain hanging the UI: both `AssetsPanel.qml`'s folder-path picker and `BinBreadcrumb.qml`'s trail now track visited ids and bail on a repeat instead of walking `parentId` forever — a malformed self- or mutually-parented folder from a deserialized project could otherwise freeze the app the moment the picker opened or the breadcrumb rendered.
- Switch the "Move to folder…" picker's path separator from the OS path character to `>`, matching `BinBreadcrumb.qml`'s own trail style (`Media > audio`) instead of the filesystem's.
- Allow moving a folder itself into another folder via right-click "Move to folder…", not just moving assets into one. Its own assets and subfolders travel with it since they only ever point at it by id. `BinFolderListModel::moveFolder()`/`AppController::moveBinFolder()` refuse:
  - moving a folder into itself or into one of its own descendants (would create a cycle)
  - a nonexistent/stale destination id (previously would have been assigned as-is, silently detaching the folder and everything under it from the root hierarchy)
- The picker's destination list is filtered to match those same rules, and now closes immediately on click instead of racing its own live-updating list (moving a folder changes `undoAvailable`, which the list's model depends on).
- Translated the new "Folder moved" undo label across es/fr_CA/it/pt_BR/si.

## Test plan
- [x] `EditorState` ctest passes, including new coverage: `moveBinFolderReparentsAndUndo`, `moveBinFolderRefusesCycle`, `moveBinFolderRefusesNonexistentParent`
- [x] `Translations` and `Core` ctests pass
- [x] Manual: move a folder into another folder (grid and list view), confirm its contents move along and undo restores the tree
- [x] Manual: confirm a folder's own subfolders don't appear as destinations for it, and the picker closes right away on click