### PR TITLE
feat: add Import Folder to mirror a directory's structure into the media bin

### DIFF
--- a/i18n/drift.ts
+++ b/i18n/drift.ts
@@ -3133,6 +3133,13 @@
         </translation>
     </message>
     <message numerus="yes">
+        <source>Imported %n files into %1 folders. %2 files were skipped — Drift does not recognize their format. Drag them onto the bin to try anyway.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>Imported %n files into %1 folders.</source>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/i18n/drift.ts
+++ b/i18n/drift.ts
@@ -2980,6 +2980,13 @@
     </message>
 </context>
 <context>
+    <name>AssetLibrary</name>
+    <message>
+        <source>Media files (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AssetsPanel</name>
     <message>
         <source>Imported %1 of %2 files. %3 could not be read.</source>
@@ -3023,10 +3030,6 @@
     </message>
     <message>
         <source>Replace Media</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Media files (*.mp4 *.mov *.mkv *.avi *.webm *.m4v *.mp3 *.wav *.aac *.flac *.ogg *.m4a *.png *.jpg *.jpeg *.gif *.webp *.bmp)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3119,6 +3122,28 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Couldn’t import that folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>Imported %n files into %1 folders — as many as one folder import takes. Import the remaining subfolders separately.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Imported %n files into %1 folders.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Import Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3204,6 +3229,10 @@
     </message>
     <message>
         <source>Import video, audio or image files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import a folder, keeping its structure as bin folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/drift_es.ts
+++ b/i18n/drift_es.ts
@@ -3133,6 +3133,13 @@
         </translation>
     </message>
     <message numerus="yes">
+        <source>Imported %n files into %1 folders. %2 files were skipped — Drift does not recognize their format. Drag them onto the bin to try anyway.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>Imported %n files into %1 folders.</source>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/i18n/drift_es.ts
+++ b/i18n/drift_es.ts
@@ -2980,6 +2980,13 @@
     </message>
 </context>
 <context>
+    <name>AssetLibrary</name>
+    <message>
+        <source>Media files (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AssetsPanel</name>
     <message>
         <source>Imported %1 of %2 files. %3 could not be read.</source>
@@ -3024,10 +3031,6 @@
     <message>
         <source>Replace Media</source>
         <translation>Reemplazar medio</translation>
-    </message>
-    <message>
-        <source>Media files (*.mp4 *.mov *.mkv *.avi *.webm *.m4v *.mp3 *.wav *.aac *.flac *.ogg *.m4a *.png *.jpg *.jpeg *.gif *.webp *.bmp)</source>
-        <translation>Archivos de medios (*.mp4 *.mov *.mkv *.avi *.webm *.m4v *.mp3 *.wav *.aac *.flac *.ogg *.m4a *.png *.jpg *.jpeg *.gif *.webp *.bmp)</translation>
     </message>
     <message>
         <source>Export Image</source>
@@ -3119,6 +3122,28 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Couldn’t import that folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>Imported %n files into %1 folders — as many as one folder import takes. Import the remaining subfolders separately.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Imported %n files into %1 folders.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Import Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Text</source>
         <translation>Texto</translation>
     </message>
@@ -3205,6 +3230,10 @@
     <message>
         <source>Import video, audio or image files</source>
         <translation>Importar archivos de vídeo, audio o imagen</translation>
+    </message>
+    <message>
+        <source>Import a folder, keeping its structure as bin folders</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Touch and hold a transition, then drag it onto where two clips meet.</source>

--- a/i18n/drift_fr_CA.ts
+++ b/i18n/drift_fr_CA.ts
@@ -2982,6 +2982,13 @@
     </message>
 </context>
 <context>
+    <name>AssetLibrary</name>
+    <message>
+        <source>Media files (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AssetsPanel</name>
     <message>
         <source>Imported %1 of %2 files. %3 could not be read.</source>
@@ -3026,10 +3033,6 @@
     <message>
         <source>Replace Media</source>
         <translation>Remplacer le média</translation>
-    </message>
-    <message>
-        <source>Media files (*.mp4 *.mov *.mkv *.avi *.webm *.m4v *.mp3 *.wav *.aac *.flac *.ogg *.m4a *.png *.jpg *.jpeg *.gif *.webp *.bmp)</source>
-        <translation>Fichiers multimédias (*.mp4 *.mov *.mkv *.avi *.webm *.m4v *.mp3 *.wav *.aac *.flac *.ogg *.m4a *.png *.jpg *.jpeg *.gif *.webp *.bmp)</translation>
     </message>
     <message>
         <source>Export Image</source>
@@ -3121,6 +3124,28 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Couldn’t import that folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>Imported %n files into %1 folders — as many as one folder import takes. Import the remaining subfolders separately.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Imported %n files into %1 folders.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Import Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Text</source>
         <translation>Texte</translation>
     </message>
@@ -3207,6 +3232,10 @@
     <message>
         <source>Import video, audio or image files</source>
         <translation>Importer des fichiers vidéo, audio ou image</translation>
+    </message>
+    <message>
+        <source>Import a folder, keeping its structure as bin folders</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Touch and hold a transition, then drag it onto where two clips meet.</source>

--- a/i18n/drift_fr_CA.ts
+++ b/i18n/drift_fr_CA.ts
@@ -3135,6 +3135,13 @@
         </translation>
     </message>
     <message numerus="yes">
+        <source>Imported %n files into %1 folders. %2 files were skipped — Drift does not recognize their format. Drag them onto the bin to try anyway.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>Imported %n files into %1 folders.</source>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/i18n/drift_it.ts
+++ b/i18n/drift_it.ts
@@ -3133,6 +3133,13 @@
         </translation>
     </message>
     <message numerus="yes">
+        <source>Imported %n files into %1 folders. %2 files were skipped — Drift does not recognize their format. Drag them onto the bin to try anyway.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>Imported %n files into %1 folders.</source>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/i18n/drift_it.ts
+++ b/i18n/drift_it.ts
@@ -2980,6 +2980,13 @@
     </message>
 </context>
 <context>
+    <name>AssetLibrary</name>
+    <message>
+        <source>Media files (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AssetsPanel</name>
     <message>
         <source>Imported %1 of %2 files. %3 could not be read.</source>
@@ -3024,10 +3031,6 @@
     <message>
         <source>Replace Media</source>
         <translation>Sostituisci elemento multimediale</translation>
-    </message>
-    <message>
-        <source>Media files (*.mp4 *.mov *.mkv *.avi *.webm *.m4v *.mp3 *.wav *.aac *.flac *.ogg *.m4a *.png *.jpg *.jpeg *.gif *.webp *.bmp)</source>
-        <translation>File multimediali (*.mp4 *.mov *.mkv *.avi *.webm *.m4v *.mp3 *.wav *.aac *.flac *.ogg *.m4a *.png *.jpg *.jpeg *.gif *.webp *.bmp)</translation>
     </message>
     <message>
         <source>Export Image</source>
@@ -3119,6 +3122,28 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Couldn’t import that folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>Imported %n files into %1 folders — as many as one folder import takes. Import the remaining subfolders separately.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Imported %n files into %1 folders.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Import Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Text</source>
         <translation>Testo</translation>
     </message>
@@ -3205,6 +3230,10 @@
     <message>
         <source>Import video, audio or image files</source>
         <translation>Importa file video, audio o immagine</translation>
+    </message>
+    <message>
+        <source>Import a folder, keeping its structure as bin folders</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Touch and hold a transition, then drag it onto where two clips meet.</source>

--- a/i18n/drift_ja.ts
+++ b/i18n/drift_ja.ts
@@ -2971,6 +2971,13 @@
     </message>
 </context>
 <context>
+    <name>AssetLibrary</name>
+    <message>
+        <source>Media files (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AssetsPanel</name>
     <message>
         <source>Imported %1 of %2 files. %3 could not be read.</source>
@@ -3015,10 +3022,6 @@
     <message>
         <source>Replace Media</source>
         <translation>メディアを置き換え</translation>
-    </message>
-    <message>
-        <source>Media files (*.mp4 *.mov *.mkv *.avi *.webm *.m4v *.mp3 *.wav *.aac *.flac *.ogg *.m4a *.png *.jpg *.jpeg *.gif *.webp *.bmp)</source>
-        <translation>メディアファイル (*.mp4 *.mov *.mkv *.avi *.webm *.m4v *.mp3 *.wav *.aac *.flac *.ogg *.m4a *.png *.jpg *.jpeg *.gif *.webp *.bmp)</translation>
     </message>
     <message>
         <source>Export Image</source>
@@ -3104,6 +3107,26 @@
     </message>
     <message>
         <source>“%1” is used by %2 clips on the timeline. Removing this media will also remove those clips and any transitions connected to them. The files on disk are not deleted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Couldn’t import that folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>Imported %n files into %1 folders — as many as one folder import takes. Import the remaining subfolders separately.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Imported %n files into %1 folders.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Import Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3193,6 +3216,10 @@
     <message>
         <source>Import video, audio or image files</source>
         <translation>ビデオ、オーディオ、画像ファイルをインポート</translation>
+    </message>
+    <message>
+        <source>Import a folder, keeping its structure as bin folders</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Touch and hold a transition, then drag it onto where two clips meet.</source>

--- a/i18n/drift_ja.ts
+++ b/i18n/drift_ja.ts
@@ -3120,6 +3120,12 @@
         </translation>
     </message>
     <message numerus="yes">
+        <source>Imported %n files into %1 folders. %2 files were skipped — Drift does not recognize their format. Drag them onto the bin to try anyway.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>Imported %n files into %1 folders.</source>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/i18n/drift_pt_BR.ts
+++ b/i18n/drift_pt_BR.ts
@@ -2980,6 +2980,13 @@
     </message>
 </context>
 <context>
+    <name>AssetLibrary</name>
+    <message>
+        <source>Media files (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AssetsPanel</name>
     <message>
         <source>Imported %1 of %2 files. %3 could not be read.</source>
@@ -3024,10 +3031,6 @@
     <message>
         <source>Replace Media</source>
         <translation>Substituir mídia</translation>
-    </message>
-    <message>
-        <source>Media files (*.mp4 *.mov *.mkv *.avi *.webm *.m4v *.mp3 *.wav *.aac *.flac *.ogg *.m4a *.png *.jpg *.jpeg *.gif *.webp *.bmp)</source>
-        <translation>Arquivos de mídia (*.mp4 *.mov *.mkv *.avi *.webm *.m4v *.mp3 *.wav *.aac *.flac *.ogg *.m4a *.png *.jpg *.jpeg *.gif *.webp *.bmp)</translation>
     </message>
     <message>
         <source>Export Image</source>
@@ -3119,6 +3122,28 @@
         <translation>Há %2 clipes na linha do tempo usando “%1”. Ao remover esta mídia, esses clipes e as transições associadas também serão removidos. O arquivo original no disco não será apagado.</translation>
     </message>
     <message>
+        <source>Couldn’t import that folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>Imported %n files into %1 folders — as many as one folder import takes. Import the remaining subfolders separately.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Imported %n files into %1 folders.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Import Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Text</source>
         <translation>Texto</translation>
     </message>
@@ -3205,6 +3230,10 @@
     <message>
         <source>Import video, audio or image files</source>
         <translation>Importar arquivos de vídeo, áudio ou imagem</translation>
+    </message>
+    <message>
+        <source>Import a folder, keeping its structure as bin folders</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Touch and hold a transition, then drag it onto where two clips meet.</source>

--- a/i18n/drift_pt_BR.ts
+++ b/i18n/drift_pt_BR.ts
@@ -3133,6 +3133,13 @@
         </translation>
     </message>
     <message numerus="yes">
+        <source>Imported %n files into %1 folders. %2 files were skipped — Drift does not recognize their format. Drag them onto the bin to try anyway.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>Imported %n files into %1 folders.</source>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/i18n/drift_si.ts
+++ b/i18n/drift_si.ts
@@ -3133,6 +3133,13 @@
         </translation>
     </message>
     <message numerus="yes">
+        <source>Imported %n files into %1 folders. %2 files were skipped — Drift does not recognize their format. Drag them onto the bin to try anyway.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>Imported %n files into %1 folders.</source>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/i18n/drift_si.ts
+++ b/i18n/drift_si.ts
@@ -2980,6 +2980,13 @@
     </message>
 </context>
 <context>
+    <name>AssetLibrary</name>
+    <message>
+        <source>Media files (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AssetsPanel</name>
     <message>
         <source>Imported %1 of %2 files. %3 could not be read.</source>
@@ -3024,10 +3031,6 @@
     <message>
         <source>Replace Media</source>
         <translation>මාධ්‍ය ප්‍රතිස්ථාපනය කරන්න</translation>
-    </message>
-    <message>
-        <source>Media files (*.mp4 *.mov *.mkv *.avi *.webm *.m4v *.mp3 *.wav *.aac *.flac *.ogg *.m4a *.png *.jpg *.jpeg *.gif *.webp *.bmp)</source>
-        <translation>මාධ්‍ය ගොනු (*.mp4 *.mov *.mkv *.avi *.webm *.m4v *.mp3 *.wav *.aac *.flac *.ogg *.m4a *.png *.jpg *.jpeg *.gif *.webp *.bmp)</translation>
     </message>
     <message>
         <source>Export Image</source>
@@ -3119,6 +3122,28 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Couldn’t import that folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>Imported %n files into %1 folders — as many as one folder import takes. Import the remaining subfolders separately.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Imported %n files into %1 folders.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Import Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Text</source>
         <translation>පෙළ</translation>
     </message>
@@ -3205,6 +3230,10 @@
     <message>
         <source>Import video, audio or image files</source>
         <translation>වීඩියෝ, ශ්‍රව්‍ය හෝ පින්තූර ගොනු ආයාත කරන්න</translation>
+    </message>
+    <message>
+        <source>Import a folder, keeping its structure as bin folders</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Touch and hold a transition, then drag it onto where two clips meet.</source>

--- a/i18n/drift_zh_Hans.ts
+++ b/i18n/drift_zh_Hans.ts
@@ -2971,6 +2971,13 @@
     </message>
 </context>
 <context>
+    <name>AssetLibrary</name>
+    <message>
+        <source>Media files (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AssetsPanel</name>
     <message>
         <source>Imported %1 of %2 files. %3 could not be read.</source>
@@ -3014,10 +3021,6 @@
     </message>
     <message>
         <source>Replace Media</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Media files (*.mp4 *.mov *.mkv *.avi *.webm *.m4v *.mp3 *.wav *.aac *.flac *.ogg *.m4a *.png *.jpg *.jpeg *.gif *.webp *.bmp)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3107,6 +3110,26 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Couldn’t import that folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>Imported %n files into %1 folders — as many as one folder import takes. Import the remaining subfolders separately.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>Imported %n files into %1 folders.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Import Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Text</source>
         <translation type="unfinished">文本</translation>
     </message>
@@ -3192,6 +3215,10 @@
     </message>
     <message>
         <source>Import video, audio or image files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import a folder, keeping its structure as bin folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/drift_zh_Hans.ts
+++ b/i18n/drift_zh_Hans.ts
@@ -3120,6 +3120,12 @@
         </translation>
     </message>
     <message numerus="yes">
+        <source>Imported %n files into %1 folders. %2 files were skipped — Drift does not recognize their format. Drag them onto the bin to try anyway.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>Imported %n files into %1 folders.</source>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/src/models/AppController.cpp
+++ b/src/models/AppController.cpp
@@ -2827,6 +2827,10 @@ struct FolderImportEntry
 struct FolderImportPlan
 {
     QList<FolderImportEntry> entries;
+    // Files the walk looked at and passed over because nothing recognizes the extension. Only
+    // counts what was actually examined, so hitting the limit below does not inflate it with
+    // everything the walk never reached.
+    int skipped = 0;
     bool truncated = false;
 };
 
@@ -2850,8 +2854,10 @@ void planDirectory(const QDir &dir, int parentIndex, FolderImportPlan &plan, int
 
     const QFileInfoList files = dir.entryInfoList(QDir::Files, QDir::Name);
     for (const QFileInfo &info : files) {
-        if (!AssetLibrary::isMediaPath(info.fileName()))
+        if (!AssetLibrary::isMediaPath(info.fileName())) {
+            ++plan.skipped;
             continue;
+        }
         if (fileCount >= kFolderImportFileLimit) {
             plan.truncated = true;
             break;
@@ -2949,7 +2955,7 @@ bool AppController::importFolder(const QUrl &folderUrl)
 
         m_importingFolder = false;
         emit importingFolderChanged();
-        emit folderImportFinished(folderCount, fileCount, plan.truncated);
+        emit folderImportFinished(folderCount, fileCount, plan.skipped, plan.truncated);
     });
 
     watcher->setFuture(QtConcurrent::run([dir]() {

--- a/src/models/AppController.cpp
+++ b/src/models/AppController.cpp
@@ -2539,6 +2539,107 @@ int AppController::moveAssetsToFolder(const QStringList &assetIds, const QString
     return moved;
 }
 
+namespace {
+// Matches the extensions AssetsPanel.qml's import file picker offers, so a folder import never
+// treats a project file, cache entry, or stray document as media.
+bool isImportableMediaFile(const QFileInfo &info)
+{
+    static const QSet<QString> extensions = {
+        // video
+        QStringLiteral("mp4"), QStringLiteral("mov"), QStringLiteral("mkv"),
+        QStringLiteral("avi"), QStringLiteral("webm"), QStringLiteral("m4v"),
+        // audio
+        QStringLiteral("mp3"), QStringLiteral("wav"), QStringLiteral("aac"),
+        QStringLiteral("flac"), QStringLiteral("ogg"), QStringLiteral("m4a"),
+        // image
+        QStringLiteral("png"), QStringLiteral("jpg"), QStringLiteral("jpeg"),
+        QStringLiteral("gif"), QStringLiteral("webp"), QStringLiteral("bmp"),
+    };
+    return extensions.contains(info.suffix().toLower());
+}
+} // namespace
+
+void AppController::importDirectoryInto(const QDir &dir, const QString &parentFolderId,
+                                        int &folderCount, int &fileCount,
+                                        QSet<QString> &visitedDirs)
+{
+    // Guards against a symlinked subdirectory that loops back to an ancestor (or to another
+    // already-mirrored directory): canonicalFilePath() resolves the symlink, so the second
+    // visit is recognized and skipped instead of recursing forever.
+    const QString canonicalPath = QFileInfo(dir.absolutePath()).canonicalFilePath();
+    if (canonicalPath.isEmpty() || visitedDirs.contains(canonicalPath))
+        return;
+    visitedDirs.insert(canonicalPath);
+
+    const QString folderId = m_binFolderModel.createFolder(dir.dirName(), parentFolderId);
+    if (folderId.isEmpty())
+        return;
+    ++folderCount;
+
+    if (m_assetLibrary) {
+        QStringList mediaPaths;
+        const QFileInfoList entries = dir.entryInfoList(QDir::Files, QDir::Name);
+        for (const QFileInfo &info : entries) {
+            if (isImportableMediaFile(info))
+                mediaPaths.append(info.absoluteFilePath());
+        }
+        if (!mediaPaths.isEmpty()) {
+            // Retargeted for the duration of this one call — importLocalPaths reads it via
+            // m_importFolderId — then left for the caller to restore once the whole tree is done.
+            m_assetLibrary->setImportFolderId(folderId);
+            const QStringList ids = m_assetLibrary->importLocalPaths(mediaPaths);
+            fileCount += ids.size();
+            // A path already in the bin from an earlier import is returned as-is by
+            // importLocalPaths, keeping whatever folder it already lived in — otherwise this
+            // mirrored folder would look empty despite the file counting as imported into it.
+            for (const QString &id : ids) {
+                const int index = m_assetLibrary->indexOfId(id);
+                if (index < 0)
+                    continue;
+                if (m_assetLibrary->assetAt(index).value(QStringLiteral("folderId")).toString()
+                    != folderId)
+                    m_assetLibrary->moveAssetToFolder(index, folderId);
+            }
+        }
+    }
+
+    const QFileInfoList subdirs = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+    for (const QFileInfo &subdirInfo : subdirs) {
+        importDirectoryInto(QDir(subdirInfo.absoluteFilePath()), folderId, folderCount, fileCount,
+                            visitedDirs);
+    }
+}
+
+QVariantMap AppController::importFolder(const QUrl &folderUrl)
+{
+    const QString path = folderUrl.isLocalFile() ? folderUrl.toLocalFile() : folderUrl.toString();
+    const QDir dir(path);
+    if (path.isEmpty() || !dir.exists())
+        return {};
+
+    int folderCount = 0;
+    int fileCount = 0;
+    QSet<QString> visitedDirs;
+    importDirectoryInto(dir, m_currentBinFolderId, folderCount, fileCount, visitedDirs);
+
+    // The recursive walk above repointed the import destination at whichever subfolder it last
+    // populated; put it back at wherever the user is actually browsing.
+    if (m_assetLibrary)
+        m_assetLibrary->setImportFolderId(m_currentBinFolderId);
+
+    // Not pushed through pushProjectEdit: like a plain media import, this isn't meant to be
+    // undoable — "undo" is deleting the folder by hand, same as removing an imported asset. But
+    // unlike plain media import, autosave/the unsaved-changes prompt should still cover it, so
+    // it's marked dirty directly (the same split setProjectName/setProjectMetadata already use).
+    if (folderCount > 0)
+        setDirty(true);
+
+    return {
+        {QStringLiteral("folders"), folderCount},
+        {QStringLiteral("files"), fileCount},
+    };
+}
+
 bool AppController::replaceAssetSource(int assetIndex, const QUrl &url)
 {
     if (!m_assetLibrary)

--- a/src/models/AppController.cpp
+++ b/src/models/AppController.cpp
@@ -2808,54 +2808,118 @@ int AppController::moveAssetsToFolder(const QStringList &assetIds, const QString
 }
 
 namespace {
-// Matches the extensions AssetsPanel.qml's import file picker offers, so a folder import never
-// treats a project file, cache entry, or stray document as media.
-bool isImportableMediaFile(const QFileInfo &info)
-{
-    static const QSet<QString> extensions = {
-        // video
-        QStringLiteral("mp4"), QStringLiteral("mov"), QStringLiteral("mkv"),
-        QStringLiteral("avi"), QStringLiteral("webm"), QStringLiteral("m4v"),
-        // audio
-        QStringLiteral("mp3"), QStringLiteral("wav"), QStringLiteral("aac"),
-        QStringLiteral("flac"), QStringLiteral("ogg"), QStringLiteral("m4a"),
-        // image
-        QStringLiteral("png"), QStringLiteral("jpg"), QStringLiteral("jpeg"),
-        QStringLiteral("gif"), QStringLiteral("webp"), QStringLiteral("bmp"),
-    };
-    return extensions.contains(info.suffix().toLower());
-}
-} // namespace
 
-void AppController::importDirectoryInto(const QDir &dir, const QString &parentFolderId,
-                                        int &folderCount, int &fileCount,
-                                        QSet<QString> &visitedDirs)
+// A folder picked by mistake — a home directory, an external drive — can hold tens of thousands
+// of files, and importing them all means a probe and a thumbnail job each. The walk stops here
+// and says so, rather than filling the bin with something nobody asked for.
+constexpr int kFolderImportFileLimit = 500;
+
+// One filesystem directory, flattened out of the walk so the GUI-thread half can replay the tree
+// without touching the disk again. `parentIndex` points at an earlier entry in the same list;
+// -1 is the folder the user picked.
+struct FolderImportEntry
+{
+    QString name;
+    int parentIndex = -1;
+    QStringList files;
+};
+
+struct FolderImportPlan
+{
+    QList<FolderImportEntry> entries;
+    bool truncated = false;
+};
+
+// Runs on a worker thread: nothing here touches the project, the models, or anything else the
+// GUI thread owns. That matters most under Flatpak, where the picked directory is a
+// document-portal FUSE mount and every stat is a round trip out of the sandbox.
+void planDirectory(const QDir &dir, int parentIndex, FolderImportPlan &plan, int &fileCount,
+                   QSet<QString> &visitedDirs)
 {
     // Guards against a symlinked subdirectory that loops back to an ancestor (or to another
-    // already-mirrored directory): canonicalFilePath() resolves the symlink, so the second
+    // already-planned directory): canonicalFilePath() resolves the symlink, so the second
     // visit is recognized and skipped instead of recursing forever.
     const QString canonicalPath = QFileInfo(dir.absolutePath()).canonicalFilePath();
     if (canonicalPath.isEmpty() || visitedDirs.contains(canonicalPath))
         return;
     visitedDirs.insert(canonicalPath);
 
-    const QString folderId = m_binFolderModel.createFolder(dir.dirName(), parentFolderId);
-    if (folderId.isEmpty())
-        return;
-    ++folderCount;
+    FolderImportEntry entry;
+    entry.name = dir.dirName();
+    entry.parentIndex = parentIndex;
 
-    if (m_assetLibrary) {
-        QStringList mediaPaths;
-        const QFileInfoList entries = dir.entryInfoList(QDir::Files, QDir::Name);
-        for (const QFileInfo &info : entries) {
-            if (isImportableMediaFile(info))
-                mediaPaths.append(info.absoluteFilePath());
+    const QFileInfoList files = dir.entryInfoList(QDir::Files, QDir::Name);
+    for (const QFileInfo &info : files) {
+        if (!AssetLibrary::isMediaPath(info.fileName()))
+            continue;
+        if (fileCount >= kFolderImportFileLimit) {
+            plan.truncated = true;
+            break;
         }
-        if (!mediaPaths.isEmpty()) {
-            // Retargeted for the duration of this one call — importLocalPaths reads it via
-            // m_importFolderId — then left for the caller to restore once the whole tree is done.
+        entry.files.append(info.absoluteFilePath());
+        ++fileCount;
+    }
+
+    const int index = plan.entries.size();
+    plan.entries.append(entry);
+    // Stop the whole walk at the limit rather than only the file collection, so hitting it
+    // leaves a partial tree instead of thousands of empty mirrored folders.
+    if (plan.truncated)
+        return;
+
+    const QFileInfoList subdirs = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+    for (const QFileInfo &subdirInfo : subdirs) {
+        planDirectory(QDir(subdirInfo.absoluteFilePath()), index, plan, fileCount, visitedDirs);
+        if (plan.truncated)
+            return;
+    }
+}
+
+} // namespace
+
+bool AppController::importFolder(const QUrl &folderUrl)
+{
+    if (m_importingFolder)
+        return false;
+
+    const QString path = folderUrl.isLocalFile() ? folderUrl.toLocalFile() : folderUrl.toString();
+    const QDir dir(path);
+    if (path.isEmpty() || !dir.exists())
+        return false;
+
+    m_importingFolder = true;
+    emit importingFolderChanged();
+
+    // Only the walk is off-thread. Creating the bin folders and the asset rows stays on the GUI
+    // thread, because both are model mutations — but with the file limit above, that half is
+    // bounded work on data already in memory.
+    auto *watcher = new QFutureWatcher<FolderImportPlan>(this);
+    connect(watcher, &QFutureWatcher<FolderImportPlan>::finished, this, [this, watcher]() {
+        watcher->deleteLater();
+        const FolderImportPlan plan = watcher->result();
+
+        QStringList folderIds;
+        folderIds.reserve(plan.entries.size());
+        int folderCount = 0;
+        int fileCount = 0;
+
+        for (const FolderImportEntry &entry : plan.entries) {
+            const QString parentId =
+                entry.parentIndex < 0 ? m_currentBinFolderId : folderIds.at(entry.parentIndex);
+            const QString folderId = m_binFolderModel.createFolder(entry.name, parentId);
+            // Appended before the empty check so later entries' parentIndex stays aligned.
+            folderIds.append(folderId);
+            if (folderId.isEmpty())
+                continue;
+            ++folderCount;
+
+            if (entry.files.isEmpty() || !m_assetLibrary)
+                continue;
+
+            // Retargeted for the duration of this one entry — importLocalPaths reads it via
+            // m_importFolderId — then put back once the whole tree is done.
             m_assetLibrary->setImportFolderId(folderId);
-            const QStringList ids = m_assetLibrary->importLocalPaths(mediaPaths);
+            const QStringList ids = m_assetLibrary->importLocalPaths(entry.files);
             fileCount += ids.size();
             // A path already in the bin from an earlier import is returned as-is by
             // importLocalPaths, keeping whatever folder it already lived in — otherwise this
@@ -2869,43 +2933,33 @@ void AppController::importDirectoryInto(const QDir &dir, const QString &parentFo
                     m_assetLibrary->moveAssetToFolder(index, folderId);
             }
         }
-    }
 
-    const QFileInfoList subdirs = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
-    for (const QFileInfo &subdirInfo : subdirs) {
-        importDirectoryInto(QDir(subdirInfo.absoluteFilePath()), folderId, folderCount, fileCount,
-                            visitedDirs);
-    }
-}
+        // The loop above repointed the import destination at whichever folder it last populated;
+        // put it back at wherever the user is actually browsing.
+        if (m_assetLibrary)
+            m_assetLibrary->setImportFolderId(m_currentBinFolderId);
 
-QVariantMap AppController::importFolder(const QUrl &folderUrl)
-{
-    const QString path = folderUrl.isLocalFile() ? folderUrl.toLocalFile() : folderUrl.toString();
-    const QDir dir(path);
-    if (path.isEmpty() || !dir.exists())
-        return {};
+        // Not pushed through pushProjectEdit: like a plain media import, this isn't meant to be
+        // undoable — "undo" is deleting the folder by hand, same as removing an imported asset.
+        // But unlike plain media import, autosave/the unsaved-changes prompt should still cover
+        // it, so it's marked dirty directly (the same split setProjectName/setProjectMetadata
+        // already use).
+        if (folderCount > 0)
+            setDirty(true);
 
-    int folderCount = 0;
-    int fileCount = 0;
-    QSet<QString> visitedDirs;
-    importDirectoryInto(dir, m_currentBinFolderId, folderCount, fileCount, visitedDirs);
+        m_importingFolder = false;
+        emit importingFolderChanged();
+        emit folderImportFinished(folderCount, fileCount, plan.truncated);
+    });
 
-    // The recursive walk above repointed the import destination at whichever subfolder it last
-    // populated; put it back at wherever the user is actually browsing.
-    if (m_assetLibrary)
-        m_assetLibrary->setImportFolderId(m_currentBinFolderId);
-
-    // Not pushed through pushProjectEdit: like a plain media import, this isn't meant to be
-    // undoable — "undo" is deleting the folder by hand, same as removing an imported asset. But
-    // unlike plain media import, autosave/the unsaved-changes prompt should still cover it, so
-    // it's marked dirty directly (the same split setProjectName/setProjectMetadata already use).
-    if (folderCount > 0)
-        setDirty(true);
-
-    return {
-        {QStringLiteral("folders"), folderCount},
-        {QStringLiteral("files"), fileCount},
-    };
+    watcher->setFuture(QtConcurrent::run([dir]() {
+        FolderImportPlan plan;
+        int fileCount = 0;
+        QSet<QString> visitedDirs;
+        planDirectory(dir, -1, plan, fileCount, visitedDirs);
+        return plan;
+    }));
+    return true;
 }
 
 bool AppController::replaceAssetSource(int assetIndex, const QUrl &url)

--- a/src/models/AppController.h
+++ b/src/models/AppController.h
@@ -39,6 +39,7 @@
 
 struct EffectTemplateEntry;
 
+class QDir;
 class QTimer;
 class AddonManager;
 
@@ -575,6 +576,14 @@ public:
     Q_INVOKABLE bool moveAssetToFolder(int assetIndex, const QString &folderId);
     // Multi-select bulk move, one undo step for the whole batch. Returns how many were moved.
     Q_INVOKABLE int moveAssetsToFolder(const QStringList &assetIds, const QString &folderId);
+    // Imports a whole directory: mirrors its subfolder tree into the bin (one new bin folder per
+    // filesystem folder, including empty ones) and imports every media file into the bin folder
+    // matching its containing directory. `folderUrl` must be a local (file://) directory. Returns
+    // {"folders": N, "files": N} counting what was created/queued, or an empty map if the URL
+    // didn't resolve to a readable directory. Not undoable — like a plain media import, "undo" is
+    // deleting the folder by hand — but still marks the project dirty, so autosave and the
+    // unsaved-changes prompt cover the hierarchy it creates.
+    Q_INVOKABLE QVariantMap importFolder(const QUrl &folderUrl);
     // Points an existing bin row at a different file, keeping every clip that uses it where it
     // is — its position, trim, effects and transitions all survive. Asynchronous: true only means
     // the probe started, and the outcome arrives as assetReplaceFinished.
@@ -1319,6 +1328,13 @@ signals:
 
 protected:
     void pushProjectEdit(const drift::Project &before, const QString &text);
+    // Recursive worker behind importFolder: creates a bin folder for `dir` under parentFolderId,
+    // imports the media files directly inside it, then recurses into its subdirectories. Tallies
+    // into folderCount/fileCount as it goes. `visitedDirs` holds every canonical path already
+    // mirrored, so a symlink cycle (or a diamond pointing at the same real directory twice)
+    // stops instead of recursing forever.
+    void importDirectoryInto(const QDir &dir, const QString &parentFolderId, int &folderCount,
+                             int &fileCount, QSet<QString> &visitedDirs);
 
     // Lifts one effect, one audio effect, or the whole stack off a clip. Every copy and
     // save-as-preset entry point funnels through this, so all of them produce one payload shape.

--- a/src/models/AppController.h
+++ b/src/models/AppController.h
@@ -1329,9 +1329,10 @@ signals:
     // the replacement and was pulled back to it.
     void assetReplaceFinished(bool ok, const QString &message, int adjustedClips);
     void importingFolderChanged();
-    // Outcome of importFolder: how many bin folders and assets it actually created, and whether
-    // the walk stopped at the file limit with more still on disk.
-    void folderImportFinished(int folders, int files, bool truncated);
+    // Outcome of importFolder: how many bin folders and assets it actually created, how many
+    // files it passed over as unrecognized, and whether the walk stopped at the file limit with
+    // more still on disk.
+    void folderImportFinished(int folders, int files, int skipped, bool truncated);
     void replacingAssetIdChanged();
     void assetEditChanged();
     void assetEditFinished(bool ok, const QString &message);

--- a/src/models/AppController.h
+++ b/src/models/AppController.h
@@ -39,7 +39,6 @@
 
 struct EffectTemplateEntry;
 
-class QDir;
 class QTimer;
 class AddonManager;
 
@@ -63,6 +62,9 @@ class AppController : public QObject
     // not persisted, not undoable, same treatment as mediaGridMode's touch-only sibling.
     Q_PROPERTY(QString currentBinFolderId READ currentBinFolderId WRITE setCurrentBinFolderId
                    NOTIFY currentBinFolderIdChanged)
+    // True while importFolder's off-thread directory walk is running, so the bin can raise its
+    // progress overlay over a slow tree (a big hierarchy, or a Flatpak document-portal mount).
+    Q_PROPERTY(bool importingFolder READ importingFolder NOTIFY importingFolderChanged)
     Q_PROPERTY(TimelineModel *timelineModel READ timelineModel CONSTANT)
     Q_PROPERTY(ClipListModel *clipListModel READ clipListModel CONSTANT)
     Q_PROPERTY(PlaybackEngine *playback READ playback CONSTANT)
@@ -584,12 +586,15 @@ public:
     Q_INVOKABLE int moveAssetsToFolder(const QStringList &assetIds, const QString &folderId);
     // Imports a whole directory: mirrors its subfolder tree into the bin (one new bin folder per
     // filesystem folder, including empty ones) and imports every media file into the bin folder
-    // matching its containing directory. `folderUrl` must be a local (file://) directory. Returns
-    // {"folders": N, "files": N} counting what was created/queued, or an empty map if the URL
-    // didn't resolve to a readable directory. Not undoable — like a plain media import, "undo" is
-    // deleting the folder by hand — but still marks the project dirty, so autosave and the
+    // matching its containing directory. `folderUrl` must be a local (file://) directory. The
+    // directory walk runs off-thread, so this returns as soon as it starts — false means the URL
+    // didn't resolve to a readable directory or an import was already running, and the outcome
+    // arrives as folderImportFinished. Stops after a fixed number of files so a folder picked by
+    // mistake can't queue thousands of probes. Not undoable — like a plain media import, "undo"
+    // is deleting the folder by hand — but still marks the project dirty, so autosave and the
     // unsaved-changes prompt cover the hierarchy it creates.
-    Q_INVOKABLE QVariantMap importFolder(const QUrl &folderUrl);
+    Q_INVOKABLE bool importFolder(const QUrl &folderUrl);
+    bool importingFolder() const { return m_importingFolder; }
     // Points an existing bin row at a different file, keeping every clip that uses it where it
     // is — its position, trim, effects and transitions all survive. Asynchronous: true only means
     // the probe started, and the outcome arrives as assetReplaceFinished.
@@ -1323,6 +1328,10 @@ signals:
     // media's name on success. `adjustedClips` counts clips whose source range no longer fitted
     // the replacement and was pulled back to it.
     void assetReplaceFinished(bool ok, const QString &message, int adjustedClips);
+    void importingFolderChanged();
+    // Outcome of importFolder: how many bin folders and assets it actually created, and whether
+    // the walk stopped at the file limit with more still on disk.
+    void folderImportFinished(int folders, int files, bool truncated);
     void replacingAssetIdChanged();
     void assetEditChanged();
     void assetEditFinished(bool ok, const QString &message);
@@ -1334,13 +1343,6 @@ signals:
 
 protected:
     void pushProjectEdit(const drift::Project &before, const QString &text);
-    // Recursive worker behind importFolder: creates a bin folder for `dir` under parentFolderId,
-    // imports the media files directly inside it, then recurses into its subdirectories. Tallies
-    // into folderCount/fileCount as it goes. `visitedDirs` holds every canonical path already
-    // mirrored, so a symlink cycle (or a diamond pointing at the same real directory twice)
-    // stops instead of recursing forever.
-    void importDirectoryInto(const QDir &dir, const QString &parentFolderId, int &folderCount,
-                             int &fileCount, QSet<QString> &visitedDirs);
 
     // Lifts one effect, one audio effect, or the whole stack off a clip. Every copy and
     // save-as-preset entry point funnels through this, so all of them produce one payload shape.
@@ -1500,6 +1502,7 @@ protected:
     AddonManager *m_addonManager = nullptr;
     BinFolderListModel m_binFolderModel;
     QString m_currentBinFolderId;
+    bool m_importingFolder = false;
     TimelineModel m_timelineModel;
     ClipListModel m_clipListModel;
     // These trees must outlive m_playback: the compositor thread holds a bare

--- a/src/models/AssetLibrary.cpp
+++ b/src/models/AssetLibrary.cpp
@@ -132,29 +132,41 @@ QString materializeImportUrl(const QUrl &url)
 
 #endif // Q_OS_ANDROID
 
-bool isImagePath(const QString &path)
+// The one place that decides what counts as media. The picker's name filter, the folder-import
+// walk and the provisional kind guess all read these lists, so a format can no longer be offered
+// by one entry point and skipped by another.
+const QStringList &videoExtensions()
 {
     static const QStringList extensions = {
-        QStringLiteral("png"),  QStringLiteral("jpg"),  QStringLiteral("jpeg"),
-        QStringLiteral("gif"),  QStringLiteral("webp"), QStringLiteral("bmp"),
-        QStringLiteral("tiff"), QStringLiteral("tif"),  QStringLiteral("svg"),
+        QStringLiteral("mp4"), QStringLiteral("mov"),  QStringLiteral("mkv"),
+        QStringLiteral("avi"), QStringLiteral("webm"), QStringLiteral("m4v"),
     };
-    return extensions.contains(QFileInfo(path).suffix().toLower());
+    return extensions;
 }
 
-bool isAudioPath(const QString &path)
+const QStringList &audioExtensions()
 {
     static const QStringList extensions = {
         QStringLiteral("mp3"),  QStringLiteral("wav"),  QStringLiteral("aac"),
         QStringLiteral("flac"), QStringLiteral("ogg"),  QStringLiteral("m4a"),
         QStringLiteral("wma"),  QStringLiteral("aiff"), QStringLiteral("aif"),
     };
-    return extensions.contains(QFileInfo(path).suffix().toLower());
+    return extensions;
+}
+
+const QStringList &imageExtensions()
+{
+    static const QStringList extensions = {
+        QStringLiteral("png"),  QStringLiteral("jpg"),  QStringLiteral("jpeg"),
+        QStringLiteral("gif"),  QStringLiteral("webp"), QStringLiteral("bmp"),
+        QStringLiteral("tiff"), QStringLiteral("tif"),  QStringLiteral("svg"),
+    };
+    return extensions;
 }
 
 drift::MediaKind kindFrom(const MediaInfo &info, const QString &path)
 {
-    if (isImagePath(path))
+    if (AssetLibrary::isImagePath(path))
         return drift::MediaKind::Image;
 
     for (const StreamInfo &stream : info.streams) {
@@ -170,9 +182,9 @@ drift::MediaKind kindFrom(const MediaInfo &info, const QString &path)
 
 drift::MediaKind provisionalKind(const QString &path)
 {
-    if (isImagePath(path))
+    if (AssetLibrary::isImagePath(path))
         return drift::MediaKind::Image;
-    if (isAudioPath(path))
+    if (AssetLibrary::isAudioPath(path))
         return drift::MediaKind::Audio;
     return drift::MediaKind::Video;
 }
@@ -282,6 +294,39 @@ std::optional<drift::MediaAsset> probeAsset(const QString &absolutePath, bool im
 }
 
 } // namespace
+
+bool AssetLibrary::isVideoPath(const QString &path)
+{
+    return videoExtensions().contains(QFileInfo(path).suffix().toLower());
+}
+
+bool AssetLibrary::isAudioPath(const QString &path)
+{
+    return audioExtensions().contains(QFileInfo(path).suffix().toLower());
+}
+
+bool AssetLibrary::isImagePath(const QString &path)
+{
+    return imageExtensions().contains(QFileInfo(path).suffix().toLower());
+}
+
+bool AssetLibrary::isMediaPath(const QString &path)
+{
+    return isVideoPath(path) || isAudioPath(path) || isImagePath(path);
+}
+
+QString AssetLibrary::mediaNameFilter() const
+{
+    static const QString pattern = [] {
+        QStringList globs;
+        for (const QStringList *group : {&videoExtensions(), &audioExtensions(), &imageExtensions()}) {
+            for (const QString &extension : *group)
+                globs.append(QStringLiteral("*.") + extension);
+        }
+        return globs.join(QLatin1Char(' '));
+    }();
+    return tr("Media files (%1)").arg(pattern);
+}
 
 bool AssetLibrary::sandboxed() const
 {

--- a/src/models/AssetLibrary.cpp
+++ b/src/models/AssetLibrary.cpp
@@ -135,11 +135,31 @@ QString materializeImportUrl(const QUrl &url)
 // The one place that decides what counts as media. The picker's name filter, the folder-import
 // walk and the provisional kind guess all read these lists, so a format can no longer be offered
 // by one entry point and skipped by another.
+// Containers FFmpeg demuxes, not everything it can be made to open: its own extension table is
+// no help here, since half of these demuxers probe instead of matching on a suffix (mpegts and
+// mpeg declare none at all) while the ones that do declare cover raw streams, subtitles and
+// tracker music. Anything not here can still be dragged onto the bin, where the probe decides.
 const QStringList &videoExtensions()
 {
     static const QStringList extensions = {
-        QStringLiteral("mp4"), QStringLiteral("mov"),  QStringLiteral("mkv"),
-        QStringLiteral("avi"), QStringLiteral("webm"), QStringLiteral("m4v"),
+        // MP4 / QuickTime family
+        QStringLiteral("mp4"),  QStringLiteral("m4v"),  QStringLiteral("mov"),
+        QStringLiteral("3gp"),  QStringLiteral("3g2"),
+        // Matroska
+        QStringLiteral("mkv"),  QStringLiteral("webm"),
+        // AVI / ASF
+        QStringLiteral("avi"),  QStringLiteral("wmv"),  QStringLiteral("asf"),
+        QStringLiteral("divx"),
+        // Flash
+        QStringLiteral("flv"),  QStringLiteral("f4v"),
+        // MPEG program and transport streams
+        QStringLiteral("mpg"),  QStringLiteral("mpeg"), QStringLiteral("m2v"),
+        QStringLiteral("ts"),   QStringLiteral("m2ts"), QStringLiteral("mts"),
+        QStringLiteral("m2t"),  QStringLiteral("vob"),
+        // Ogg, RealMedia
+        QStringLiteral("ogv"),  QStringLiteral("rm"),   QStringLiteral("rmvb"),
+        // Broadcast and camera
+        QStringLiteral("mxf"),  QStringLiteral("dv"),   QStringLiteral("y4m"),
     };
     return extensions;
 }

--- a/src/models/AssetLibrary.h
+++ b/src/models/AssetLibrary.h
@@ -62,6 +62,15 @@ public:
     Q_INVOKABLE bool importUrlsAsync(const QList<QUrl> &urls);
     bool importing() const { return m_importing; }
     bool sandboxed() const;
+    // The one place that decides what counts as media, so the file picker, the folder-import
+    // walk and the kind guess can never disagree about a format. Extension-only: the real kind
+    // comes from the probe once the file is open.
+    static bool isVideoPath(const QString &path);
+    static bool isAudioPath(const QString &path);
+    static bool isImagePath(const QString &path);
+    static bool isMediaPath(const QString &path);
+    // The same set spelled as a QFileDialog name filter, e.g. "Media files (*.mp4 *.mov ...)".
+    Q_INVOKABLE QString mediaNameFilter() const;
     // Import local paths and return the asset ids involved (new or already-present).
     QStringList importLocalPaths(const QStringList &paths);
     bool isImportPending(const QString &assetId) const;

--- a/src/models/FileDialogs.cpp
+++ b/src/models/FileDialogs.cpp
@@ -157,6 +157,24 @@ QList<QUrl> FileDialogs::openFiles(const QString &title, const QStringList &name
     return dialog.selectedUrls();
 }
 
+QUrl FileDialogs::openDirectory(const QString &title) const
+{
+#ifdef Q_OS_ANDROID
+    Q_UNUSED(title);
+    return {};
+#else
+    QFileDialog dialog;
+    dialog.setWindowTitle(title);
+    dialog.setAcceptMode(QFileDialog::AcceptOpen);
+    dialog.setFileMode(QFileDialog::Directory);
+    dialog.setOption(QFileDialog::ShowDirsOnly, true);
+    if (dialog.exec() != QDialog::Accepted)
+        return {};
+    const QList<QUrl> urls = dialog.selectedUrls();
+    return urls.isEmpty() ? QUrl() : urls.first();
+#endif
+}
+
 QUrl FileDialogs::saveFile(const QString &title, const QStringList &nameFilters,
                            const QString &suggestedName, const QString &suffix,
                            const QString &initialDirectory, const QStringList &mimeTypeFilters) const

--- a/src/models/FileDialogs.h
+++ b/src/models/FileDialogs.h
@@ -21,6 +21,10 @@ public:
     Q_INVOKABLE QUrl openFile(const QString &title, const QStringList &nameFilters,
                               const QStringList &mimeTypeFilters = QStringList()) const;
     Q_INVOKABLE QList<QUrl> openFiles(const QString &title, const QStringList &nameFilters) const;
+    // Native directory picker, for importing a folder's contents with its structure preserved.
+    // Empty URL when cancelled. Not offered on Android: SAF's tree picker (ACTION_OPEN_DOCUMENT_TREE)
+    // is a different flow than the document picker this class wraps, and isn't wired up.
+    Q_INVOKABLE QUrl openDirectory(const QString &title) const;
     // `suffix` is appended to `suggestedName` for the picker's initial file name; the path the
     // dialog returns is used exactly as given. `initialDirectory` opens the picker in that folder
     // when it exists (e.g. the last export location). `mimeTypeFilters` are used when those types

--- a/src/qml/AssetsPanel.qml
+++ b/src/qml/AssetsPanel.qml
@@ -90,8 +90,9 @@ PanelFrame {
         }
     }
 
-    // True while an import is running, so the panel can show progress.
-    readonly property bool importing: AssetLibrary.importing
+    // True while an import is running, so the panel can show progress. The folder walk counts:
+    // it is the half that can take a while on a deep tree or a sandboxed (portal) mount.
+    readonly property bool importing: AssetLibrary.importing || EditorState.importingFolder
 
     // A single id goes through the existing single-asset add so that case is byte-for-byte the
     // behavior it always was; only an actual multi-selection goes through the batch add, which
@@ -517,9 +518,7 @@ PanelFrame {
     // Points a bin row at a different file while every clip using it stays put, so a project set
     // up once — music, outro, CTA — can be re-pointed at the next video instead of rebuilt.
     function requestReplaceAsset(assetIndex) {
-        var url = FileDialogs.openFile(qsTr("Replace Media"), [
-            qsTr("Media files (*.mp4 *.mov *.mkv *.avi *.webm *.m4v *.mp3 *.wav *.aac *.flac *.ogg *.m4a *.png *.jpg *.jpeg *.gif *.webp *.bmp)")
-        ])
+        var url = FileDialogs.openFile(qsTr("Replace Media"), [AssetLibrary.mediaNameFilter()])
         if (!url || url.toString() === "")
             return
         EditorState.replaceAssetSource(assetIndex, url)
@@ -546,6 +545,16 @@ PanelFrame {
     Connections {
         target: EditorState
 
+        function onFolderImportFinished(folders, files, truncated) {
+            if (folders === 0) {
+                Toasts.error(qsTr("Couldn’t import that folder."))
+            } else if (truncated) {
+                Toasts.warning(qsTr("Imported %n files into %1 folders — as many as one folder import takes. Import the remaining subfolders separately.", "", files).arg(folders))
+            } else {
+                Toasts.success(qsTr("Imported %n files into %1 folders.", "", files).arg(folders))
+            }
+        }
+
         // The probe runs off-thread, so the outcome comes back here rather than from the call.
         function onAssetReplaceFinished(ok, message, adjustedClips) {
             if (!ok) {
@@ -568,9 +577,7 @@ PanelFrame {
     }
 
     function importMedia() {
-        var urls = FileDialogs.openFiles(qsTr("Import Media"), [
-            qsTr("Media files (*.mp4 *.mov *.mkv *.avi *.webm *.m4v *.mp3 *.wav *.aac *.flac *.ogg *.m4a *.png *.jpg *.jpeg *.gif *.webp *.bmp)")
-        ])
+        var urls = FileDialogs.openFiles(qsTr("Import Media"), [AssetLibrary.mediaNameFilter()])
         root.importUrlsReporting(urls)
     }
 
@@ -582,12 +589,9 @@ PanelFrame {
         var url = FileDialogs.openDirectory(qsTr("Import Folder"))
         if (!url || url.toString() === "")
             return
-        const result = EditorState.importFolder(url)
-        if (!result || !result.folders) {
+        // The walk runs off-thread, so the outcome arrives as onFolderImportFinished below.
+        if (!EditorState.importFolder(url))
             Toasts.error(qsTr("Couldn’t import that folder."))
-            return
-        }
-        Toasts.success(qsTr("Imported %n files into %1 folders.", "", result.files).arg(result.folders))
     }
 
     // Selects a tab by id. Used by cross-panel jumps such as the properties

--- a/src/qml/AssetsPanel.qml
+++ b/src/qml/AssetsPanel.qml
@@ -545,11 +545,15 @@ PanelFrame {
     Connections {
         target: EditorState
 
-        function onFolderImportFinished(folders, files, truncated) {
+        // Hitting the limit outranks the skipped count: the walk stopped early, so what it passed
+        // over is only part of the story and saying both would suggest otherwise.
+        function onFolderImportFinished(folders, files, skipped, truncated) {
             if (folders === 0) {
                 Toasts.error(qsTr("Couldn’t import that folder."))
             } else if (truncated) {
                 Toasts.warning(qsTr("Imported %n files into %1 folders — as many as one folder import takes. Import the remaining subfolders separately.", "", files).arg(folders))
+            } else if (skipped > 0) {
+                Toasts.warning(qsTr("Imported %n files into %1 folders. %2 files were skipped — Drift does not recognize their format. Drag them onto the bin to try anyway.", "", files).arg(folders).arg(skipped))
             } else {
                 Toasts.success(qsTr("Imported %n files into %1 folders.", "", files).arg(folders))
             }

--- a/src/qml/AssetsPanel.qml
+++ b/src/qml/AssetsPanel.qml
@@ -567,6 +567,22 @@ PanelFrame {
         root.importUrlsReporting(urls)
     }
 
+    // Imports a whole directory: a new bin folder mirrors the picked folder (and everything
+    // nested under it), and every media file lands in the bin folder matching its containing
+    // directory. EditorState.importFolder does the walk synchronously — probing and
+    // thumbnailing each file still happens in the background the same as any other import.
+    function importFolder() {
+        var url = FileDialogs.openDirectory(qsTr("Import Folder"))
+        if (!url || url.toString() === "")
+            return
+        const result = EditorState.importFolder(url)
+        if (!result || !result.folders) {
+            Toasts.error(qsTr("Couldn’t import that folder."))
+            return
+        }
+        Toasts.success(qsTr("Imported %n files into %1 folders.", "", result.files).arg(result.folders))
+    }
+
     // Selects a tab by id. Used by cross-panel jumps such as the properties
     // panel's "Browse effects" / "Browse audio effects" empty-state actions.
     function showTab(tabId) {
@@ -917,6 +933,17 @@ PanelFrame {
                         enabled: !root.importing
                         anchors.verticalCenter: parent.verticalCenter
                         onClicked: root.importMedia()
+                    }
+
+                    ThemedButton {
+                        text: qsTr("Import Folder")
+                        variant: "ghost"
+                        glyph: Theme.icons.folderInput
+                        tooltip: qsTr("Import a folder, keeping its structure as bin folders")
+                        enabled: !root.importing
+                        visible: !Theme.touchUi
+                        anchors.verticalCenter: parent.verticalCenter
+                        onClicked: root.importFolder()
                     }
                 }
             }

--- a/tests/tst_editorstate.cpp
+++ b/tests/tst_editorstate.cpp
@@ -538,7 +538,9 @@ void EditorStateTest::importFolderMirrorsDirectoryTree()
     // root, SubA, SubB, EmptyDir.
     QCOMPARE(finished.first().at(0).toInt(), 4);
     QCOMPARE(finished.first().at(1).toInt(), 3);
-    QVERIFY(!finished.first().at(2).toBool());
+    // notes.txt, and nothing else.
+    QCOMPARE(finished.first().at(2).toInt(), 1);
+    QVERIFY(!finished.first().at(3).toBool());
     QCOMPARE(library.count(), 3);
     QCOMPARE(state.binFolderModel()->count(), 4);
 
@@ -697,8 +699,10 @@ void EditorStateTest::importFolderStopsAtFileLimit()
     QSignalSpy finished(&state, &AppController::folderImportFinished);
     QVERIFY(state.importFolder(QUrl::fromLocalFile(tempDir.path())));
     QTRY_COMPARE_WITH_TIMEOUT(finished.count(), 1, 30000);
-    QVERIFY(finished.first().at(2).toBool());
+    QVERIFY(finished.first().at(3).toBool());
     QCOMPARE(finished.first().at(1).toInt(), 500);
+    // Everything in the tree is media, so stopping early must not be reported as skipping.
+    QCOMPARE(finished.first().at(2).toInt(), 0);
 
     // The probes these kicked off run on worker threads that capture `library` by raw pointer, so
     // they have to finish before teardown. None of the placeholder files is real media, so every

--- a/tests/tst_editorstate.cpp
+++ b/tests/tst_editorstate.cpp
@@ -66,6 +66,7 @@ private slots:
     void importFolderMirrorsDirectoryTree();
     void importFolderMovesAlreadyImportedMediaIntoMirroredFolder();
     void importFolderSkipsSymlinkCycles();
+    void importFolderStopsAtFileLimit();
     void moveAssetToFolderAndUndo();
     void moveBinFolderReparentsAndUndo();
     void moveBinFolderRefusesCycle();
@@ -515,22 +516,29 @@ void EditorStateTest::importFolderMirrorsDirectoryTree()
     QVERIFY(root.mkpath(QStringLiteral("SubA/SubB")));
     QVERIFY(root.mkpath(QStringLiteral("EmptyDir")));
 
-    auto writeFile = [](const QString &path) {
-        QFile file(path);
-        QVERIFY(file.open(QIODevice::WriteOnly));
-        file.write("not a real media file");
-        file.close();
+    // Real 1x1 images, not placeholder bytes: a file that fails to probe is dropped from the bin
+    // again, and the folder assertions below need the rows to still be there.
+    auto writeMedia = [](const QString &path) {
+        QImage image(1, 1, QImage::Format_RGB32);
+        image.fill(Qt::black);
+        QVERIFY(image.save(path));
     };
-    writeFile(root.filePath(QStringLiteral("root.mp4")));
-    writeFile(root.filePath(QStringLiteral("SubA/a.mp4")));
-    writeFile(root.filePath(QStringLiteral("SubA/SubB/b.mp4")));
+    writeMedia(root.filePath(QStringLiteral("root.png")));
+    writeMedia(root.filePath(QStringLiteral("SubA/a.png")));
+    writeMedia(root.filePath(QStringLiteral("SubA/SubB/b.png")));
     // A non-media sidecar file must be left out of the import.
-    writeFile(root.filePath(QStringLiteral("SubA/notes.txt")));
+    QFile notes(root.filePath(QStringLiteral("SubA/notes.txt")));
+    QVERIFY(notes.open(QIODevice::WriteOnly));
+    notes.write("not a real media file");
+    notes.close();
 
-    const QVariantMap result = state.importFolder(QUrl::fromLocalFile(tempDir.path()));
+    QSignalSpy finished(&state, &AppController::folderImportFinished);
+    QVERIFY(state.importFolder(QUrl::fromLocalFile(tempDir.path())));
+    QTRY_COMPARE_WITH_TIMEOUT(finished.count(), 1, 10000);
     // root, SubA, SubB, EmptyDir.
-    QCOMPARE(result.value(QStringLiteral("folders")).toInt(), 4);
-    QCOMPARE(result.value(QStringLiteral("files")).toInt(), 3);
+    QCOMPARE(finished.first().at(0).toInt(), 4);
+    QCOMPARE(finished.first().at(1).toInt(), 3);
+    QVERIFY(!finished.first().at(2).toBool());
     QCOMPARE(library.count(), 3);
     QCOMPARE(state.binFolderModel()->count(), 4);
 
@@ -568,9 +576,9 @@ void EditorStateTest::importFolderMirrorsDirectoryTree()
         }
         return QString(QStringLiteral("<not found>"));
     };
-    QCOMPARE(folderIdOfAsset(QStringLiteral("root.mp4")), rootFolderId);
-    QCOMPARE(folderIdOfAsset(QStringLiteral("a.mp4")), subAId);
-    QCOMPARE(folderIdOfAsset(QStringLiteral("b.mp4")), subBId);
+    QCOMPARE(folderIdOfAsset(QStringLiteral("root.png")), rootFolderId);
+    QCOMPARE(folderIdOfAsset(QStringLiteral("a.png")), subAId);
+    QCOMPARE(folderIdOfAsset(QStringLiteral("b.png")), subBId);
 
     // Import destination is left wherever the user was browsing (root), not inside the tree
     // this walk last populated.
@@ -600,14 +608,10 @@ void EditorStateTest::importFolderMovesAlreadyImportedMediaIntoMirroredFolder()
     QDir root(tempDir.path());
     QVERIFY(root.mkpath(QStringLiteral("SubA")));
 
-    auto writeFile = [](const QString &path) {
-        QFile file(path);
-        QVERIFY(file.open(QIODevice::WriteOnly));
-        file.write("not a real media file");
-        file.close();
-    };
-    const QString filePath = root.filePath(QStringLiteral("SubA/a.mp4"));
-    writeFile(filePath);
+    const QString filePath = root.filePath(QStringLiteral("SubA/a.png"));
+    QImage image(1, 1, QImage::Format_RGB32);
+    image.fill(Qt::black);
+    QVERIFY(image.save(filePath));
 
     // The file is already in the bin — imported individually, at the root — before the folder
     // import ever runs.
@@ -617,8 +621,10 @@ void EditorStateTest::importFolderMovesAlreadyImportedMediaIntoMirroredFolder()
     QCOMPARE(library.assetAt(library.indexOfId(assetId)).value(QStringLiteral("folderId")).toString(),
              QString());
 
-    const QVariantMap result = state.importFolder(QUrl::fromLocalFile(tempDir.path()));
-    QCOMPARE(result.value(QStringLiteral("files")).toInt(), 1);
+    QSignalSpy finished(&state, &AppController::folderImportFinished);
+    QVERIFY(state.importFolder(QUrl::fromLocalFile(tempDir.path())));
+    QTRY_COMPARE_WITH_TIMEOUT(finished.count(), 1, 10000);
+    QCOMPARE(finished.first().at(1).toInt(), 1);
     QCOMPARE(library.count(), 1);
 
     // The mirrored SubA folder must actually contain the file, not sit empty while the count
@@ -658,9 +664,46 @@ void EditorStateTest::importFolderSkipsSymlinkCycles()
     // Hangs (or stack-overflows) here if the visited-set guard regresses — there is no bound on
     // the recursion otherwise, since the symlink always resolves back to an already-mirrored
     // directory.
-    const QVariantMap result = state.importFolder(QUrl::fromLocalFile(tempDir.path()));
+    QSignalSpy finished(&state, &AppController::folderImportFinished);
+    QVERIFY(state.importFolder(QUrl::fromLocalFile(tempDir.path())));
+    QTRY_COMPARE_WITH_TIMEOUT(finished.count(), 1, 10000);
     // root and SubA only — the cycle back through the symlink is skipped, not re-descended.
-    QCOMPARE(result.value(QStringLiteral("folders")).toInt(), 2);
+    QCOMPARE(finished.first().at(0).toInt(), 2);
+}
+
+void EditorStateTest::importFolderStopsAtFileLimit()
+{
+    AssetLibrary library;
+    AppController state(&library);
+
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    QDir root(tempDir.path());
+    QVERIFY(root.mkpath(QStringLiteral("Deeper")));
+
+    // Comfortably past the limit, and split across two directories so the walk has to stop
+    // mid-tree rather than at a directory boundary.
+    for (int i = 0; i < 400; ++i) {
+        QFile file(root.filePath(QStringLiteral("root%1.mp4").arg(i)));
+        QVERIFY(file.open(QIODevice::WriteOnly));
+        file.close();
+    }
+    for (int i = 0; i < 400; ++i) {
+        QFile file(root.filePath(QStringLiteral("Deeper/deep%1.mp4").arg(i)));
+        QVERIFY(file.open(QIODevice::WriteOnly));
+        file.close();
+    }
+
+    QSignalSpy finished(&state, &AppController::folderImportFinished);
+    QVERIFY(state.importFolder(QUrl::fromLocalFile(tempDir.path())));
+    QTRY_COMPARE_WITH_TIMEOUT(finished.count(), 1, 30000);
+    QVERIFY(finished.first().at(2).toBool());
+    QCOMPARE(finished.first().at(1).toInt(), 500);
+
+    // The probes these kicked off run on worker threads that capture `library` by raw pointer, so
+    // they have to finish before teardown. None of the placeholder files is real media, so every
+    // one of them fails to probe and drops its row again — draining the bin is the wait.
+    QTRY_COMPARE_WITH_TIMEOUT(library.count(), 0, 60000);
 }
 
 void EditorStateTest::moveAssetToFolderAndUndo()

--- a/tests/tst_editorstate.cpp
+++ b/tests/tst_editorstate.cpp
@@ -63,6 +63,9 @@ private slots:
     void undoingBinFolderRenameEmitsDataChanged();
     void importIntoDeletedFolderFallsBackToRoot();
     void importUnreadableUrlReportsFailed();
+    void importFolderMirrorsDirectoryTree();
+    void importFolderMovesAlreadyImportedMediaIntoMirroredFolder();
+    void importFolderSkipsSymlinkCycles();
     void moveAssetToFolderAndUndo();
     void moveBinFolderReparentsAndUndo();
     void moveBinFolderRefusesCycle();
@@ -496,6 +499,165 @@ void EditorStateTest::importUnreadableUrlReportsFailed()
     QCOMPARE(finished.first().at(0).toInt(), 0);
     QCOMPARE(finished.first().at(1).toInt(), 1);
     QCOMPARE(library.count(), 0);
+}
+
+void EditorStateTest::importFolderMirrorsDirectoryTree()
+{
+    AssetLibrary library;
+    AppController state(&library);
+
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    QDir root(tempDir.path());
+    QVERIFY(root.mkpath(QStringLiteral("SubA/SubB")));
+    QVERIFY(root.mkpath(QStringLiteral("EmptyDir")));
+
+    auto writeFile = [](const QString &path) {
+        QFile file(path);
+        QVERIFY(file.open(QIODevice::WriteOnly));
+        file.write("not a real media file");
+        file.close();
+    };
+    writeFile(root.filePath(QStringLiteral("root.mp4")));
+    writeFile(root.filePath(QStringLiteral("SubA/a.mp4")));
+    writeFile(root.filePath(QStringLiteral("SubA/SubB/b.mp4")));
+    // A non-media sidecar file must be left out of the import.
+    writeFile(root.filePath(QStringLiteral("SubA/notes.txt")));
+
+    const QVariantMap result = state.importFolder(QUrl::fromLocalFile(tempDir.path()));
+    // root, SubA, SubB, EmptyDir.
+    QCOMPARE(result.value(QStringLiteral("folders")).toInt(), 4);
+    QCOMPARE(result.value(QStringLiteral("files")).toInt(), 3);
+    QCOMPARE(library.count(), 3);
+    QCOMPARE(state.binFolderModel()->count(), 4);
+
+    const QString rootFolderId = [&] {
+        for (int i = 0; i < state.binFolderModel()->count(); ++i) {
+            const QVariantMap folder = state.binFolderModel()->folderAt(i);
+            if (folder.value(QStringLiteral("name")).toString() == root.dirName()
+                && folder.value(QStringLiteral("parentId")).toString().isEmpty())
+                return folder.value(QStringLiteral("id")).toString();
+        }
+        return QString();
+    }();
+    QVERIFY(!rootFolderId.isEmpty());
+
+    auto folderNamed = [&](const QString &name, const QString &parentId) {
+        for (int i = 0; i < state.binFolderModel()->count(); ++i) {
+            const QVariantMap folder = state.binFolderModel()->folderAt(i);
+            if (folder.value(QStringLiteral("name")).toString() == name
+                && folder.value(QStringLiteral("parentId")).toString() == parentId)
+                return folder.value(QStringLiteral("id")).toString();
+        }
+        return QString();
+    };
+    const QString subAId = folderNamed(QStringLiteral("SubA"), rootFolderId);
+    QVERIFY(!subAId.isEmpty());
+    const QString subBId = folderNamed(QStringLiteral("SubB"), subAId);
+    QVERIFY(!subBId.isEmpty());
+    QVERIFY(!folderNamed(QStringLiteral("EmptyDir"), rootFolderId).isEmpty());
+
+    auto folderIdOfAsset = [&](const QString &fileName) {
+        for (int i = 0; i < library.count(); ++i) {
+            const QVariantMap asset = library.assetAt(i);
+            if (QFileInfo(asset.value(QStringLiteral("path")).toString()).fileName() == fileName)
+                return asset.value(QStringLiteral("folderId")).toString();
+        }
+        return QString(QStringLiteral("<not found>"));
+    };
+    QCOMPARE(folderIdOfAsset(QStringLiteral("root.mp4")), rootFolderId);
+    QCOMPARE(folderIdOfAsset(QStringLiteral("a.mp4")), subAId);
+    QCOMPARE(folderIdOfAsset(QStringLiteral("b.mp4")), subBId);
+
+    // Import destination is left wherever the user was browsing (root), not inside the tree
+    // this walk last populated.
+    QCOMPARE(state.currentBinFolderId(), QString());
+
+    // The probe this kicked off runs on a QtConcurrent worker thread that captures `library` by
+    // raw pointer; wait for it to finish before the undo below tears the assets back down again.
+    for (int i = 0; i < library.count(); ++i) {
+        const QString id = library.assetIdAt(i);
+        QTRY_VERIFY_WITH_TIMEOUT(!library.isImportPending(id), 5000);
+    }
+
+    // Marks the project dirty like any other bin folder mutation, or a close right after an
+    // import silently drops the hierarchy with no prompt — but is not undoable: "undo" for a
+    // folder import is deleting the folder by hand, the same as removing an imported asset.
+    QVERIFY(state.hasUnsavedChanges());
+    QVERIFY(!state.undoAvailable());
+}
+
+void EditorStateTest::importFolderMovesAlreadyImportedMediaIntoMirroredFolder()
+{
+    AssetLibrary library;
+    AppController state(&library);
+
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    QDir root(tempDir.path());
+    QVERIFY(root.mkpath(QStringLiteral("SubA")));
+
+    auto writeFile = [](const QString &path) {
+        QFile file(path);
+        QVERIFY(file.open(QIODevice::WriteOnly));
+        file.write("not a real media file");
+        file.close();
+    };
+    const QString filePath = root.filePath(QStringLiteral("SubA/a.mp4"));
+    writeFile(filePath);
+
+    // The file is already in the bin — imported individually, at the root — before the folder
+    // import ever runs.
+    const QStringList preexistingIds = library.importLocalPaths({filePath});
+    QCOMPARE(preexistingIds.size(), 1);
+    const QString assetId = preexistingIds.first();
+    QCOMPARE(library.assetAt(library.indexOfId(assetId)).value(QStringLiteral("folderId")).toString(),
+             QString());
+
+    const QVariantMap result = state.importFolder(QUrl::fromLocalFile(tempDir.path()));
+    QCOMPARE(result.value(QStringLiteral("files")).toInt(), 1);
+    QCOMPARE(library.count(), 1);
+
+    // The mirrored SubA folder must actually contain the file, not sit empty while the count
+    // above claims it was imported.
+    QString subAId;
+    for (int i = 0; i < state.binFolderModel()->count(); ++i) {
+        const QVariantMap folder = state.binFolderModel()->folderAt(i);
+        if (folder.value(QStringLiteral("name")).toString() == QStringLiteral("SubA"))
+            subAId = folder.value(QStringLiteral("id")).toString();
+    }
+    QVERIFY(!subAId.isEmpty());
+    QCOMPARE(library.assetAt(library.indexOfId(assetId)).value(QStringLiteral("folderId")).toString(),
+             subAId);
+
+    QTRY_VERIFY_WITH_TIMEOUT(!library.isImportPending(assetId), 5000);
+}
+
+void EditorStateTest::importFolderSkipsSymlinkCycles()
+{
+#ifdef Q_OS_WIN
+    QSKIP("Symlink creation needs elevated privileges on Windows");
+#endif
+    AssetLibrary library;
+    AppController state(&library);
+
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    QDir root(tempDir.path());
+    QVERIFY(root.mkpath(QStringLiteral("SubA")));
+
+    // SubA/loop -> the temp dir itself, so recursing into it would walk back into root forever
+    // without a visited-set guard.
+    const QString linkPath = root.filePath(QStringLiteral("SubA/loop"));
+    if (!QFile::link(tempDir.path(), linkPath))
+        QSKIP("This filesystem does not support symlinks");
+
+    // Hangs (or stack-overflows) here if the visited-set guard regresses — there is no bound on
+    // the recursion otherwise, since the symlink always resolves back to an already-mirrored
+    // directory.
+    const QVariantMap result = state.importFolder(QUrl::fromLocalFile(tempDir.path()));
+    // root and SubA only — the cycle back through the symlink is skipped, not re-descended.
+    QCOMPARE(result.value(QStringLiteral("folders")).toInt(), 2);
 }
 
 void EditorStateTest::moveAssetToFolderAndUndo()


### PR DESCRIPTION
Recursively imports a picked folder into matching bin folders, importing media into the folder that matches its source directory. Guards against symlink cycles, reparents already-imported media so the mirrored tree never looks emptier than it claims, and marks the project dirty for autosave/unsaved-changes — but stays out of undo, since "undo" for an import is just deleting the folder by hand.