### PR TITLE
feat: add track renaming

### DIFF
--- a/i18n/drift.ts
+++ b/i18n/drift.ts
@@ -2886,6 +2886,10 @@
         <source>Folder moved</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Track renamed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -8378,6 +8382,22 @@ If playback stutters, try another.</source>
     </message>
     <message>
         <source>Reset row height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/i18n/drift_es.ts
+++ b/i18n/drift_es.ts
@@ -2886,6 +2886,10 @@
         <source>Folder moved</source>
         <translation>Carpeta movida</translation>
     </message>
+    <message>
+        <source>Track renamed</source>
+        <translation>Pista renombrada</translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -8386,6 +8390,22 @@ Si la reproducción se corta, prueba con otra opción.</translation>
     <message>
         <source>Reset row height</source>
         <translation>Restablecer altura de fila</translation>
+    </message>
+    <message>
+        <source>Rename track</source>
+        <translation>Cambiar nombre de la pista</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation>Cambiar nombre</translation>
+    </message>
+    <message>
+        <source>Track name</source>
+        <translation>Nombre de la pista</translation>
+    </message>
+    <message>
+        <source>Rename…</source>
+        <translation>Cambiar nombre…</translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_fr_CA.ts
+++ b/i18n/drift_fr_CA.ts
@@ -2888,6 +2888,10 @@
         <source>Folder moved</source>
         <translation>Dossier déplacé</translation>
     </message>
+    <message>
+        <source>Track renamed</source>
+        <translation>Piste renommée</translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -8391,6 +8395,22 @@ En cas de saccades à la lecture, essayez un autre mode.</translation>
     <message>
         <source>Reset row height</source>
         <translation>Réinitialiser la hauteur de ligne</translation>
+    </message>
+    <message>
+        <source>Rename track</source>
+        <translation>Renommer la piste</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation>Renommer</translation>
+    </message>
+    <message>
+        <source>Track name</source>
+        <translation>Nom de la piste</translation>
+    </message>
+    <message>
+        <source>Rename…</source>
+        <translation>Renommer…</translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_it.ts
+++ b/i18n/drift_it.ts
@@ -2886,6 +2886,10 @@
         <source>Folder moved</source>
         <translation>Cartella spostata</translation>
     </message>
+    <message>
+        <source>Track renamed</source>
+        <translation>Traccia rinominata</translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -8386,6 +8390,22 @@ Se la riproduzione va a scatti, prova un&apos;altra opzione.</translation>
     <message>
         <source>Reset row height</source>
         <translation>Reimposta altezza riga</translation>
+    </message>
+    <message>
+        <source>Rename track</source>
+        <translation>Rinomina traccia</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation>Rinomina</translation>
+    </message>
+    <message>
+        <source>Track name</source>
+        <translation>Nome traccia</translation>
+    </message>
+    <message>
+        <source>Rename…</source>
+        <translation>Rinomina…</translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_pt_BR.ts
+++ b/i18n/drift_pt_BR.ts
@@ -2886,6 +2886,10 @@
         <source>Folder moved</source>
         <translation>Pasta movida</translation>
     </message>
+    <message>
+        <source>Track renamed</source>
+        <translation>Faixa renomeada</translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -8386,6 +8390,22 @@ Se a reprodução travar, experimente outro.</translation>
     <message>
         <source>Reset row height</source>
         <translation>Redefinir altura da linha</translation>
+    </message>
+    <message>
+        <source>Rename track</source>
+        <translation>Renomear faixa</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation>Renomear</translation>
+    </message>
+    <message>
+        <source>Track name</source>
+        <translation>Nome da faixa</translation>
+    </message>
+    <message>
+        <source>Rename…</source>
+        <translation>Renomear…</translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_si.ts
+++ b/i18n/drift_si.ts
@@ -2886,6 +2886,10 @@
         <source>Folder moved</source>
         <translation>ෆෝල්ඩරය ගෙන යන ලදී</translation>
     </message>
