### PR TITLE
Use native macOS shortcut labels and modifier behavior

### DIFF
--- a/src/qml/EditorHeader.qml
+++ b/src/qml/EditorHeader.qml
@@ -293,7 +293,7 @@ Rectangle {
                 text: qsTr("Save")
                 tooltip: {
                     const keys = EditorState.shortcutFor("save")
-                    return keys.length > 0 ? qsTr("Save project (%1)").arg(keys)
+                    return keys.length > 0 ? qsTr("Save project (%1)").arg(Theme.shortcutDisplay(keys))
                                            : qsTr("Save project")
                 }
                 anchors.verticalCenter: parent.verticalCenter

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -676,7 +676,7 @@ ApplicationWindow {
             width: 0
             height: 0
             Shortcut {
-                sequence: modelData.shortcut
+                sequence: Theme.nativeShortcutSequence(modelData.shortcut)
                 context: Qt.ApplicationShortcut
                 onActivated: {
                     if (modelData.id === "clearSelection"

--- a/src/qml/Theme.qml
+++ b/src/qml/Theme.qml
@@ -10,6 +10,107 @@ import Drift
 QtObject {
     id: theme
 
+
+    // --- Platform keyboard shortcuts -----------------------------------------
+    // Shortcut strings stored by EditorState use a portable/canonical notation:
+    //
+    //   Ctrl  = primary application accelerator
+    //           Command on macOS, Control on Windows/Linux
+    //
+    // This keeps project/settings data portable while the UI and actual Shortcut
+    // objects follow the conventions of the operating system.
+    readonly property bool isMacOS: Qt.platform.os === "osx"
+    readonly property bool isWindows: Qt.platform.os === "windows"
+    readonly property bool isLinux: Qt.platform.os === "linux"
+
+    function nativeShortcutSequence(sequence) {
+        // Qt already performs the native Apple modifier mapping:
+        //
+        //   Ctrl -> Command (⌘)
+        //   Meta -> physical Control (⌃)
+        //   Alt  -> Option (⌥)
+        //
+        // Therefore the canonical shortcut string must be passed through
+        // unchanged. Converting Ctrl to Meta here would incorrectly turn
+        // Command shortcuts into physical Control shortcuts on macOS.
+        return sequence
+    }
+
+    function shortcutDisplay(sequence) {
+        if (!sequence || sequence.length === 0)
+            return ""
+
+        if (!isMacOS)
+            return sequence
+
+        const parts = sequence.split("+")
+
+        let control = false
+        let option = false
+        let shift = false
+        let command = false
+        let key = ""
+
+        for (let i = 0; i < parts.length; ++i) {
+            const part = parts[i]
+
+            // Qt's native Apple mapping:
+            // Ctrl = Command, Meta = physical Control.
+            if (part === "Ctrl")
+                command = true
+            else if (part === "Meta")
+                control = true
+            else if (part === "Alt")
+                option = true
+            else if (part === "Shift")
+                shift = true
+            else
+                key = part
+        }
+
+        const keySymbols = {
+            "Left": "←",
+            "Right": "→",
+            "Up": "↑",
+            "Down": "↓",
+            "Backspace": "⌫",
+            "Delete": "⌦",
+            "Escape": "⎋",
+            "Return": "↩",
+            "Enter": "⌅"
+        }
+
+        if (keySymbols[key] !== undefined)
+            key = keySymbols[key]
+
+        // Ordem visual tradicional da Apple.
+        return (control ? "⌃" : "")
+             + (option ? "⌥" : "")
+             + (shift ? "⇧" : "")
+             + (command ? "⌘" : "")
+             + key
+    }
+
+    function platformShortcutText(text) {
+        if (!text || !isMacOS)
+            return text
+
+        // Used for prose/tooltips such as "Ctrl+scroll" and
+        // "Shift for 5s", preserving the translated sentence itself.
+        return text
+            .replace(/Ctrl/g, "⌘")
+            .replace(/Alt/g, "⌥")
+            .replace(/Shift/g, "⇧")
+            .replace(/Meta/g, "⌘")
+    }
+
+    function primaryModifierPressed(modifiers) {
+        // On macOS Qt maps Command to ControlModifier by default.
+        // On Windows/Linux this is the physical Control key.
+        return (modifiers & Qt.ControlModifier) !== 0
+    }
+
+
     property FontLoader _interLoader: FontLoader { source: "qrc:/qt/qml/Drift/resources/fonts/Inter.ttf" }
 
     readonly property string fontFamily: _interLoader.name || "sans-serif"

--- a/src/qml/components/ShortcutCaptureField.qml
+++ b/src/qml/components/ShortcutCaptureField.qml
@@ -24,7 +24,7 @@ AbstractButton {
 
     Accessible.role: Accessible.Button
     Accessible.name: qsTr("Shortcut for %1").arg(root.actionId)
-    Accessible.description: root.shortcut.length > 0 ? root.shortcut : qsTr("Not set")
+    Accessible.description: root.shortcut.length > 0 ? Theme.shortcutDisplay(root.shortcut) : qsTr("Not set")
     Accessible.onPressAction: root.arm()
 
     function arm() {
@@ -90,6 +90,14 @@ AbstractButton {
             return ""
 
         let parts = []
+
+        // Qt already normalizes Apple modifiers:
+        //
+        // ControlModifier = Command on macOS
+        // MetaModifier    = physical Control on macOS
+        //
+        // Store exactly Qt's canonical names. This keeps Shortcut {}
+        // execution and the persisted shortcut map consistent.
         if (event.modifiers & Qt.ControlModifier)
             parts.push("Ctrl")
         if (event.modifiers & Qt.AltModifier)
@@ -98,6 +106,7 @@ AbstractButton {
             parts.push("Shift")
         if (event.modifiers & Qt.MetaModifier)
             parts.push("Meta")
+
         parts.push(name)
         return parts.join("+")
     }
@@ -108,7 +117,9 @@ AbstractButton {
         verticalAlignment: Text.AlignVCenter
         elide: Text.ElideRight
         text: root.capturing ? qsTr("Press keys…")
-                             : (root.shortcut.length > 0 ? root.shortcut : qsTr("Click to set"))
+                             : (root.shortcut.length > 0
+                                ? Theme.shortcutDisplay(root.shortcut)
+                                : qsTr("Click to set"))
         color: root.capturing ? Theme.primary : Theme.panelForeground
         font.family: Theme.monoFontFamily
         font.pixelSize: Theme.fontSizeXs
@@ -146,7 +157,8 @@ AbstractButton {
         // binding it twice would make Qt fire neither.
         const clash = EditorState.setShortcut(root.actionId, chord)
         if (clash.length > 0)
-            Toasts.warning(qsTr("“%1” is already used by %2.").arg(chord).arg(clash))
+            Toasts.warning(qsTr("“%1” is already used by %2.")
+                           .arg(Theme.shortcutDisplay(chord)).arg(clash))
         root.capturing = false
         event.accepted = true
     }

--- a/src/qml/components/preview/CropOverlay.qml
+++ b/src/qml/components/preview/CropOverlay.qml
@@ -101,7 +101,7 @@ Item {
         // so a separate handler behind it never got them. Ctrl-less
         // scrolls are explicitly rejected so they keep propagating.
         onWheel: (wheel) => {
-            if (!(wheel.modifiers & Qt.ControlModifier)
+            if (!Theme.primaryModifierPressed(wheel.modifiers)
                     || wheel.angleDelta.y === 0) {
                 wheel.accepted = false
                 return
@@ -323,7 +323,7 @@ Item {
                 font.pixelSize: Theme.fontSizeXs
             }
             Text {
-                text: qsTr("Ctrl + scroll to zoom")
+                text: Theme.platformShortcutText(qsTr("Ctrl + scroll to zoom"))
                 color: root.didZoom ? Theme.guideMedium : Theme.onMedia
                 font.family: Theme.fontFamily
                 font.pixelSize: Theme.fontSizeXs

--- a/src/qml/components/preview/PreviewToolbar.qml
+++ b/src/qml/components/preview/PreviewToolbar.qml
@@ -74,7 +74,7 @@ Item {
         // stay centred. AbstractButton.clicked carries no modifiers, hence the query into Qt.
         function jumpStep() {
             const modifiers = EditorState.keyboardModifiers()
-            if (modifiers & Qt.ControlModifier)
+            if (Theme.primaryModifierPressed(modifiers))
                 return 10
             if (modifiers & Qt.ShiftModifier)
                 return 5
@@ -85,7 +85,7 @@ Item {
             anchors.verticalCenter: parent.verticalCenter
             glyph: Theme.icons.rewind
             variant: "text"
-            tooltip: qsTr("Jump back 1s · Shift for 5s · Ctrl for 10s")
+            tooltip: Theme.platformShortcutText(qsTr("Jump back 1s · Shift for 5s · Ctrl for 10s"))
             onClicked: EditorState.jumpSeconds(-parent.jumpStep())
         }
 
@@ -129,7 +129,7 @@ Item {
             anchors.verticalCenter: parent.verticalCenter
             glyph: Theme.icons.fastForward
             variant: "text"
-            tooltip: qsTr("Jump forward 1s · Shift for 5s · Ctrl for 10s")
+            tooltip: Theme.platformShortcutText(qsTr("Jump forward 1s · Shift for 5s · Ctrl for 10s"))
             onClicked: EditorState.jumpSeconds(parent.jumpStep())
         }
     }
@@ -152,8 +152,9 @@ Item {
             horizontalAlignment: Text.AlignHCenter
 
             ThemedToolTip {
-                text: qsTr("Preview zoom — Ctrl+scroll over the preview to zoom, "
-                           + "middle-drag to pan. Click to reset to 100%.")
+                text: Theme.platformShortcutText(
+                          qsTr("Preview zoom — Ctrl+scroll over the preview to zoom, "
+                             + "middle-drag to pan. Click to reset to 100%."))
                 visible: zoomLabelMouse.containsMouse
             }
 


### PR DESCRIPTION
## Summary

This PR improves keyboard shortcut presentation and modifier handling on macOS.

### Changes

- Displays native macOS shortcut symbols in the UI:
  - Command → `⌘`
  - Option → `⌥`
  - Shift → `⇧`
  - Control → `⌃`
- Keeps Qt shortcut definitions in their canonical form (`Ctrl+...`) so native Qt modifier mapping continues to work correctly across platforms.
- Improves shortcut capture on macOS by respecting Qt's native mapping:
  - `Qt.ControlModifier` corresponds to Command
  - `Qt.MetaModifier` corresponds to physical Control
- Updates shortcut hints and tooltips in preview/editor UI to use platform-appropriate labels.
- Keeps Windows/Linux behavior unchanged.

## Motivation

Qt maps application shortcuts to native platform modifiers automatically.

On macOS, a shortcut such as `Ctrl+S` is internally the portable Qt representation for Command+S. Displaying the raw text as `Ctrl+S` is confusing to macOS users even though the physical shortcut is actually `⌘S`.

The goal of this change is to keep the portable shortcut definitions intact while presenting them using native macOS terminology and symbols.

## Testing

- Built successfully on macOS.
- 10/10 project tests passed.
- Manually verified on macOS:
  - `⌘S` Save
  - `⌘Z` Undo
  - `⇧⌘Z` Redo
  - `⌘C` / `⌘V`
  - shortcut capture using Command
  - platform-specific shortcut hints and tooltips