+    <message>
+        <source>Track renamed</source>
+        <translation>ට්‍රැකයේ නම වෙනස් කරන ලදී</translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -8386,6 +8390,22 @@ If playback stutters, try another.</source>
     <message>
         <source>Reset row height</source>
         <translation>පේළි උස යළි සකසන්න</translation>
+    </message>
+    <message>
+        <source>Rename track</source>
+        <translation>ට්‍රැකයේ නම වෙනස් කරන්න</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation>නම වෙනස් කරන්න</translation>
+    </message>
+    <message>
+        <source>Track name</source>
+        <translation>ට්‍රැක් නම</translation>
+    </message>
+    <message>
+        <source>Rename…</source>
+        <translation>නම වෙනස් කරන්න…</translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_zh_Hans.ts
+++ b/i18n/drift_zh_Hans.ts
@@ -2879,6 +2879,10 @@
         <source>Folder moved</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Track renamed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AssetCategoryChips</name>
@@ -8359,6 +8363,22 @@ If playback stutters, try another.</source>
     </message>
     <message>
         <source>Reset row height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rename…</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/core/Project.cpp
+++ b/src/core/Project.cpp
@@ -699,6 +699,7 @@ Project Project::fromJson(const QJsonObject &object, QString *errorOut)
             Track track;
             track.type = trackTypeFromString(
                 trackObject.value(QStringLiteral("type")).toString(QStringLiteral("video")));
+            track.name = trackObject.value(QStringLiteral("name")).toString();
             track.muted = trackObject.value(QStringLiteral("muted")).toBool(false);
             track.hidden = trackObject.value(QStringLiteral("hidden")).toBool(false);
             track.locked = trackObject.value(QStringLiteral("locked")).toBool(false);
@@ -798,6 +799,7 @@ QJsonObject Project::toJson() const
 
         tracksArray.append(QJsonObject{
             {QStringLiteral("type"), trackTypeToString(track.type)},
+            {QStringLiteral("name"), track.name},
             {QStringLiteral("muted"), track.muted},
             {QStringLiteral("hidden"), track.hidden},
             {QStringLiteral("locked"), track.locked},

--- a/src/core/Track.h
+++ b/src/core/Track.h
@@ -18,6 +18,9 @@ struct Track
     TrackType type = TrackType::Video;
     QList<Clip> clips;
     QList<Transition> transitions;
+    // User-given label, shown instead of the type+position fallback ("Video 1") once set.
+    // Empty by default — most tracks never get a custom name.
+    QString name;
     bool muted = false;
     bool hidden = false;
     bool locked = false;

--- a/src/models/AppController.cpp
+++ b/src/models/AppController.cpp
@@ -1198,6 +1198,7 @@ QVariantList AppController::tracks() const
 
         result.append(QVariantMap{
             {QStringLiteral("type"), drift::trackTypeToString(track.type)},
+            {QStringLiteral("name"), track.name},
             {QStringLiteral("clips"), clips},
             {QStringLiteral("transitions"), transitions},
             {QStringLiteral("muted"), track.muted},
@@ -12382,6 +12383,25 @@ void AppController::setTrackHidden(int trackIndex, bool hidden)
     m_project.tracks()[trackIndex].hidden = hidden;
     pushProjectEdit(before, tr("Track visibility"));
     finishEdit(hidden ? tr("Track hidden") : tr("Track shown"));
+}
+
+bool AppController::renameTrack(int trackIndex, const QString &name)
+{
+    if (trackIndex < 0 || trackIndex >= m_project.tracks().size())
+        return false;
+
+    // Unlike renameAsset, an empty result is allowed through rather than refused — it clears
+    // the custom name back to the type+position fallback ("Video 1"), which is a real,
+    // reachable state (Track::name's own default) rather than an invalid one.
+    const QString trimmed = name.trimmed();
+    if (m_project.tracks()[trackIndex].name == trimmed)
+        return false;
+
+    const drift::Project before = m_project;
+    m_project.tracks()[trackIndex].name = trimmed;
+    pushProjectEdit(before, tr("Track renamed"));
+    finishEdit(tr("Track renamed"));
+    return true;
 }
 
 bool AppController::trackMuted(int trackIndex) const

--- a/src/models/AppController.h
+++ b/src/models/AppController.h
@@ -971,6 +971,9 @@ public:
     Q_INVOKABLE bool importUserEffectPreset(const QUrl &fileUrl);
     Q_INVOKABLE void setTrackMuted(int trackIndex, bool muted);
     Q_INVOKABLE void setTrackHidden(int trackIndex, bool hidden);
+    // Empty name clears the custom label, falling back to the type+position display
+    // ("Video 1") again.
+    Q_INVOKABLE bool renameTrack(int trackIndex, const QString &name);
     Q_INVOKABLE bool trackMuted(int trackIndex) const;
     Q_INVOKABLE bool trackHidden(int trackIndex) const;
     Q_INVOKABLE void setTrackShowWaveform(int trackIndex, bool show);

--- a/src/qml/components/timeline/TrackHeaderColumn.qml
+++ b/src/qml/components/timeline/TrackHeaderColumn.qml
@@ -32,8 +32,39 @@ Item {
     // Pending delete confirmation — index kept until Accept/Reject so the menu
     // can close without wiping the track immediately.
     property int pendingDeleteTrack: -1
+    // Same idea for the rename dialog.
+    property int pendingRenameTrack: -1
 
     clip: true
+
+    ThemedDialog {
+        id: renameTrackDialog
+        title: qsTr("Rename track")
+        acceptText: qsTr("Rename")
+        preferredWidth: Theme.dialogWidthSm
+
+        contentItem: Column {
+            width: parent ? parent.width : Theme.dialogWidthSm
+            spacing: Theme.spacingMd
+
+            ThemedTextField {
+                id: renameTrackField
+                width: parent.width
+                placeholderText: qsTr("Track name")
+            }
+        }
+
+        onOpened: {
+            renameTrackField.forceActiveFocus()
+            renameTrackField.selectAll()
+        }
+        onAccepted: {
+            if (root.pendingRenameTrack >= 0)
+                EditorState.renameTrack(root.pendingRenameTrack, renameTrackField.text)
+            root.pendingRenameTrack = -1
+        }
+        onRejected: root.pendingRenameTrack = -1
+    }
 
     ThemedDialog {
         id: confirmDeleteTrack
@@ -94,8 +125,9 @@ Item {
         return Theme.icons.video;
     }
 
-    // Single-letter stand-in for the type glyph plus name band, which do not fit a
-    // 72px compact header. "V1"/"A2" is the whole identification a phone gets.
+    // Single-letter stand-in for the type glyph plus name band, which do not fit a 72px
+    // compact header. "V1"/"A2" is the fallback identification a phone gets until the track
+    // has a custom name — see trackCompactLabel, which prefers that name when it's set.
     function trackTypeShortLabel(type) {
         if (type === "audio") return qsTr("A");
         if (type === "text") return qsTr("T");
@@ -160,6 +192,17 @@ Item {
             readonly property bool trackMuted: root.tracks[index].muted === true
             readonly property bool trackHidden: root.tracks[index].hidden === true
             readonly property bool trackWaveform: root.tracks[index].showWaveform === true
+            // Falls back to the type+position label until a custom name is set.
+            readonly property string trackDisplayName:
+                root.tracks[index].name && root.tracks[index].name.length > 0
+                ? root.tracks[index].name
+                : root.trackTypeLabel(root.tracks[index].type) + " " + (index + 1)
+            // Same, but falling back to the short "V1"/"A2" form the compact header uses when
+            // there's no custom name to show instead.
+            readonly property string trackCompactLabel:
+                root.tracks[index].name && root.tracks[index].name.length > 0
+                ? root.tracks[index].name
+                : root.trackTypeShortLabel(root.tracks[index].type) + (index + 1)
             width: root.labelsWidth
             height: root.trackHeight(index)
                     + (index < root.tracks.length - 1 ? Theme.trackGap : 0)
@@ -290,6 +333,7 @@ Item {
             }
 
             Row {
+                id: trackIconRow
                 anchors.right: parent.right
                 anchors.rightMargin: root.compact ? 4 : 12
                 anchors.verticalCenter: parent.verticalCenter
@@ -399,19 +443,43 @@ Item {
                 }
             }
 
+            // Text/subtitle rows are too short for the name band above (it needs both a
+            // top-anchored name and a vertically centered icon row without the two
+            // overlapping), so the name sits inline here instead, between the grip and the
+            // type/toggle icons.
+            Text {
+                visible: !root.compact && root.trackHeight(index) < 40
+                anchors.left: parent.left
+                anchors.leftMargin: Theme.spacing3xl + Theme.spacingSm
+                anchors.right: trackIconRow.left
+                anchors.rightMargin: Theme.spacingSm
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.verticalCenterOffset: index < root.tracks.length - 1 ? -Theme.trackGap / 2 : 0
+                text: trackLabelRow.trackDisplayName
+                color: Theme.mutedForeground
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeTiny
+                elide: Text.ElideRight
+            }
+
             // Compact stand-in for the glyph and the name band: sits in the gap
             // between the grip and the mute/hide pair, which is the only free
-            // horizontal space the compact header has.
+            // horizontal space the compact header has. Shows the custom name (elided) once
+            // one is set — the context menu's Rename is reachable here too (long-press),
+            // and a rename that changes nothing visible would look like it silently failed.
             Text {
                 visible: root.compact
                 anchors.left: parent.left
                 anchors.leftMargin: 18
+                anchors.right: trackIconRow.left
+                anchors.rightMargin: Theme.spacingSm
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.verticalCenterOffset: index < root.tracks.length - 1 ? -Theme.trackGap / 2 : 0
-                text: root.trackTypeShortLabel(root.tracks[index].type) + (index + 1)
+                text: trackLabelRow.trackCompactLabel
                 color: Theme.mutedForeground
                 font.family: Theme.fontFamily
                 font.pixelSize: Theme.fontSizeTiny
+                elide: Text.ElideRight
             }
 
             // Filmstrip/waveform toggle for compact headers. Parked in the bottom-left
@@ -446,8 +514,7 @@ Item {
                 anchors.rightMargin: Theme.spacingLg
                 anchors.top: parent.top
                 anchors.topMargin: Theme.spacingMd
-                text: root.trackTypeLabel(root.tracks[index].type)
-                      + " " + (index + 1)
+                text: trackLabelRow.trackDisplayName
                 color: Theme.mutedForeground
                 font.family: Theme.fontFamily
                 font.pixelSize: Theme.fontSizeTiny
@@ -468,6 +535,16 @@ Item {
                 ThemedContextMenu {
                     id: trackContextMenu
 
+                    ThemedMenuItem {
+                        text: qsTr("Rename…")
+                        icon.name: Theme.icons.pencil
+                        onTriggered: {
+                            root.pendingRenameTrack = index
+                            renameTrackField.text = trackLabelRow.trackDisplayName
+                            renameTrackDialog.open()
+                        }
+                    }
+                    ThemedMenuSeparator {}
                     ThemedMenuItem {
                         text: trackLabelRow.trackMuted ? qsTr("Unmute track")
                                                        : qsTr("Mute track")

--- a/src/qml/components/timeline/TrackHeaderColumn.qml
+++ b/src/qml/components/timeline/TrackHeaderColumn.qml
@@ -435,7 +435,7 @@ Item {
                     // Tracks were identifiable only by this 16px
                     // glyph, with no name and no tooltip.
                     ThemedToolTip {
-                        text: root.trackTypeLabel(root.tracks[index].type)
+                        text: trackLabelRow.trackDisplayName
                         visible: typeHover.hovered
                     }
 
@@ -540,7 +540,10 @@ Item {
                         icon.name: Theme.icons.pencil
                         onTriggered: {
                             root.pendingRenameTrack = index
-                            renameTrackField.text = trackLabelRow.trackDisplayName
+                            // Custom name only — pre-filling the type+position fallback
+                            // ("Video 1") would persist it as a real name on an unchanged
+                            // confirm, then stick after the track is reordered.
+                            renameTrackField.text = root.tracks[index].name || ""
                             renameTrackDialog.open()
                         }
                     }

--- a/tests/tst_editorstate.cpp
+++ b/tests/tst_editorstate.cpp
@@ -73,6 +73,7 @@ private slots:
     void addClipsFromAssetsPlacesThemSequentially();
     void moveTrackReordersAndRemapsSelection();
     void addTrackInsertsEmptyTrackByType();
+    void renameTrackAndUndo();
     void projectPersistenceRoundTrip();
     void projectJsonExportImportRoundTrip();
     void projectJsonImportRejectsGarbageAndLeavesTimeline();
@@ -799,6 +800,35 @@ void EditorStateTest::addTrackInsertsEmptyTrackByType()
     QVERIFY(state.undoAvailable());
     state.undo();
     QCOMPARE(state.tracks().size(), 2);
+}
+
+void EditorStateTest::renameTrackAndUndo()
+{
+    AssetLibrary library;
+    AppController state(&library);
+    QCOMPARE(state.tracks().size(), 1);
+
+    // No custom name yet.
+    QCOMPARE(state.tracks().at(0).toMap().value(QStringLiteral("name")).toString(), QString());
+
+    QVERIFY(state.renameTrack(0, QStringLiteral("Dialogue")));
+    QCOMPARE(state.tracks().at(0).toMap().value(QStringLiteral("name")).toString(),
+             QStringLiteral("Dialogue"));
+
+    // Unchanged and out-of-range are both refused, not pushed as no-op undo steps.
+    QVERIFY(!state.renameTrack(0, QStringLiteral("Dialogue")));
+    QVERIFY(!state.renameTrack(5, QStringLiteral("Nope")));
+
+    // Empty clears the custom name back to the type+position fallback, rather than being
+    // refused the way an empty asset name is.
+    QVERIFY(state.renameTrack(0, QStringLiteral("  ")));
+    QCOMPARE(state.tracks().at(0).toMap().value(QStringLiteral("name")).toString(), QString());
+
+    state.undo();
+    QCOMPARE(state.tracks().at(0).toMap().value(QStringLiteral("name")).toString(),
+             QStringLiteral("Dialogue"));
+    state.undo();
+    QCOMPARE(state.tracks().at(0).toMap().value(QStringLiteral("name")).toString(), QString());
 }
 
 // Packaging embeds the derived artifacts and repoints the project at the extraction directory, so

--- a/tests/tst_editorstate.cpp
+++ b/tests/tst_editorstate.cpp
@@ -815,6 +815,11 @@ void EditorStateTest::renameTrackAndUndo()
     QCOMPARE(state.tracks().at(0).toMap().value(QStringLiteral("name")).toString(),
              QStringLiteral("Dialogue"));
 
+    QString error;
+    const drift::Project reloaded = drift::Project::fromJson(state.project()->toJson(), &error);
+    QVERIFY(error.isEmpty());
+    QCOMPARE(reloaded.tracks().at(0).name, QStringLiteral("Dialogue"));
+
     // Unchanged and out-of-range are both refused, not pushed as no-op undo steps.
     QVERIFY(!state.renameTrack(0, QStringLiteral("Dialogue")));
     QVERIFY(!state.renameTrack(5, QStringLiteral("Nope")));


### PR DESCRIPTION
Right-click a track header for a new "Rename…" option; Track gains a
persisted name field, falling back to the existing type+position
label ("Video 1") when empty. Fixes the name being invisible on short
rows (text/subtitle tracks) and in Android's compact header, where
renaming previously succeeded with no visible result. Translate the
new strings across es/fr_CA/it/pt_BR/si.