### PR TITLE
feat: correct video rotation losslessly, from the bin and on the timeline

### DIFF
--- a/i18n/drift.ts
+++ b/i18n/drift.ts
@@ -2215,11 +2215,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Media rotated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>An edit is already saving</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Could not open the media file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Media trimmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Trim saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/drift.ts
+++ b/i18n/drift.ts
@@ -872,6 +872,10 @@
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AndroidMoreToolsSheet</name>
@@ -3440,6 +3444,14 @@
     </message>
     <message>
         <source>Track renamed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clip orientation set to %1°</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6531,6 +6543,10 @@
     </message>
     <message>
         <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10163,6 +10179,14 @@ If playback stutters, try another.</source>
     </message>
     <message>
         <source>Reset position &amp; size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fix orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Corrects the source&apos;s own rotation losslessly — unlike Angle above, this changes decoding, not just the on-screen box.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/i18n/drift_es.ts
+++ b/i18n/drift_es.ts
@@ -2215,12 +2215,24 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Media rotated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>An edit is already saving</source>
         <translation>Ya se está guardando una edición</translation>
     </message>
     <message>
         <source>Could not open the media file</source>
         <translation>No se pudo abrir el archivo de medios</translation>
+    </message>
+    <message>
+        <source>Media trimmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Trim saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Saving…</source>

--- a/i18n/drift_es.ts
+++ b/i18n/drift_es.ts
@@ -872,6 +872,10 @@
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
+    <message>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AndroidMoreToolsSheet</name>
@@ -3441,6 +3445,14 @@
     <message>
         <source>Track renamed</source>
         <translation>Pista renombrada</translation>
+    </message>
+    <message>
+        <source>Orientation changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clip orientation set to %1°</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6532,6 +6544,10 @@
     <message>
         <source>Save</source>
         <translation>Guardar</translation>
+    </message>
+    <message>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10171,6 +10187,14 @@ Si la reproducción se corta, prueba con otra opción.</translation>
     <message>
         <source>Reset position &amp; size</source>
         <translation>Restablecer posición y tamaño</translation>
+    </message>
+    <message>
+        <source>Fix orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Corrects the source&apos;s own rotation losslessly — unlike Angle above, this changes decoding, not just the on-screen box.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_fr_CA.ts
+++ b/i18n/drift_fr_CA.ts
@@ -873,6 +873,10 @@
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
+    <message>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AndroidMoreToolsSheet</name>
@@ -3443,6 +3447,14 @@
     <message>
         <source>Track renamed</source>
         <translation>Piste renommée</translation>
+    </message>
+    <message>
+        <source>Orientation changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clip orientation set to %1°</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6535,6 +6547,10 @@
     <message>
         <source>Save</source>
         <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10176,6 +10192,14 @@ En cas de saccades à la lecture, essayez un autre mode.</translation>
     <message>
         <source>Reset position &amp; size</source>
         <translation>Réinitialiser position &amp; taille</translation>
+    </message>
+    <message>
+        <source>Fix orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Corrects the source&apos;s own rotation losslessly — unlike Angle above, this changes decoding, not just the on-screen box.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_fr_CA.ts
+++ b/i18n/drift_fr_CA.ts
@@ -2221,12 +2221,24 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Media rotated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>An edit is already saving</source>
         <translation>Une modification est déjà en cours d’enregistrement</translation>
     </message>
     <message>
         <source>Could not open the media file</source>
         <translation>Impossible d’ouvrir le fichier multimédia</translation>
+    </message>
+    <message>
+        <source>Media trimmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Trim saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Saving…</source>

--- a/i18n/drift_it.ts
+++ b/i18n/drift_it.ts
@@ -872,6 +872,10 @@
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
+    <message>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AndroidMoreToolsSheet</name>
@@ -3441,6 +3445,14 @@
     <message>
         <source>Track renamed</source>
         <translation>Traccia rinominata</translation>
+    </message>
+    <message>
+        <source>Orientation changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clip orientation set to %1°</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6532,6 +6544,10 @@
     <message>
         <source>Save</source>
         <translation>Salva</translation>
+    </message>
+    <message>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10171,6 +10187,14 @@ Se la riproduzione va a scatti, prova un&apos;altra opzione.</translation>
     <message>
         <source>Reset position &amp; size</source>
         <translation>Reimposta posizione e dimensioni</translation>
+    </message>
+    <message>
+        <source>Fix orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Corrects the source&apos;s own rotation losslessly — unlike Angle above, this changes decoding, not just the on-screen box.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_it.ts
+++ b/i18n/drift_it.ts
@@ -2215,12 +2215,24 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Media rotated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>An edit is already saving</source>
         <translation>Un salvataggio delle modifiche è già in corso</translation>
     </message>
     <message>
         <source>Could not open the media file</source>
         <translation>Impossibile aprire il file multimediale</translation>
+    </message>
+    <message>
+        <source>Media trimmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Trim saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Saving…</source>

--- a/i18n/drift_ja.ts
+++ b/i18n/drift_ja.ts
@@ -871,6 +871,10 @@
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
+    <message>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AndroidMoreToolsSheet</name>
@@ -3431,6 +3435,14 @@
     <message>
         <source>Track renamed</source>
         <translation>トラック名を変更しました</translation>
+    </message>
+    <message>
+        <source>Orientation changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clip orientation set to %1°</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6503,6 +6515,10 @@
     <message>
         <source>Save</source>
         <translation>保存</translation>
+    </message>
+    <message>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10136,6 +10152,14 @@ If playback stutters, try another.</source>
     <message>
         <source>Reset position &amp; size</source>
         <translation>位置とサイズをリセット</translation>
+    </message>
+    <message>
+        <source>Fix orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Corrects the source&apos;s own rotation losslessly — unlike Angle above, this changes decoding, not just the on-screen box.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_ja.ts
+++ b/i18n/drift_ja.ts
@@ -2209,12 +2209,24 @@
         <translation>メディアおよび参照されていたクリップを削除しました</translation>
     </message>
     <message>
+        <source>Media rotated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>An edit is already saving</source>
         <translation>編集は既に保存中です</translation>
     </message>
     <message>
         <source>Could not open the media file</source>
         <translation>メディアファイルを開けませんでした</translation>
+    </message>
+    <message>
+        <source>Media trimmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Trim saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Saving…</source>

--- a/i18n/drift_pt_BR.ts
+++ b/i18n/drift_pt_BR.ts
@@ -872,6 +872,10 @@
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
+    <message>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AndroidMoreToolsSheet</name>
@@ -3441,6 +3445,14 @@
     <message>
         <source>Track renamed</source>
         <translation>Faixa renomeada</translation>
+    </message>
+    <message>
+        <source>Orientation changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clip orientation set to %1°</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6532,6 +6544,10 @@
     <message>
         <source>Save</source>
         <translation>Salvar</translation>
+    </message>
+    <message>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10171,6 +10187,14 @@ Se a reprodução travar, experimente outro.</translation>
     <message>
         <source>Reset position &amp; size</source>
         <translation>Redefinir posição &amp; tamanho</translation>
+    </message>
+    <message>
+        <source>Fix orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Corrects the source&apos;s own rotation losslessly — unlike Angle above, this changes decoding, not just the on-screen box.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_pt_BR.ts
+++ b/i18n/drift_pt_BR.ts
@@ -2215,12 +2215,24 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Media rotated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>An edit is already saving</source>
         <translation>Uma edição já está sendo salva</translation>
     </message>
     <message>
         <source>Could not open the media file</source>
         <translation>Não foi possível abrir o arquivo de mídia</translation>
+    </message>
+    <message>
+        <source>Media trimmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Trim saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Saving…</source>

--- a/i18n/drift_si.ts
+++ b/i18n/drift_si.ts
@@ -2215,12 +2215,24 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Media rotated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>An edit is already saving</source>
         <translation>දැනටමත් සංස්කරණයක් සුරැකෙමින් පවතී</translation>
     </message>
     <message>
         <source>Could not open the media file</source>
         <translation>මාධ්‍ය ගොනුව විවෘත කිරීමට නොහැකි විය</translation>
+    </message>
+    <message>
+        <source>Media trimmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Trim saved</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Saving…</source>

--- a/i18n/drift_si.ts
+++ b/i18n/drift_si.ts
@@ -872,6 +872,10 @@
         <source>Cancel</source>
         <translation>අවලංගු කරන්න</translation>
     </message>
+    <message>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AndroidMoreToolsSheet</name>
@@ -3441,6 +3445,14 @@
     <message>
         <source>Track renamed</source>
         <translation>ට්‍රැකයේ නම වෙනස් කරන ලදී</translation>
+    </message>
+    <message>
+        <source>Orientation changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clip orientation set to %1°</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6532,6 +6544,10 @@
     <message>
         <source>Save</source>
         <translation>සුරකින්න</translation>
+    </message>
+    <message>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10171,6 +10187,14 @@ If playback stutters, try another.</source>
     <message>
         <source>Reset position &amp; size</source>
         <translation>පිහිටීම සහ ප්‍රමාණය යළි සකසන්න</translation>
+    </message>
+    <message>
+        <source>Fix orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Corrects the source&apos;s own rotation losslessly — unlike Angle above, this changes decoding, not just the on-screen box.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/i18n/drift_tl.ts
+++ b/i18n/drift_tl.ts
@@ -2215,6 +2215,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Media rotated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Folder moved</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2224,6 +2228,14 @@
     </message>
     <message>
         <source>Could not open the media file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Media trimmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Trim saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/drift_tl.ts
+++ b/i18n/drift_tl.ts
@@ -872,6 +872,10 @@
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AndroidMoreToolsSheet</name>
@@ -3440,6 +3444,14 @@
     </message>
     <message>
         <source>Clips added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clip orientation set to %1°</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6531,6 +6543,10 @@
     </message>
     <message>
         <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10163,6 +10179,14 @@ If playback stutters, try another.</source>
     </message>
     <message>
         <source>Reset position &amp; size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fix orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Corrects the source&apos;s own rotation losslessly — unlike Angle above, this changes decoding, not just the on-screen box.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/i18n/drift_zh_Hans.ts
+++ b/i18n/drift_zh_Hans.ts
@@ -871,6 +871,10 @@
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
+    <message>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AndroidMoreToolsSheet</name>
@@ -3430,6 +3434,14 @@
     </message>
     <message>
         <source>Track renamed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Orientation changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clip orientation set to %1°</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6502,6 +6514,10 @@
     </message>
     <message>
         <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10128,6 +10144,14 @@ If playback stutters, try another.</source>
     </message>
     <message>
         <source>Reset position &amp; size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fix orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Corrects the source&apos;s own rotation losslessly — unlike Angle above, this changes decoding, not just the on-screen box.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/i18n/drift_zh_Hans.ts
+++ b/i18n/drift_zh_Hans.ts
@@ -2209,11 +2209,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Media rotated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>An edit is already saving</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Could not open the media file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Media trimmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Trim saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/core/Clip.h
+++ b/src/core/Clip.h
@@ -146,9 +146,12 @@ struct Clip
     KeyframeTrack<double> transformH;
     KeyframeTrack<double> rotation;
     // Discrete pixel-orientation correction (0/90/180/270), applied losslessly at decode time —
-    // distinct from `rotation` above, which is a free decorative spin effect. -1 = no override,
-    // fall back to the source file's own probed display-matrix rotation.
-    int rotationOverride = -1;
+    // distinct from `rotation` above, which is a free decorative spin effect. Relative, not
+    // absolute: added on top of whatever display-matrix rotation the file actually being decoded
+    // carries. That is what lets one value stay right across every file a clip can read from —
+    // the original, a reverse proxy (tag preserved) or a vidstab bake (ffmpeg autorotated the
+    // pixels and dropped the tag). 0 = show the file as its own tag says.
+    int rotationCorrection = 0;
     KeyframeTrack<double> volume;
     QList<Effect> effects;
     QList<Effect> audioEffects; // libavfilter chains applied to this clip's audio in the mixer

--- a/src/core/Clip.h
+++ b/src/core/Clip.h
@@ -145,6 +145,10 @@ struct Clip
     KeyframeTrack<double> transformW;
     KeyframeTrack<double> transformH;
     KeyframeTrack<double> rotation;
+    // Discrete pixel-orientation correction (0/90/180/270), applied losslessly at decode time —
+    // distinct from `rotation` above, which is a free decorative spin effect. -1 = no override,
+    // fall back to the source file's own probed display-matrix rotation.
+    int rotationOverride = -1;
     KeyframeTrack<double> volume;
     QList<Effect> effects;
     QList<Effect> audioEffects; // libavfilter chains applied to this clip's audio in the mixer

--- a/src/core/MediaAsset.h
+++ b/src/core/MediaAsset.h
@@ -74,4 +74,11 @@ inline int effectiveRotation(const MediaAsset &asset)
     return asset.rotationOverride >= 0 ? asset.rotationOverride : asset.rotationDegrees;
 }
 
+// How far the bin's correction turns this asset beyond its own tag — the Clip::rotationCorrection
+// a clip placed from it starts with.
+inline int rotationCorrectionOf(const MediaAsset &asset)
+{
+    return ((effectiveRotation(asset) - asset.rotationDegrees) % 360 + 360) % 360;
+}
+
 } // namespace drift

--- a/src/core/MediaAsset.h
+++ b/src/core/MediaAsset.h
@@ -39,6 +39,14 @@ struct MediaAsset
     int height = 0;
     double fps = 0.0;
     int rotationDegrees = 0;
+    // User-chosen correction from the bin preview; -1 = use the probed rotationDegrees as-is.
+    int rotationOverride = -1;
+
+    // Non-destructive bin-preview trim: applied to a fresh clip's srcIn/srcOut when the asset is
+    // added to the timeline. The source file itself is never re-encoded for a plain trim — only
+    // an actual crop still does that. -1 for trimOutUs = no trim (use the full duration).
+    TimeUs trimInUs = 0;
+    TimeUs trimOutUs = -1;
 
     int sampleRate = 0;
     int channels = 0;
@@ -58,5 +66,12 @@ struct MediaAsset
     // an asset between folders never touches anything on the timeline.
     QString folderId;
 };
+
+// The rotation to actually use for this asset: the user's bin-preview correction when set,
+// otherwise the value probed from the file's own display-matrix tag.
+inline int effectiveRotation(const MediaAsset &asset)
+{
+    return asset.rotationOverride >= 0 ? asset.rotationOverride : asset.rotationDegrees;
+}
 
 } // namespace drift

--- a/src/core/Project.cpp
+++ b/src/core/Project.cpp
@@ -340,6 +340,7 @@ QJsonObject clipToJson(const Clip &clip)
         {QStringLiteral("width"), keyframesToJson(clip.transformW)},
         {QStringLiteral("height"), keyframesToJson(clip.transformH)},
         {QStringLiteral("rotation"), keyframesToJson(clip.rotation)},
+        {QStringLiteral("rotationOverride"), clip.rotationOverride},
         {QStringLiteral("effects"), effectsToJson(clip.effects)},
         {QStringLiteral("audioEffects"), effectsToJson(clip.audioEffects)},
     };
@@ -450,6 +451,7 @@ Clip clipFromJsonV2(const QJsonObject &object, int canvasW = 1920, int canvasH =
     clip.pan = object.value(QStringLiteral("pan")).toDouble(0.0);
     clip.opacity = keyframesFromJson(object.value(QStringLiteral("opacity")).toObject());
     clip.rotation = keyframesFromJson(object.value(QStringLiteral("rotation")).toObject());
+    clip.rotationOverride = object.value(QStringLiteral("rotationOverride")).toInt(-1);
     clip.effects = effectsFromJson(object.value(QStringLiteral("effects")).toArray());
     clip.audioEffects = effectsFromJson(object.value(QStringLiteral("audioEffects")).toArray());
 
@@ -505,6 +507,9 @@ QJsonObject assetToJson(const MediaAsset &asset)
         {QStringLiteral("height"), asset.height},
         {QStringLiteral("fps"), asset.fps},
         {QStringLiteral("rotationDegrees"), asset.rotationDegrees},
+        {QStringLiteral("rotationOverride"), asset.rotationOverride},
+        {QStringLiteral("trimInUs"), static_cast<double>(asset.trimInUs)},
+        {QStringLiteral("trimOutUs"), static_cast<double>(asset.trimOutUs)},
         {QStringLiteral("sampleRate"), asset.sampleRate},
         {QStringLiteral("channels"), asset.channels},
         {QStringLiteral("codecName"), asset.codecName},
@@ -536,6 +541,9 @@ MediaAsset assetFromJsonV2(const QJsonObject &object)
     asset.height = object.value(QStringLiteral("height")).toInt();
     asset.fps = object.value(QStringLiteral("fps")).toDouble();
     asset.rotationDegrees = object.value(QStringLiteral("rotationDegrees")).toInt();
+    asset.rotationOverride = object.value(QStringLiteral("rotationOverride")).toInt(-1);
+    asset.trimInUs = static_cast<TimeUs>(object.value(QStringLiteral("trimInUs")).toDouble(0));
+    asset.trimOutUs = static_cast<TimeUs>(object.value(QStringLiteral("trimOutUs")).toDouble(-1));
     asset.sampleRate = object.value(QStringLiteral("sampleRate")).toInt();
     asset.channels = object.value(QStringLiteral("channels")).toInt();
     asset.codecName = object.value(QStringLiteral("codecName")).toString();

--- a/src/core/Project.cpp
+++ b/src/core/Project.cpp
@@ -340,7 +340,7 @@ QJsonObject clipToJson(const Clip &clip)
         {QStringLiteral("width"), keyframesToJson(clip.transformW)},
         {QStringLiteral("height"), keyframesToJson(clip.transformH)},
         {QStringLiteral("rotation"), keyframesToJson(clip.rotation)},
-        {QStringLiteral("rotationOverride"), clip.rotationOverride},
+        {QStringLiteral("rotationCorrection"), clip.rotationCorrection},
         {QStringLiteral("effects"), effectsToJson(clip.effects)},
         {QStringLiteral("audioEffects"), effectsToJson(clip.audioEffects)},
     };
@@ -451,7 +451,7 @@ Clip clipFromJsonV2(const QJsonObject &object, int canvasW = 1920, int canvasH =
     clip.pan = object.value(QStringLiteral("pan")).toDouble(0.0);
     clip.opacity = keyframesFromJson(object.value(QStringLiteral("opacity")).toObject());
     clip.rotation = keyframesFromJson(object.value(QStringLiteral("rotation")).toObject());
-    clip.rotationOverride = object.value(QStringLiteral("rotationOverride")).toInt(-1);
+    clip.rotationCorrection = object.value(QStringLiteral("rotationCorrection")).toInt(0);
     clip.effects = effectsFromJson(object.value(QStringLiteral("effects")).toArray());
     clip.audioEffects = effectsFromJson(object.value(QStringLiteral("audioEffects")).toArray());
 

--- a/src/core/TimelineOps.cpp
+++ b/src/core/TimelineOps.cpp
@@ -781,6 +781,8 @@ void retargetClipToSource(Clip &dst, const Clip &src, TimeUs srcMediaDurationUs)
     dst.reverse = src.reverse;
     dst.flipH = src.flipH;
     dst.flipV = src.flipV;
+    // Belongs to the angle's media, not the slot: it is what makes that file decode upright.
+    dst.rotationCorrection = src.rotationCorrection;
 
     // A ramp is normalised over the clip's own source range and decides its timeline duration.
     // dst's duration is fixed by the slot it occupies, so there is no range for a ramp to

--- a/src/engine/ClipReader.cpp
+++ b/src/engine/ClipReader.cpp
@@ -314,7 +314,8 @@ QSize ClipReader::decodeSizeFor(int maxWidth, int maxHeight) const
     // The caller's box is in display orientation but srcW/srcH are coded, and the
     // returned size is the sws target — so match the box to the source instead of
     // the other way round. The transpose happens after conversion.
-    if (m_sourceRotation == 90 || m_sourceRotation == 270)
+    const int rotation = effectiveRotation();
+    if (rotation == 90 || rotation == 270)
         std::swap(maxWidth, maxHeight);
 
     // Never decode larger than the source; scaling up is the compositor's job.
@@ -1344,7 +1345,7 @@ bool ClipReader::transferHwFrameToImage(const AVFrame *hwFrame, QImage &out, int
     if (!swFrame)
         return false;
 
-    const QImage image = frameToRgba(swFrame, m_sws, targetWidth, targetHeight, m_sourceRotation);
+    const QImage image = frameToRgba(swFrame, m_sws, targetWidth, targetHeight, effectiveRotation());
     if (image.isNull())
         return false;
 
@@ -1429,7 +1430,7 @@ bool ClipReader::convertFrame(const AVFrame *frame, QImage &out, int targetWidth
     if (isHardwarePixelFormat(static_cast<AVPixelFormat>(frame->format)))
         return transferHwFrameToImage(frame, out, targetWidth, targetHeight);
 
-    const QImage image = frameToRgba(frame, m_sws, targetWidth, targetHeight, m_sourceRotation);
+    const QImage image = frameToRgba(frame, m_sws, targetWidth, targetHeight, effectiveRotation());
     if (image.isNull())
         return false;
 
@@ -1450,7 +1451,7 @@ bool ClipReader::convertFramePreview(const AVFrame *frame, PreviewVideoFrame &ou
     if (m_mcSurfaceMode && frame->format == AV_PIX_FMT_MEDIACODEC) {
         Q_UNUSED(targetWidth);
         Q_UNUSED(targetHeight);
-        out = makePreviewFrame(frame, m_sourceRotation);
+        out = makePreviewFrame(frame, effectiveRotation());
         return out.isValid();
     }
 #endif
@@ -1459,14 +1460,14 @@ bool ClipReader::convertFramePreview(const AVFrame *frame, PreviewVideoFrame &ou
         || isHardwarePixelFormat(static_cast<AVPixelFormat>(frame->format));
     if (hw) {
         const AVFrame *scaled = scaleHwFrame(frame, targetWidth, targetHeight);
-        out = makePreviewFrame(scaled, m_sourceRotation);
+        out = makePreviewFrame(scaled, effectiveRotation());
         if (scaled == m_vppScaled)
             av_frame_unref(m_vppScaled);
         return out.isValid();
     }
 
     AVFrame *nv12 = softwareFrameToNv12(frame, m_swsNv12, targetWidth, targetHeight);
-    out = takePreviewFrame(nv12, m_sourceRotation);
+    out = takePreviewFrame(nv12, effectiveRotation());
     return out.isValid();
 }
 

--- a/src/engine/ClipReader.h
+++ b/src/engine/ClipReader.h
@@ -68,6 +68,21 @@ public:
     // exist when clips cut from one file overlap; each still keeps a cache, so without this the
     // memory ceiling would multiply by the number of them.
     void setPreviewCacheShare(int shares) { m_previewCacheShares = qMax(1, shares); }
+    // Overrides the source's own probed display-matrix rotation for every subsequent decode
+    // (-1 = use the probed value). Applied per-call like setStabilizeParams, not gated behind
+    // open()'s reopen guard, so a change takes effect on the very next frame.
+    void setRotationOverride(int rotationOverride)
+    {
+        if (m_rotationOverride == rotationOverride)
+            return;
+        m_rotationOverride = rotationOverride;
+        // Cached frames are keyed by source PTS only, never by orientation. applyDecodeSize's
+        // size-based invalidation happens to catch a 90<->270 swap (the decode target transposes)
+        // but not a 0<->180 change (same size, still wrong-side-up) — clear both explicitly so
+        // every rotation change is covered, not just the ones that also happen to resize.
+        m_videoCache.clear();
+        m_previewCache.clear();
+    }
 
     // Diagnostics, summed over every reader in this process. A reader asked for a position its
     // cursor is not near has to decode its way there from the preceding keyframe, so this is what
@@ -192,6 +207,9 @@ private:
     // Source display-matrix rotation (0/90/180/270), applied to every decoded frame
     // so everything downstream sees upright pixels.
     int m_sourceRotation = 0;
+    // -1 = none; otherwise takes precedence over m_sourceRotation. See effectiveRotation().
+    int m_rotationOverride = -1;
+    int effectiveRotation() const { return m_rotationOverride >= 0 ? m_rotationOverride : m_sourceRotation; }
     int m_outputSampleRate = 48000;
     bool m_hwAccelActive = false;
     bool m_hwAccelDisabled = false; // sticky after a failed hardware decode

--- a/src/engine/ClipReader.h
+++ b/src/engine/ClipReader.h
@@ -68,14 +68,15 @@ public:
     // exist when clips cut from one file overlap; each still keeps a cache, so without this the
     // memory ceiling would multiply by the number of them.
     void setPreviewCacheShare(int shares) { m_previewCacheShares = qMax(1, shares); }
-    // Overrides the source's own probed display-matrix rotation for every subsequent decode
-    // (-1 = use the probed value). Applied per-call like setStabilizeParams, not gated behind
-    // open()'s reopen guard, so a change takes effect on the very next frame.
-    void setRotationOverride(int rotationOverride)
+    // Extra quarter-turns applied on top of the source's own probed display-matrix rotation for
+    // every subsequent decode (see Clip::rotationCorrection). Applied per-call like
+    // setStabilizeParams, not gated behind open()'s reopen guard, so a change takes effect on the
+    // very next frame.
+    void setRotationCorrection(int degrees)
     {
-        if (m_rotationOverride == rotationOverride)
+        if (m_rotationCorrection == degrees)
             return;
-        m_rotationOverride = rotationOverride;
+        m_rotationCorrection = degrees;
         // Cached frames are keyed by source PTS only, never by orientation. applyDecodeSize's
         // size-based invalidation happens to catch a 90<->270 swap (the decode target transposes)
         // but not a 0<->180 change (same size, still wrong-side-up) — clear both explicitly so
@@ -207,9 +208,8 @@ private:
     // Source display-matrix rotation (0/90/180/270), applied to every decoded frame
     // so everything downstream sees upright pixels.
     int m_sourceRotation = 0;
-    // -1 = none; otherwise takes precedence over m_sourceRotation. See effectiveRotation().
-    int m_rotationOverride = -1;
-    int effectiveRotation() const { return m_rotationOverride >= 0 ? m_rotationOverride : m_sourceRotation; }
+    int m_rotationCorrection = 0;
+    int effectiveRotation() const { return ((m_sourceRotation + m_rotationCorrection) % 360 + 360) % 360; }
     int m_outputSampleRate = 48000;
     bool m_hwAccelActive = false;
     bool m_hwAccelDisabled = false; // sticky after a failed hardware decode

--- a/src/engine/ClipReaderPool.cpp
+++ b/src/engine/ClipReaderPool.cpp
@@ -140,7 +140,9 @@ void ClipReaderPool::warmVideoFrames(const QList<VideoRequest> &requests)
         QMetaObject::invokeMethod(ensureWorker(m_videoWorkers, request.path).worker, "decodePreviewVideo",
                                   Qt::QueuedConnection,
                                   Q_ARG(quint64, request.streamId), Q_ARG(drift::TimeUs, request.sourceUs),
-                                  Q_ARG(int, request.maxWidth), Q_ARG(int, request.maxHeight));
+                                  Q_ARG(int, request.maxWidth), Q_ARG(int, request.maxHeight),
+                                  Q_ARG(QString, QString()), Q_ARG(int, 15), Q_ARG(bool, false),
+                                  Q_ARG(int, request.rotationCorrection));
     }
 }
 
@@ -163,7 +165,7 @@ qint64 ClipReaderPool::decodeWaitNs()
 
 QImage ClipReaderPool::readVideoFrame(const QString &path, quint64 streamId, drift::TimeUs sourceUs,
                                       int maxWidth, int maxHeight, const QString &stabilizePath,
-                                      int stabilizeSmoothing, bool stabilizeTripod, int rotationOverride)
+                                      int stabilizeSmoothing, bool stabilizeTripod, int rotationCorrection)
 {
     if (path.isEmpty())
         return {};
@@ -187,7 +189,7 @@ QImage ClipReaderPool::readVideoFrame(const QString &path, quint64 streamId, dri
                                Q_ARG(quint64, streamId), Q_ARG(drift::TimeUs, sourceUs),
                                Q_ARG(int, maxWidth), Q_ARG(int, maxHeight),
                                Q_ARG(QString, stabilizePath), Q_ARG(int, stabilizeSmoothing), Q_ARG(bool, stabilizeTripod),
-                               Q_ARG(int, rotationOverride));
+                               Q_ARG(int, rotationCorrection));
     t_decodeWaitNs += decodeWait.nsecsElapsed();
 
     // Decode one frame beyond the current position while the caller composites
@@ -205,7 +207,7 @@ PreviewVideoFrame ClipReaderPool::readPreviewVideoFrame(const QString &path, qui
                                                         drift::TimeUs sourceUs, int maxWidth, int maxHeight,
                                                         const QString &stabilizePath,
                                                         int stabilizeSmoothing, bool stabilizeTripod,
-                                                        int rotationOverride)
+                                                        int rotationCorrection)
 {
     if (path.isEmpty())
         return {};
@@ -226,7 +228,7 @@ PreviewVideoFrame ClipReaderPool::readPreviewVideoFrame(const QString &path, qui
                                Q_ARG(drift::TimeUs, sourceUs), Q_ARG(int, maxWidth),
                                Q_ARG(int, maxHeight),
                                Q_ARG(QString, stabilizePath), Q_ARG(int, stabilizeSmoothing),
-                               Q_ARG(bool, stabilizeTripod), Q_ARG(int, rotationOverride));
+                               Q_ARG(bool, stabilizeTripod), Q_ARG(int, rotationCorrection));
     t_decodeWaitNs += decodeWait.nsecsElapsed();
 
     worker->requestPrefetchPreview(streamId, maxWidth, maxHeight,

--- a/src/engine/ClipReaderPool.cpp
+++ b/src/engine/ClipReaderPool.cpp
@@ -163,7 +163,7 @@ qint64 ClipReaderPool::decodeWaitNs()
 
 QImage ClipReaderPool::readVideoFrame(const QString &path, quint64 streamId, drift::TimeUs sourceUs,
                                       int maxWidth, int maxHeight, const QString &stabilizePath,
-                                      int stabilizeSmoothing, bool stabilizeTripod)
+                                      int stabilizeSmoothing, bool stabilizeTripod, int rotationOverride)
 {
     if (path.isEmpty())
         return {};
@@ -186,7 +186,8 @@ QImage ClipReaderPool::readVideoFrame(const QString &path, quint64 streamId, dri
     QMetaObject::invokeMethod(worker, "decodeVideo", Qt::BlockingQueuedConnection, Q_RETURN_ARG(QImage, frame),
                                Q_ARG(quint64, streamId), Q_ARG(drift::TimeUs, sourceUs),
                                Q_ARG(int, maxWidth), Q_ARG(int, maxHeight),
-                               Q_ARG(QString, stabilizePath), Q_ARG(int, stabilizeSmoothing), Q_ARG(bool, stabilizeTripod));
+                               Q_ARG(QString, stabilizePath), Q_ARG(int, stabilizeSmoothing), Q_ARG(bool, stabilizeTripod),
+                               Q_ARG(int, rotationOverride));
     t_decodeWaitNs += decodeWait.nsecsElapsed();
 
     // Decode one frame beyond the current position while the caller composites
@@ -203,7 +204,8 @@ QImage ClipReaderPool::readVideoFrame(const QString &path, quint64 streamId, dri
 PreviewVideoFrame ClipReaderPool::readPreviewVideoFrame(const QString &path, quint64 streamId,
                                                         drift::TimeUs sourceUs, int maxWidth, int maxHeight,
                                                         const QString &stabilizePath,
-                                                        int stabilizeSmoothing, bool stabilizeTripod)
+                                                        int stabilizeSmoothing, bool stabilizeTripod,
+                                                        int rotationOverride)
 {
     if (path.isEmpty())
         return {};
@@ -224,7 +226,7 @@ PreviewVideoFrame ClipReaderPool::readPreviewVideoFrame(const QString &path, qui
                                Q_ARG(drift::TimeUs, sourceUs), Q_ARG(int, maxWidth),
                                Q_ARG(int, maxHeight),
                                Q_ARG(QString, stabilizePath), Q_ARG(int, stabilizeSmoothing),
-                               Q_ARG(bool, stabilizeTripod));
+                               Q_ARG(bool, stabilizeTripod), Q_ARG(int, rotationOverride));
     t_decodeWaitNs += decodeWait.nsecsElapsed();
 
     worker->requestPrefetchPreview(streamId, maxWidth, maxHeight,

--- a/src/engine/ClipReaderPool.h
+++ b/src/engine/ClipReaderPool.h
@@ -41,6 +41,10 @@ public:
         drift::TimeUs sourceUs = 0;
         int maxWidth = 0;
         int maxHeight = 0;
+        // Must match what the readVideoFrame/readPreviewVideoFrame that follows will pass: the
+        // reader clears its frame caches whenever this changes, so a warm at one value and a read
+        // at another would decode every frame twice and cache nothing.
+        int rotationCorrection = 0;
     };
 
     // Kick every request off on its own worker thread without waiting. Each path
@@ -71,18 +75,18 @@ public:
     void setHardwareDecodeMode(ClipReader::HardwareDecodeMode mode,
                                drift::hwaccel::Backend backend = drift::hwaccel::Backend::None);
 
-    // `rotationOverride` (0/90/180/270, or -1 to use the source file's own probed display-matrix
-    // rotation) lets a clip's chosen orientation correction reach the decoder losslessly.
+    // `rotationCorrection` (Clip::rotationCorrection) lets a clip's orientation fix reach the
+    // decoder losslessly.
     QImage readVideoFrame(const QString &path, quint64 streamId, drift::TimeUs sourceUs, int maxWidth,
                           int maxHeight, const QString &stabilizePath = QString(),
                           int stabilizeSmoothing = 15, bool stabilizeTripod = false,
-                          int rotationOverride = -1);
+                          int rotationCorrection = 0);
     // Preview path: AVFrame handle (hardware surfaces stay on the GPU). Empty when decode fails.
     PreviewVideoFrame readPreviewVideoFrame(const QString &path, quint64 streamId, drift::TimeUs sourceUs,
                                             int maxWidth, int maxHeight,
                                             const QString &stabilizePath = QString(),
                                             int stabilizeSmoothing = 15, bool stabilizeTripod = false,
-                                            int rotationOverride = -1);
+                                            int rotationCorrection = 0);
     int readAudioInterleaved(const QString &path, quint64 streamId, drift::TimeUs sourceStartUs,
                              int sampleCount, int outputSampleRate, float *interleavedStereoOut,
                              int audioStreamOrdinal = 0);

--- a/src/engine/ClipReaderPool.h
+++ b/src/engine/ClipReaderPool.h
@@ -71,14 +71,18 @@ public:
     void setHardwareDecodeMode(ClipReader::HardwareDecodeMode mode,
                                drift::hwaccel::Backend backend = drift::hwaccel::Backend::None);
 
+    // `rotationOverride` (0/90/180/270, or -1 to use the source file's own probed display-matrix
+    // rotation) lets a clip's chosen orientation correction reach the decoder losslessly.
     QImage readVideoFrame(const QString &path, quint64 streamId, drift::TimeUs sourceUs, int maxWidth,
                           int maxHeight, const QString &stabilizePath = QString(),
-                          int stabilizeSmoothing = 15, bool stabilizeTripod = false);
+                          int stabilizeSmoothing = 15, bool stabilizeTripod = false,
+                          int rotationOverride = -1);
     // Preview path: AVFrame handle (hardware surfaces stay on the GPU). Empty when decode fails.
     PreviewVideoFrame readPreviewVideoFrame(const QString &path, quint64 streamId, drift::TimeUs sourceUs,
                                             int maxWidth, int maxHeight,
                                             const QString &stabilizePath = QString(),
-                                            int stabilizeSmoothing = 15, bool stabilizeTripod = false);
+                                            int stabilizeSmoothing = 15, bool stabilizeTripod = false,
+                                            int rotationOverride = -1);
     int readAudioInterleaved(const QString &path, quint64 streamId, drift::TimeUs sourceStartUs,
                              int sampleCount, int outputSampleRate, float *interleavedStereoOut,
                              int audioStreamOrdinal = 0);

--- a/src/engine/ClipReaderWorker.cpp
+++ b/src/engine/ClipReaderWorker.cpp
@@ -53,13 +53,13 @@ ClipReader *ClipReaderWorker::readerFor(quint64 streamId, int audioStreamOrdinal
 
 QImage ClipReaderWorker::decodeVideo(quint64 streamId, drift::TimeUs sourceUs, int maxWidth, int maxHeight,
                                      const QString &stabilizePath, int stabilizeSmoothing, bool stabilizeTripod,
-                                     int rotationOverride)
+                                     int rotationCorrection)
 {
     QMutexLocker lock(&m_mutex);
     ClipReader *reader = readerFor(streamId);
     if (reader) {
         reader->setStabilizeParams(stabilizePath, stabilizeSmoothing, stabilizeTripod);
-        reader->setRotationOverride(rotationOverride);
+        reader->setRotationCorrection(rotationCorrection);
     }
     QImage frame;
     if (!reader || !reader->readVideoFrameAt(sourceUs, frame, maxWidth, maxHeight))
@@ -71,13 +71,13 @@ PreviewVideoFrame ClipReaderWorker::decodePreviewVideo(quint64 streamId, drift::
                                                        int maxWidth, int maxHeight,
                                                        const QString &stabilizePath,
                                                        int stabilizeSmoothing, bool stabilizeTripod,
-                                                       int rotationOverride)
+                                                       int rotationCorrection)
 {
     QMutexLocker lock(&m_mutex);
     ClipReader *reader = readerFor(streamId);
     if (reader) {
         reader->setStabilizeParams(stabilizePath, stabilizeSmoothing, stabilizeTripod);
-        reader->setRotationOverride(rotationOverride);
+        reader->setRotationCorrection(rotationCorrection);
     }
     PreviewVideoFrame frame;
     if (!reader || !reader->readPreviewVideoFrame(sourceUs, frame, maxWidth, maxHeight))

--- a/src/engine/ClipReaderWorker.cpp
+++ b/src/engine/ClipReaderWorker.cpp
@@ -52,12 +52,15 @@ ClipReader *ClipReaderWorker::readerFor(quint64 streamId, int audioStreamOrdinal
 }
 
 QImage ClipReaderWorker::decodeVideo(quint64 streamId, drift::TimeUs sourceUs, int maxWidth, int maxHeight,
-                                     const QString &stabilizePath, int stabilizeSmoothing, bool stabilizeTripod)
+                                     const QString &stabilizePath, int stabilizeSmoothing, bool stabilizeTripod,
+                                     int rotationOverride)
 {
     QMutexLocker lock(&m_mutex);
     ClipReader *reader = readerFor(streamId);
-    if (reader)
+    if (reader) {
         reader->setStabilizeParams(stabilizePath, stabilizeSmoothing, stabilizeTripod);
+        reader->setRotationOverride(rotationOverride);
+    }
     QImage frame;
     if (!reader || !reader->readVideoFrameAt(sourceUs, frame, maxWidth, maxHeight))
         return {};
@@ -67,12 +70,15 @@ QImage ClipReaderWorker::decodeVideo(quint64 streamId, drift::TimeUs sourceUs, i
 PreviewVideoFrame ClipReaderWorker::decodePreviewVideo(quint64 streamId, drift::TimeUs sourceUs,
                                                        int maxWidth, int maxHeight,
                                                        const QString &stabilizePath,
-                                                       int stabilizeSmoothing, bool stabilizeTripod)
+                                                       int stabilizeSmoothing, bool stabilizeTripod,
+                                                       int rotationOverride)
 {
     QMutexLocker lock(&m_mutex);
     ClipReader *reader = readerFor(streamId);
-    if (reader)
+    if (reader) {
         reader->setStabilizeParams(stabilizePath, stabilizeSmoothing, stabilizeTripod);
+        reader->setRotationOverride(rotationOverride);
+    }
     PreviewVideoFrame frame;
     if (!reader || !reader->readPreviewVideoFrame(sourceUs, frame, maxWidth, maxHeight))
         return {};

--- a/src/engine/ClipReaderWorker.h
+++ b/src/engine/ClipReaderWorker.h
@@ -48,11 +48,11 @@ public slots:
     void closePath();
     QImage decodeVideo(quint64 streamId, drift::TimeUs sourceUs, int maxWidth, int maxHeight,
                        const QString &stabilizePath = QString(), int stabilizeSmoothing = 15,
-                       bool stabilizeTripod = false, int rotationOverride = -1);
+                       bool stabilizeTripod = false, int rotationCorrection = 0);
     PreviewVideoFrame decodePreviewVideo(quint64 streamId, drift::TimeUs sourceUs, int maxWidth,
                                          int maxHeight, const QString &stabilizePath = QString(),
                                          int stabilizeSmoothing = 15, bool stabilizeTripod = false,
-                                         int rotationOverride = -1);
+                                         int rotationCorrection = 0);
     int decodeAudio(quint64 streamId, drift::TimeUs sourceStartUs, int sampleCount,
                     int outputSampleRate, float *interleavedStereoOut, int audioStreamOrdinal = 0);
     void prefetchNextVideo(quint64 streamId, int maxWidth, int maxHeight);

--- a/src/engine/ClipReaderWorker.h
+++ b/src/engine/ClipReaderWorker.h
@@ -48,10 +48,11 @@ public slots:
     void closePath();
     QImage decodeVideo(quint64 streamId, drift::TimeUs sourceUs, int maxWidth, int maxHeight,
                        const QString &stabilizePath = QString(), int stabilizeSmoothing = 15,
-                       bool stabilizeTripod = false);
+                       bool stabilizeTripod = false, int rotationOverride = -1);
     PreviewVideoFrame decodePreviewVideo(quint64 streamId, drift::TimeUs sourceUs, int maxWidth,
                                          int maxHeight, const QString &stabilizePath = QString(),
-                                         int stabilizeSmoothing = 15, bool stabilizeTripod = false);
+                                         int stabilizeSmoothing = 15, bool stabilizeTripod = false,
+                                         int rotationOverride = -1);
     int decodeAudio(quint64 streamId, drift::TimeUs sourceStartUs, int sampleCount,
                     int outputSampleRate, float *interleavedStereoOut, int audioStreamOrdinal = 0);
     void prefetchNextVideo(quint64 streamId, int maxWidth, int maxHeight);

--- a/src/engine/FilmstripTileCache.cpp
+++ b/src/engine/FilmstripTileCache.cpp
@@ -61,18 +61,20 @@ void FilmstripTileCache::clear()
     m_queue.clear();
 }
 
-QString FilmstripTileCache::keyFor(const QString &sourcePath, int level, qint64 index)
+QString FilmstripTileCache::keyFor(const QString &sourcePath, int level, qint64 index,
+                                   int rotationCorrection)
 {
     return sourcePath + QLatin1Char('|') + QString::number(level) + QLatin1Char('|')
-           + QString::number(index);
+           + QString::number(index) + QLatin1Char('|') + QString::number(rotationCorrection);
 }
 
-QString FilmstripTileCache::tile(const QString &sourcePath, int level, qint64 index)
+QString FilmstripTileCache::tile(const QString &sourcePath, int level, qint64 index,
+                                 int rotationCorrection)
 {
     if (sourcePath.isEmpty() || m_failed.contains(sourcePath))
         return {};
 
-    const QString key = keyFor(sourcePath, level, index);
+    const QString key = keyFor(sourcePath, level, index, rotationCorrection);
     const auto cached = m_ready.constFind(key);
     if (cached != m_ready.constEnd())
         return cached.value();
@@ -81,7 +83,7 @@ QString FilmstripTileCache::tile(const QString &sourcePath, int level, qint64 in
         return {};
 
     // A tile written by an earlier session is on disk but not in m_ready yet.
-    const QString path = MediaThumbnail::tilePath(sourcePath, level, index);
+    const QString path = MediaThumbnail::tilePath(sourcePath, level, index, rotationCorrection);
     if (QFileInfo::exists(path)) {
         if (m_ready.size() >= kMaxReadyEntries)
             m_ready.clear();
@@ -90,10 +92,10 @@ QString FilmstripTileCache::tile(const QString &sourcePath, int level, qint64 in
     }
 
     m_queued.insert(key);
-    m_queue.append({sourcePath, level, index});
+    m_queue.append({sourcePath, level, index, rotationCorrection});
     while (m_queue.size() > kMaxQueued) {
-        m_queued.remove(keyFor(m_queue.first().sourcePath, m_queue.first().level,
-                               m_queue.first().index));
+        const Request &first = m_queue.first();
+        m_queued.remove(keyFor(first.sourcePath, first.level, first.index, first.rotationCorrection));
         m_queue.removeFirst();
     }
 
@@ -123,7 +125,8 @@ void FilmstripTileCache::runBatch()
     QList<qint64> indices;
     for (int i = m_queue.size() - 1; i >= 0 && indices.size() < kBatchSize; --i) {
         const Request &request = m_queue.at(i);
-        if (request.sourcePath != newest.sourcePath || request.level != newest.level)
+        if (request.sourcePath != newest.sourcePath || request.level != newest.level
+            || request.rotationCorrection != newest.rotationCorrection)
             continue;
         indices.append(request.index);
         m_queue.removeAt(i);
@@ -134,35 +137,37 @@ void FilmstripTileCache::runBatch()
     m_busy = true;
     const QString sourcePath = newest.sourcePath;
     const int level = newest.level;
+    const int rotationCorrection = newest.rotationCorrection;
     QMetaObject::invokeMethod(
         m_decodeContext,
-        [this, sourcePath, level, indices] {
+        [this, sourcePath, level, rotationCorrection, indices] {
             m_idleTimer->stop();
-            const QList<qint64> produced = m_decoder.generateTiles(sourcePath, level, indices);
+            const QList<qint64> produced =
+                m_decoder.generateTiles(sourcePath, level, indices, rotationCorrection);
             m_idleTimer->start();
             QMetaObject::invokeMethod(
                 this,
-                [this, sourcePath, level, produced, indices] {
-                    applyBatch(sourcePath, level, produced, indices);
+                [this, sourcePath, level, rotationCorrection, produced, indices] {
+                    applyBatch(sourcePath, level, rotationCorrection, produced, indices);
                 },
                 Qt::QueuedConnection);
         },
         Qt::QueuedConnection);
 }
 
-void FilmstripTileCache::applyBatch(const QString &sourcePath, int level,
+void FilmstripTileCache::applyBatch(const QString &sourcePath, int level, int rotationCorrection,
                                     const QList<qint64> &produced, const QList<qint64> &requested)
 {
     m_busy = false;
 
     for (const qint64 index : requested)
-        m_queued.remove(keyFor(sourcePath, level, index));
+        m_queued.remove(keyFor(sourcePath, level, index, rotationCorrection));
 
     if (m_ready.size() + produced.size() > kMaxReadyEntries)
         m_ready.clear();
     for (const qint64 index : produced)
-        m_ready.insert(keyFor(sourcePath, level, index),
-                       MediaThumbnail::tilePath(sourcePath, level, index));
+        m_ready.insert(keyFor(sourcePath, level, index, rotationCorrection),
+                       MediaThumbnail::tilePath(sourcePath, level, index, rotationCorrection));
 
     if (produced.isEmpty()) {
         // Repeatedly empty means no video stream, or the file is gone. Stop asking; a single

--- a/src/engine/FilmstripTileCache.h
+++ b/src/engine/FilmstripTileCache.h
@@ -35,7 +35,7 @@ public:
 
     // Cached tile file for `2^level`-second tile number `index` of `sourcePath`, or an empty
     // string if it still needs decoding — tileReady() fires for the source when it lands.
-    QString tile(const QString &sourcePath, int level, qint64 index);
+    QString tile(const QString &sourcePath, int level, qint64 index, int rotationCorrection = 0);
 
     // Forgets everything: memoized paths, the failure blacklist and anything still queued.
     // Call when the timeline's sources change wholesale — a new project, or a relink — so a
@@ -52,14 +52,15 @@ private:
         QString sourcePath;
         int level = 0;
         qint64 index = 0;
+        int rotationCorrection = 0;
     };
 
     void scheduleBatch();
     void runBatch();
-    void applyBatch(const QString &sourcePath, int level, const QList<qint64> &produced,
-                    const QList<qint64> &requested);
+    void applyBatch(const QString &sourcePath, int level, int rotationCorrection,
+                    const QList<qint64> &produced, const QList<qint64> &requested);
 
-    static QString keyFor(const QString &sourcePath, int level, qint64 index);
+    static QString keyFor(const QString &sourcePath, int level, qint64 index, int rotationCorrection);
 
     QHash<QString, QString> m_ready;
     // Sources whose decode failed, so a broken or audio-only file isn't retried every repaint.

--- a/src/engine/FrameCompositor.cpp
+++ b/src/engine/FrameCompositor.cpp
@@ -391,7 +391,8 @@ QImage decodeClipMediaFrame(const drift::Clip &clip, drift::TimeUs timelineUs, i
     if (clip.type == drift::ClipType::Video) {
         const drift::VideoRead read = drift::resolveVideoRead(clip, timelineUs);
         return ClipReaderPool::instance().readVideoFrame(
-            read.path, ClipReaderPool::streamIdForClip(clip.id), read.sourceUs, maxWidth, maxHeight);
+            read.path, ClipReaderPool::streamIdForClip(clip.id), read.sourceUs, maxWidth, maxHeight,
+            QString(), 15, false, clip.rotationOverride);
     }
 
     return {};
@@ -679,7 +680,8 @@ void fillGpuLayerPixels(GpuLayer &layer, const drift::Clip &clip, drift::TimeUs 
     if (!timeEcho && clip.type == drift::ClipType::Video) {
         const drift::VideoRead read = drift::resolveVideoRead(clip, timelineUs);
         const PreviewVideoFrame video = ClipReaderPool::instance().readPreviewVideoFrame(
-            read.path, ClipReaderPool::streamIdForClip(clip.id), read.sourceUs, maxWidth, maxHeight);
+            read.path, ClipReaderPool::streamIdForClip(clip.id), read.sourceUs, maxWidth, maxHeight,
+            QString(), 15, false, clip.rotationOverride);
         if (video.isValid()) {
             layer.video = video;
             return;

--- a/src/engine/FrameCompositor.cpp
+++ b/src/engine/FrameCompositor.cpp
@@ -180,7 +180,8 @@ QList<ClipReaderPool::VideoRequest> collectVideoRequests(const drift::Project *p
             const drift::VideoRead read = drift::resolveVideoRead(clip, timelineUs);
             requests.append(ClipReaderPool::VideoRequest{read.path,
                                                         ClipReaderPool::streamIdForClip(clip.id),
-                                                        read.sourceUs, maxWidth, maxHeight});
+                                                        read.sourceUs, maxWidth, maxHeight,
+                                                        clip.rotationCorrection});
         }
     }
     return requests;
@@ -392,7 +393,7 @@ QImage decodeClipMediaFrame(const drift::Clip &clip, drift::TimeUs timelineUs, i
         const drift::VideoRead read = drift::resolveVideoRead(clip, timelineUs);
         return ClipReaderPool::instance().readVideoFrame(
             read.path, ClipReaderPool::streamIdForClip(clip.id), read.sourceUs, maxWidth, maxHeight,
-            QString(), 15, false, clip.rotationOverride);
+            QString(), 15, false, clip.rotationCorrection);
     }
 
     return {};
@@ -681,7 +682,7 @@ void fillGpuLayerPixels(GpuLayer &layer, const drift::Clip &clip, drift::TimeUs 
         const drift::VideoRead read = drift::resolveVideoRead(clip, timelineUs);
         const PreviewVideoFrame video = ClipReaderPool::instance().readPreviewVideoFrame(
             read.path, ClipReaderPool::streamIdForClip(clip.id), read.sourceUs, maxWidth, maxHeight,
-            QString(), 15, false, clip.rotationOverride);
+            QString(), 15, false, clip.rotationCorrection);
         if (video.isValid()) {
             layer.video = video;
             return;

--- a/src/engine/MediaEditor.cpp
+++ b/src/engine/MediaEditor.cpp
@@ -777,7 +777,7 @@ bool editVideo(const MediaEditSpec &spec, QString *errorOut,
         return fail(trEdit("The video has no usable size"));
     }
 
-    const int rotation = displayRotationOf(vStream);
+    const int rotation = spec.rotationOverride >= 0 ? spec.rotationOverride : displayRotationOf(vStream);
     int displayW = vDec->width;
     int displayH = vDec->height;
     if (rotation == 90 || rotation == 270)

--- a/src/engine/MediaEditor.h
+++ b/src/engine/MediaEditor.h
@@ -19,6 +19,10 @@ struct MediaEditSpec
     double cropY = 0;
     double cropW = 1;
     double cropH = 1;
+    // -1 = derive rotation from the source file's own display-matrix tag, as before. Set this to
+    // a bin-preview rotation override (0/90/180/270) so the crop rectangle — drawn in the QML
+    // preview against that corrected orientation — lands on the same pixels here.
+    int rotationOverride = -1;
 };
 
 // Rewrites `inputPath` into `outputPath` with the requested trim and crop. Images become PNG,

--- a/src/engine/MediaThumbnail.cpp
+++ b/src/engine/MediaThumbnail.cpp
@@ -401,14 +401,18 @@ QString MediaThumbnail::generateFilmstrip(const QString &sourcePath, const QStri
     return outPath;
 }
 
-QString MediaThumbnail::tilePath(const QString &sourcePath, int level, qint64 index)
+QString MediaThumbnail::tilePath(const QString &sourcePath, int level, qint64 index,
+                                 int rotationCorrection)
 {
     const QString absolutePath = QFileInfo(sourcePath).absoluteFilePath();
     if (absolutePath.isEmpty())
         return {};
 
-    return cacheDir() + QLatin1Char('/') + cacheKeyFor(absolutePath)
-           + QStringLiteral("_t%1_%2.jpg").arg(level).arg(index);
+    // The correction goes after the index so tileGlob()'s "_t*" still matches for pruning.
+    QString name = QStringLiteral("_t%1_%2").arg(level).arg(index);
+    if (rotationCorrection != 0)
+        name += QStringLiteral("_c%1").arg(rotationCorrection);
+    return cacheDir() + QLatin1Char('/') + cacheKeyFor(absolutePath) + name + QStringLiteral(".jpg");
 }
 
 MediaThumbnail::TileDecoder::~TileDecoder()
@@ -444,7 +448,8 @@ bool MediaThumbnail::TileDecoder::ensureOpen(const QString &absolutePath)
 }
 
 QList<qint64> MediaThumbnail::TileDecoder::generateTiles(const QString &sourcePath, int level,
-                                                         const QList<qint64> &indices)
+                                                         const QList<qint64> &indices,
+                                                         int rotationCorrection)
 {
     QList<qint64> produced;
     const QString absolutePath = QFileInfo(sourcePath).absoluteFilePath();
@@ -453,7 +458,7 @@ QList<qint64> MediaThumbnail::TileDecoder::generateTiles(const QString &sourcePa
 
     QList<qint64> todo;
     for (const qint64 index : indices) {
-        if (isValidCacheFile(tilePath(absolutePath, level, index)))
+        if (isValidCacheFile(tilePath(absolutePath, level, index, rotationCorrection)))
             produced.append(index);
         else
             todo.append(index);
@@ -466,13 +471,15 @@ QList<qint64> MediaThumbnail::TileDecoder::generateTiles(const QString &sourcePa
     if (!ensureOpen(absolutePath))
         return produced;
 
+    const int rotation =
+        ((displayRotationOf(m_fmt->streams[m_videoStreamIndex]) + rotationCorrection) % 360 + 360) % 360;
     for (const qint64 index : std::as_const(todo)) {
         const int64_t timeUs = static_cast<int64_t>(tileSeconds(level, index) * 1'000'000.0);
         QImage frame;
         if (!seekAndDecodeFrame(m_fmt, m_videoStreamIndex, m_codecCtx, timeUs, frame,
-                                kFilmstripFrameWidth, kFilmstripFrameHeight, &m_sws))
+                                kFilmstripFrameWidth, kFilmstripFrameHeight, &m_sws, rotation))
             continue;
-        if (frame.save(tilePath(absolutePath, level, index), "JPG", 85))
+        if (frame.save(tilePath(absolutePath, level, index, rotationCorrection), "JPG", 85))
             produced.append(index);
     }
 

--- a/src/engine/MediaThumbnail.cpp
+++ b/src/engine/MediaThumbnail.cpp
@@ -44,10 +44,20 @@ QString cacheDir()
 constexpr int kThumbnailCacheVersion = 3;
 constexpr int kThumbnailMaxEdge = 320;
 
-QString cacheKeyFor(const QString &sourcePath)
+// `rotationOverride` (>= 0) distinguishes a user-corrected orientation from the auto-detected
+// cache entry, so switching back to auto still hits the original file's cached thumbnail.
+// `startUs` (cover thumbnail only) does the same for a trim's "Set In" point — note the `_s`
+// prefix rather than `_t`, which the on-demand filmstrip *tile* cache already uses (see
+// tilePath/tileGlob below) and whose pruning would otherwise sweep this file up as a stale tile.
+QString cacheKeyFor(const QString &sourcePath, int rotationOverride = -1, qint64 startUs = 0)
 {
-    return QString::number(qHash(QFileInfo(sourcePath).absoluteFilePath()))
-           + QStringLiteral("_v") + QString::number(kThumbnailCacheVersion);
+    QString key = QString::number(qHash(QFileInfo(sourcePath).absoluteFilePath()))
+                  + QStringLiteral("_v") + QString::number(kThumbnailCacheVersion);
+    if (rotationOverride >= 0)
+        key += QStringLiteral("_r%1").arg(rotationOverride);
+    if (startUs > 0)
+        key += QStringLiteral("_s%1").arg(startUs);
+    return key;
 }
 
 // Thumbnails keep the source display aspect (pixel aspect included) so the media
@@ -68,14 +78,16 @@ QSize thumbnailSizeFor(int codedWidth, int codedHeight, AVRational sampleAspect)
             std::max(2, static_cast<int>(std::lround(codedHeight * scale)))};
 }
 
-QString cachePathFor(const QString &sourcePath)
+QString cachePathFor(const QString &sourcePath, int rotationOverride = -1, qint64 startUs = 0)
 {
-    return cacheDir() + QLatin1Char('/') + cacheKeyFor(sourcePath) + QStringLiteral(".jpg");
+    return cacheDir() + QLatin1Char('/') + cacheKeyFor(sourcePath, rotationOverride, startUs)
+           + QStringLiteral(".jpg");
 }
 
-QString cacheStripPathFor(const QString &sourcePath)
+QString cacheStripPathFor(const QString &sourcePath, int rotationOverride = -1)
 {
-    return cacheDir() + QLatin1Char('/') + cacheKeyFor(sourcePath) + QStringLiteral("_strip.jpg");
+    return cacheDir() + QLatin1Char('/') + cacheKeyFor(sourcePath, rotationOverride)
+           + QStringLiteral("_strip.jpg");
 }
 
 bool isValidCacheFile(const QString &path)
@@ -138,7 +150,7 @@ QImage frameToImage(const AVFrame *frame, int width, int height, SwsContext **sw
 
 bool decodeNextVideoFrame(AVFormatContext *fmt, int videoStreamIndex, AVCodecContext *codecCtx,
                           AVPacket *packet, AVFrame *frame, QImage &outImage, int width, int height,
-                          SwsContext **swsCache)
+                          SwsContext **swsCache, int rotationOverride = -1)
 {
     while (av_read_frame(fmt, packet) >= 0) {
         if (packet->stream_index != videoStreamIndex) {
@@ -159,8 +171,9 @@ bool decodeNextVideoFrame(AVFormatContext *fmt, int videoStreamIndex, AVCodecCon
             if (rc < 0)
                 return false;
 
-            outImage = frameToImage(frame, width, height, swsCache,
-                                    displayRotationOf(fmt->streams[videoStreamIndex]));
+            const int rotation = rotationOverride >= 0 ? rotationOverride
+                                                        : displayRotationOf(fmt->streams[videoStreamIndex]);
+            outImage = frameToImage(frame, width, height, swsCache, rotation);
             return !outImage.isNull();
         }
     }
@@ -170,7 +183,7 @@ bool decodeNextVideoFrame(AVFormatContext *fmt, int videoStreamIndex, AVCodecCon
 
 bool seekAndDecodeFrame(AVFormatContext *fmt, int videoStreamIndex, AVCodecContext *codecCtx,
                         int64_t timeUs, QImage &outImage, int width, int height,
-                        SwsContext **swsCache)
+                        SwsContext **swsCache, int rotationOverride = -1)
 {
     AVStream *stream = fmt->streams[videoStreamIndex];
     const int64_t targetTs = av_rescale_q(timeUs, {1, AV_TIME_BASE}, stream->time_base);
@@ -181,7 +194,7 @@ bool seekAndDecodeFrame(AVFormatContext *fmt, int videoStreamIndex, AVCodecConte
     AVFrame *frame = av_frame_alloc();
     const bool ok = packet && frame
                     && decodeNextVideoFrame(fmt, videoStreamIndex, codecCtx, packet, frame,
-                                            outImage, width, height, swsCache);
+                                            outImage, width, height, swsCache, rotationOverride);
 
     av_frame_free(&frame);
     av_packet_free(&packet);
@@ -189,9 +202,17 @@ bool seekAndDecodeFrame(AVFormatContext *fmt, int videoStreamIndex, AVCodecConte
 }
 
 bool decodeFirstVideoFrame(AVFormatContext *fmt, int videoStreamIndex, AVCodecContext *codecCtx,
-                           const QString &outPath, int width, int height)
+                           const QString &outPath, int width, int height, int rotationOverride = -1,
+                           int64_t startUs = 0)
 {
     avcodec_flush_buffers(codecCtx);
+    if (startUs > 0) {
+        // The bin's cover thumbnail should show the frame a trim's "Set In" point actually lands
+        // on, not always the file's very first frame.
+        AVStream *stream = fmt->streams[videoStreamIndex];
+        const int64_t targetTs = av_rescale_q(startUs, {1, AV_TIME_BASE}, stream->time_base);
+        av_seek_frame(fmt, videoStreamIndex, targetTs, AVSEEK_FLAG_BACKWARD);
+    }
 
     AVPacket *packet = av_packet_alloc();
     AVFrame *frame = av_frame_alloc();
@@ -202,7 +223,7 @@ bool decodeFirstVideoFrame(AVFormatContext *fmt, int videoStreamIndex, AVCodecCo
 
     while (!saved && packetsRead < 400 && packet && frame) {
         if (!decodeNextVideoFrame(fmt, videoStreamIndex, codecCtx, packet, frame, image, width,
-                                  height, &sws))
+                                  height, &sws, rotationOverride))
             break;
         ++packetsRead;
         saved = image.save(outPath, "JPG", 85);
@@ -269,13 +290,14 @@ bool openVideoDecoder(const QString &absolutePath, AVFormatContext **fmtOut,
 
 } // namespace
 
-QString MediaThumbnail::generate(const QString &sourcePath, const QString &kind)
+QString MediaThumbnail::generate(const QString &sourcePath, const QString &kind, int rotationOverride,
+                                 qint64 startUs)
 {
     const QString absolutePath = QFileInfo(sourcePath).absoluteFilePath();
     if (absolutePath.isEmpty() || !QFile::exists(absolutePath))
         return {};
 
-    const QString outPath = cachePathFor(absolutePath);
+    const QString outPath = cachePathFor(absolutePath, rotationOverride, startUs);
     if (isValidCacheFile(outPath))
         return outPath;
 
@@ -310,11 +332,13 @@ QString MediaThumbnail::generate(const QString &sourcePath, const QString &kind)
     const AVCodecParameters *par = fmt->streams[videoStreamIndex]->codecpar;
     QSize target = thumbnailSizeFor(par->width, par->height, par->sample_aspect_ratio);
     // SAR applies to the coded width, so size the frame first and transpose after.
-    const int rotation = displayRotationOf(fmt->streams[videoStreamIndex]);
+    const int rotation = rotationOverride >= 0 ? rotationOverride
+                                                : displayRotationOf(fmt->streams[videoStreamIndex]);
     if (rotation == 90 || rotation == 270)
         target.transpose();
     const bool saved = decodeFirstVideoFrame(fmt, videoStreamIndex, codecCtx, outPath,
-                                             target.width(), target.height());
+                                             target.width(), target.height(), rotationOverride,
+                                             startUs);
 
     avcodec_free_context(&codecCtx);
     avformat_close_input(&fmt);
@@ -322,19 +346,20 @@ QString MediaThumbnail::generate(const QString &sourcePath, const QString &kind)
     return saved ? outPath : QString();
 }
 
-QString MediaThumbnail::generateFilmstrip(const QString &sourcePath, const QString &kind)
+QString MediaThumbnail::generateFilmstrip(const QString &sourcePath, const QString &kind,
+                                          int rotationOverride)
 {
     const QString absolutePath = QFileInfo(sourcePath).absoluteFilePath();
     if (absolutePath.isEmpty() || !QFile::exists(absolutePath))
         return {};
 
     if (kind == QStringLiteral("image"))
-        return generate(absolutePath, kind);
+        return generate(absolutePath, kind, rotationOverride);
 
     if (kind != QStringLiteral("video"))
         return {};
 
-    const QString outPath = cacheStripPathFor(absolutePath);
+    const QString outPath = cacheStripPathFor(absolutePath, rotationOverride);
     if (isValidCacheFile(outPath))
         return outPath;
 
@@ -358,7 +383,7 @@ QString MediaThumbnail::generateFilmstrip(const QString &sourcePath, const QStri
         const int64_t timeUs = durationUs > 0 ? (durationUs * i) / frameCount : 0;
         QImage frame;
         if (!seekAndDecodeFrame(fmt, videoStreamIndex, codecCtx, timeUs, frame, frameW, frameH,
-                                &sws))
+                                &sws, rotationOverride))
             continue;
 
         anyFrame = true;

--- a/src/engine/MediaThumbnail.h
+++ b/src/engine/MediaThumbnail.h
@@ -14,8 +14,14 @@ public:
     static constexpr int kFilmstripFrameHeight = 68;
     static constexpr int kFilmstripFrameCount = 8;
 
-    static QString generate(const QString &sourcePath, const QString &kind);
-    static QString generateFilmstrip(const QString &sourcePath, const QString &kind);
+    // `rotationOverride` (0/90/180/270, or -1 to use the file's own probed display-matrix
+    // rotation) lets a bin-level user correction land in the cached thumbnail/filmstrip.
+    // `startUs` (cover thumbnail only, ignored by generateFilmstrip) seeks to that source time
+    // before capturing the frame, so a trim's "Set In" point becomes the bin's cover image.
+    static QString generate(const QString &sourcePath, const QString &kind, int rotationOverride = -1,
+                            qint64 startUs = 0);
+    static QString generateFilmstrip(const QString &sourcePath, const QString &kind,
+                                     int rotationOverride = -1);
     static QString generateAtTime(const QString &sourcePath, double sourceSeconds);
 
     // On-demand filmstrip tiles. The coarse strip above only ever holds 8 frames, so a long

--- a/src/engine/MediaThumbnail.h
+++ b/src/engine/MediaThumbnail.h
@@ -28,7 +28,10 @@ public:
     // clip repeats the same image for thousands of px; these fill in the real frame for a
     // given moment. A tile covers `2^level` source seconds starting at `index * 2^level`,
     // so zooming picks a finer level and panning reuses everything already cached.
-    static QString tilePath(const QString &sourcePath, int level, qint64 index);
+    // `rotationCorrection` is the clip's (Clip::rotationCorrection), applied on top of the
+    // file's own tag, so the strip shows frames the way the timeline does.
+    static QString tilePath(const QString &sourcePath, int level, qint64 index,
+                            int rotationCorrection = 0);
 
     // Drops the oldest tile files until the tile cache fits in `maxBytes`.
     static void pruneTileCache(qint64 maxBytes);
@@ -55,7 +58,7 @@ public:
         // near-sequential. Returns the indices that are now on disk. Reopens only when
         // `sourcePath` differs from the file already open.
         QList<qint64> generateTiles(const QString &sourcePath, int level,
-                                    const QList<qint64> &indices);
+                                    const QList<qint64> &indices, int rotationCorrection = 0);
 
         // Releases the decoder and its scaler. Safe to call when nothing is open; the next
         // generateTiles() reopens on demand.

--- a/src/engine/SceneDetect.cpp
+++ b/src/engine/SceneDetect.cpp
@@ -349,6 +349,7 @@ QString cacheDigest(const SceneDetectRequest &request)
     hash.addData(QByteArray::number(info.size()));
     hash.addData(QByteArray::number(request.sourceIn));
     hash.addData(QByteArray::number(request.sourceOut));
+    hash.addData(QByteArray::number(request.rotationCorrection));
     hash.addData(QByteArray::number(o.threshold, 'g', 10));
     hash.addData(QByteArray::number(o.minSceneSeconds, 'g', 10));
     hash.addData(QByteArray::number(o.adaptiveZ, 'g', 10));
@@ -461,7 +462,8 @@ void applyObjectLabels(const SceneDetectRequest &request, SceneAnalysis *analysi
             const TimeUs at = scene.sourceIn + TimeUs(double(scene.duration()) * through);
 
             const QImage frame = ClipReaderPool::instance().readVideoFrame(
-                request.path, kSceneScanStreamId, at, 0, 0);
+                request.path, kSceneScanStreamId, at, 0, 0, QString(), 15, false,
+                request.rotationCorrection);
             if (frame.isNull())
                 continue;
 
@@ -704,7 +706,8 @@ SceneAnalysis detectScenes(const SceneDetectRequest &request, const SceneProgres
     for (int i = 0; i < sampleCount; ++i) {
         const TimeUs sourceUs = request.sourceIn + TimeUs(std::llround(double(i) * intervalUs));
         const QImage frame = ClipReaderPool::instance().readVideoFrame(
-            request.path, kSceneScanStreamId, sourceUs, kScanFrameWidth, kScanFrameHeight);
+            request.path, kSceneScanStreamId, sourceUs, kScanFrameWidth, kScanFrameHeight,
+            QString(), 15, false, request.rotationCorrection);
         if (frame.isNull())
             return fail(QObject::tr("Could not decode frame %1").arg(i + 1));
 

--- a/src/engine/SceneDetect.h
+++ b/src/engine/SceneDetect.h
@@ -97,6 +97,7 @@ inline constexpr double kObjectWeight = 0.3;
 struct SceneDetectRequest
 {
     QString path;
+    int rotationCorrection = 0; // Clip::rotationCorrection; object boxes are in oriented pixels
     TimeUs sourceIn = 0;
     TimeUs sourceOut = 0;
     SceneDetectOptions options;

--- a/src/models/AppController.cpp
+++ b/src/models/AppController.cpp
@@ -711,6 +711,15 @@ AppController::AppController(AssetLibrary *assetLibrary, QObject *parent)
     if (m_assetLibrary) {
         connect(m_assetLibrary, &AssetLibrary::assetMetadataChanged, this,
                 &AppController::editCapabilitiesChanged);
+        // AssetLibrary has no AppController back-reference, so a bin-level edit that never goes
+        // through pushProjectEdit (setAssetRotation/setAssetTrim, called directly from QML) would
+        // otherwise leave m_dirty false — the project could be closed without a save prompt and
+        // the edit silently lost. assetUserEdited (not the broader assetMetadataChanged, which
+        // also covers a thumbnail/filmstrip landing or an audio-presence probe) fires only for
+        // those two actual user edits, so opening a project with missing cached thumbnails, or
+        // saving while one happens to regenerate, does not spuriously mark the project dirty.
+        connect(m_assetLibrary, &AssetLibrary::assetUserEdited, this,
+                [this]() { setDirty(true); });
     }
 
     connect(&m_filmstripTiles, &FilmstripTileCache::tileReady, this,
@@ -2176,14 +2185,59 @@ void fitClipLayoutToCanvas(drift::Clip &clip, int mediaW, int mediaH, int canvas
     setClipLayoutPixels(clip, 0, 0, mediaW * scale, mediaH * scale);
 }
 
+// Whether `asset` carries a bin-preview trim at all (AssetLibrary::setAssetTrim) — trimOutSeconds
+// < 0 alone does not mean "no trim": an in-only trim (start moved, end left alone) stores exactly
+// that, so a bare "is there an out point" check drops it. Shared by every place below that needs
+// to agree on what a trimmed asset's clip duration actually is.
+bool assetHasTrim(const QVariantMap &asset)
+{
+    return asset.value(QStringLiteral("trimInSeconds"), 0.0).toDouble() > 0.0
+           || asset.value(QStringLiteral("trimOutSeconds"), -1.0).toDouble() >= 0.0;
+}
+
+// The clip duration a bin-preview trim actually produces out of `fullDurationUs` — needed both by
+// applyAssetLayout (to set srcIn/srcOut) and by placement math (resolveClipStart, the batch
+// cursor) *before* the clip exists for applyAssetLayout to derive it the usual way. One function
+// so every add-from-asset site agrees with applyAssetLayout on what "the duration" means.
+drift::TimeUs trimmedClipDurationUs(const QVariantMap &asset, drift::TimeUs fullDurationUs)
+{
+    if (!assetHasTrim(asset))
+        return fullDurationUs;
+    const drift::TimeUs trimIn = qBound<drift::TimeUs>(
+        0, drift::secondsToUs(asset.value(QStringLiteral("trimInSeconds"), 0.0).toDouble()), fullDurationUs);
+    const double trimOutSeconds = asset.value(QStringLiteral("trimOutSeconds"), -1.0).toDouble();
+    const drift::TimeUs trimOut =
+        trimOutSeconds < 0.0
+            ? fullDurationUs
+            : qBound<drift::TimeUs>(trimIn + 1, drift::secondsToUs(trimOutSeconds), fullDurationUs);
+    return trimOut - trimIn;
+}
+
 void applyAssetLayout(drift::Clip &clip, const QVariantMap &asset, int canvasW, int canvasH)
 {
     int mediaW = asset.value(QStringLiteral("width")).toInt();
     int mediaH = asset.value(QStringLiteral("height")).toInt();
-    const int rotation = asset.value(QStringLiteral("rotationDegrees")).toInt();
+    // "effectiveRotation" folds in any bin-preview override over the probed rotationDegrees
+    // (AssetLibrary::assetAt) — baking it onto the clip keeps the placed clip's orientation
+    // correct even if the bin asset's override changes later.
+    const int rotation = asset.value(QStringLiteral("effectiveRotation")).toInt();
     if (rotation == 90 || rotation == 270)
         std::swap(mediaW, mediaH);
     fitClipLayoutToCanvas(clip, mediaW, mediaH, canvasW, canvasH);
+    clip.rotationOverride = rotation;
+
+    // A bin-preview trim is non-destructive (AssetLibrary::setAssetTrim never touches the file),
+    // so a freshly placed clip has to start at that saved range itself rather than the caller's
+    // default full-source srcIn/srcOut — the same idea as the rotation bake-in just above.
+    if (assetHasTrim(asset)) {
+        const drift::TimeUs durationUs =
+            drift::secondsToUs(asset.value(QStringLiteral("durationSeconds")).toDouble());
+        const drift::TimeUs trimIn = qBound<drift::TimeUs>(
+            0, drift::secondsToUs(asset.value(QStringLiteral("trimInSeconds"), 0.0).toDouble()), durationUs);
+        clip.timelineDuration = trimmedClipDurationUs(asset, durationUs);
+        clip.srcIn = trimIn;
+        clip.srcOut = trimIn + clip.timelineDuration;
+    }
 }
 
 // shapeAspect is the catalog's default width/height for the shape being added; a square shape must
@@ -2836,6 +2890,9 @@ QVariantMap AppController::clipToMap(const drift::Clip &clip, const drift::Clip 
         {QStringLiteral("reverse"), clip.reverse},
         {QStringLiteral("flipH"), clip.flipH},
         {QStringLiteral("flipV"), clip.flipV},
+        // Discrete lossless orientation correction, distinct from the free "rotation" keyframe
+        // track below — -1 means inherit the source file's own probed rotation.
+        {QStringLiteral("rotationOverride"), clip.rotationOverride},
         // Same redirect as the effect stacks above: a media clip's mask lives on the adjustment
         // pinned to it, but the inspector and the MCP tools still ask the clip for "its" mask.
         {QStringLiteral("mask"), maskToMap(maskHost ? maskHost->mask : clip.mask,
@@ -3480,6 +3537,26 @@ bool AppController::saveAssetEdit(int assetIndex, double inSeconds, double outSe
         return false;
     }
 
+    // A plain trim with no real crop needs no re-encode at all: it is stored on the asset the
+    // same non-destructive way a placed clip's srcIn/srcOut already works, and the original file
+    // is left untouched — mirroring how trimming a clip already on the timeline never re-encodes.
+    constexpr double kFullCropEps = 0.001;
+    const bool cropIsFull = cropX <= kFullCropEps && cropY <= kFullCropEps
+                            && cropW >= 1.0 - kFullCropEps && cropH >= 1.0 - kFullCropEps;
+    if (cropIsFull) {
+        const drift::TimeUs trimIn = drift::secondsToUs(qMax(0.0, inSeconds));
+        const drift::TimeUs trimOut = outSeconds < 0.0 ? -1 : drift::secondsToUs(outSeconds);
+        if (!m_assetLibrary->setAssetTrim(assetIndex, trimIn, trimOut)) {
+            // Nothing actually changed (e.g. the range already matches what is stored) — that is
+            // still a successful, no-op save from the dialog's point of view.
+            emit assetEditFinished(true, QString());
+            return true;
+        }
+        setLastMessage(tr("Trim saved"));
+        emit assetEditFinished(true, tr("Trim saved"));
+        return true;
+    }
+
     const QString outPath = drift::newEditedMediaPath(m_project.id(), kind);
     if (outPath.isEmpty()) {
         setLastMessage(tr("Could not create an output file"), QStringLiteral("error"));
@@ -3507,6 +3584,10 @@ bool AppController::saveAssetEdit(int assetIndex, double inSeconds, double outSe
     spec.cropY = cropY;
     spec.cropW = cropW;
     spec.cropH = cropH;
+    // The crop rectangle above is drawn in the preview against effectiveRotation, so the encoder
+    // has to rotate against that same correction — not the file's own tag — or the region it
+    // crops will not be the one the user saw and dragged a box around.
+    spec.rotationOverride = asset.value(QStringLiteral("effectiveRotation"), -1).toInt();
 
     (void)QtConcurrent::run([this, spec, assetIndex]() {
         QString error;
@@ -3620,6 +3701,10 @@ void AppController::finalizeAssetReplace(const QString &assetId, const drift::Me
     drift::MediaAsset replacement = filled;
     replacement.name = newName;
     replacement.sourceUri = replacementSourceUri;
+    // Captured before applyProbedSource overwrites `current` in place — rebindClipsToAsset needs
+    // to know what the asset's rotation *was* to rebase each clip's override by how much it
+    // actually changed, not just overwrite it outright.
+    const int oldEffectiveRotation = drift::effectiveRotation(*current);
     if (!m_assetLibrary->applyProbedSource(assetId, replacement)) {
         const QString message = tr("That media is no longer in this project.");
         finishEditJob(false, message);
@@ -3628,7 +3713,7 @@ void AppController::finalizeAssetReplace(const QString &assetId, const drift::Me
         return;
     }
 
-    const int adjusted = rebindClipsToAsset(assetId, replacement);
+    const int adjusted = rebindClipsToAsset(assetId, replacement, oldEffectiveRotation);
     pushProjectEdit(before, fromEdit ? tr("Media edited") : tr("Media replaced"));
     finishEdit(fromEdit ? tr("Media edited") : tr("Media replaced"));
     finishEditJob(true, newName);
@@ -3636,8 +3721,10 @@ void AppController::finalizeAssetReplace(const QString &assetId, const drift::Me
         emit assetReplaceFinished(true, newName, adjusted);
 }
 
-int AppController::rebindClipsToAsset(const QString &assetId, const drift::MediaAsset &asset)
+int AppController::rebindClipsToAsset(const QString &assetId, const drift::MediaAsset &asset,
+                                      int oldEffectiveRotation)
 {
+    const int newEffectiveRotation = drift::effectiveRotation(asset);
     int adjusted = 0;
     for (drift::Track &track : m_project.tracks()) {
         for (drift::Clip &clip : track.clips) {
@@ -3650,6 +3737,30 @@ int AppController::rebindClipsToAsset(const QString &assetId, const drift::Media
             clip.path = asset.path;
             clip.thumbnailPath = asset.thumbnailPath;
             clip.filmstripPath = asset.filmstripPath;
+            // An explicit override was baked in from whatever the asset's rotation was at add
+            // time (see applyAssetLayout), but may have since been corrected further and
+            // independently via the timeline's own "Fix orientation" control — overwriting it
+            // outright would discard that. Rebase by how much the asset's *own* rotation actually
+            // changed instead: most pointedly, a crop-save bakes any bin rotation correction into
+            // the re-encoded pixels themselves (the freshly probed `asset` here already has
+            // effectiveRotation 0/-1), and every clip's override has to drop that exact same
+            // amount too, or it applies the correction a second time on top of already-upright
+            // pixels — while a clip that was *additionally* corrected on the timeline keeps that
+            // extra correction relative to the asset's new baseline.
+            //
+            // -1 (inherit) is different in kind, not just value, and is left untouched rather
+            // than folded into the same delta: it means "whatever the file this clip now points
+            // at says its own rotation is" — a clip only ever reaches -1 by pre-dating this
+            // feature entirely (any inspector correction sets an explicit value and never goes
+            // back), so it was never coupled to the *bin's* rotation to begin with. clip.path is
+            // rewritten to `asset.path` below regardless, so leaving -1 alone already makes it
+            // read the replacement file's own tag — correct for a crop-save (which bakes rotation
+            // into pixels and leaves the output file's tag at 0, matching upright pixels exactly)
+            // and just as correct for a plain replace with an unrelated file of its own rotation.
+            if (clip.rotationOverride >= 0) {
+                const int extraCorrection = ((clip.rotationOverride - oldEffectiveRotation) % 360 + 360) % 360;
+                clip.rotationOverride = (newEffectiveRotation + extraCorrection) % 360;
+            }
             // Landmarks are baked against the old pixels. Left in place they would keep the face
             // warps tracking a face the new footage never had, and render without erroring.
             clip.faceTrackPath.clear();
@@ -4283,6 +4394,14 @@ void AppController::setDraggingAssetIndex(int index)
     emit draggingAssetIndexChanged();
 }
 
+void AppController::setAssetPreviewWindowOpen(bool open)
+{
+    if (m_assetPreviewWindowOpen == open)
+        return;
+    m_assetPreviewWindowOpen = open;
+    emit assetPreviewWindowOpenChanged();
+}
+
 void AppController::setProjectName(const QString &name)
 {
     if (m_project.name() == name)
@@ -4597,8 +4716,13 @@ void AppController::addClipFromAsset(int assetIndex)
         return;
 
     const drift::TimeUs duration = clipDurationForAssetIndex(assetIndex);
-    const drift::TimeUs start = drift::resolveClipStart(m_project, track, -1, m_playheadUs, duration, m_snapEnabled,
-                                                        m_playheadUs);
+    // A bin-preview trim shortens what actually lands on the timeline (applyAssetLayout below
+    // applies it), so collision/gap placement has to size itself against that, not the asset's
+    // full duration, or a trimmed clip gets pushed out past a neighbour it would easily fit next
+    // to.
+    const drift::TimeUs placementDuration = trimmedClipDurationUs(asset, duration);
+    const drift::TimeUs start = drift::resolveClipStart(m_project, track, -1, m_playheadUs,
+                                                        placementDuration, m_snapEnabled, m_playheadUs);
 
     drift::Clip clip;
     clip.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
@@ -4609,7 +4733,7 @@ void AppController::addClipFromAsset(int assetIndex)
     clip.thumbnailPath = thumbnailPath;
     clip.filmstripPath = filmstripPath;
     clip.timelineStart = start;
-    clip.timelineDuration = duration;
+    clip.timelineDuration = placementDuration;
     clip.srcIn = 0;
     clip.srcOut = duration;
     applyAssetLayout(clip, asset, m_project.width(), m_project.height());
@@ -4663,8 +4787,11 @@ void AppController::addClipsFromAssets(const QStringList &assetIds)
         const QString thumbnailPath = m_assetLibrary->thumbnailAt(assetIndex);
         const QString filmstripPath = m_assetLibrary->filmstripAt(assetIndex);
         const drift::TimeUs duration = clipDurationForAssetIndex(assetIndex);
-        const drift::TimeUs start =
-            drift::resolveClipStart(m_project, track, -1, cursor, duration, m_snapEnabled, cursor);
+        // See addClipFromAsset: placement must size against the trimmed length, not the asset's
+        // full duration, or a trimmed clip gets pushed past a neighbour it would fit next to.
+        const drift::TimeUs placementDuration = trimmedClipDurationUs(asset, duration);
+        const drift::TimeUs start = drift::resolveClipStart(m_project, track, -1, cursor,
+                                                            placementDuration, m_snapEnabled, cursor);
 
         drift::Clip clip;
         clip.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
@@ -4675,7 +4802,7 @@ void AppController::addClipsFromAssets(const QStringList &assetIds)
         clip.thumbnailPath = thumbnailPath;
         clip.filmstripPath = filmstripPath;
         clip.timelineStart = start;
-        clip.timelineDuration = duration;
+        clip.timelineDuration = placementDuration;
         clip.srcIn = 0;
         clip.srcOut = duration;
         applyAssetLayout(clip, asset, m_project.width(), m_project.height());
@@ -4683,7 +4810,10 @@ void AppController::addClipsFromAssets(const QStringList &assetIds)
         track.clips.append(clip);
         lastTrackIndex = trackIndex;
         lastClipIndex = track.clips.size() - 1;
-        cursor = start + duration;
+        // Not `duration`: applyAssetLayout above may have shortened clip.timelineDuration to a
+        // bin-preview trim, and the cursor has to advance by what actually got placed or the
+        // next clip lands after a gap the size of the trimmed-off tail.
+        cursor = start + clip.timelineDuration;
     }
 
     if (lastTrackIndex < 0)
@@ -4744,8 +4874,11 @@ void AppController::addClipFromAssetOnNewTrackAt(int assetIndex, int insertIndex
 
     drift::Track &track = m_project.tracks()[trackIndex];
     const drift::TimeUs duration = clipDurationForAssetIndex(assetIndex);
+    // See addClipFromAsset: placement must size against the trimmed length, not the asset's full
+    // duration.
+    const drift::TimeUs placementDuration = trimmedClipDurationUs(asset, duration);
     const drift::TimeUs start = drift::resolveClipStart(m_project, track, -1, drift::secondsToUs(atSeconds),
-                                                        duration, m_snapEnabled, m_playheadUs);
+                                                        placementDuration, m_snapEnabled, m_playheadUs);
 
     drift::Clip clip;
     clip.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
@@ -4756,7 +4889,7 @@ void AppController::addClipFromAssetOnNewTrackAt(int assetIndex, int insertIndex
     clip.thumbnailPath = thumbnailPath;
     clip.filmstripPath = filmstripPath;
     clip.timelineStart = start;
-    clip.timelineDuration = duration;
+    clip.timelineDuration = placementDuration;
     clip.srcIn = 0;
     clip.srcOut = duration;
     applyAssetLayout(clip, asset, m_project.width(), m_project.height());
@@ -4791,8 +4924,11 @@ void AppController::addClipFromAssetAt(int assetIndex, int trackIndex, double at
     const drift::Project before = m_project;
     drift::Track &track = m_project.tracks()[trackIndex];
     const drift::TimeUs duration = clipDurationForAssetIndex(assetIndex);
+    // See addClipFromAsset: placement must size against the trimmed length, not the asset's full
+    // duration.
+    const drift::TimeUs placementDuration = trimmedClipDurationUs(asset, duration);
     const drift::TimeUs start = drift::resolveClipStart(m_project, track, -1, drift::secondsToUs(atSeconds),
-                                                        duration, m_snapEnabled, m_playheadUs);
+                                                        placementDuration, m_snapEnabled, m_playheadUs);
 
     drift::Clip clip;
     clip.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
@@ -4803,7 +4939,7 @@ void AppController::addClipFromAssetAt(int assetIndex, int trackIndex, double at
     clip.thumbnailPath = thumbnailPath;
     clip.filmstripPath = filmstripPath;
     clip.timelineStart = start;
-    clip.timelineDuration = duration;
+    clip.timelineDuration = placementDuration;
     clip.srcIn = 0;
     clip.srcOut = duration;
     applyAssetLayout(clip, asset, m_project.width(), m_project.height());
@@ -6746,6 +6882,7 @@ void AppController::beginAssetPreview(int assetIndex)
     clip.srcOut = asset->durationUs;
     clip.timelineStart = 0;
     clip.timelineDuration = asset->durationUs;
+    clip.rotationOverride = asset->rotationOverride;
 
     m_assetPreviewIndex = assetIndex;
     m_assetPreviewActive = true;
@@ -10555,7 +10692,7 @@ QVariantMap AppController::suggestedProjectSetupForAsset(int assetIndex) const
 
     int w = asset.value(QStringLiteral("width")).toInt();
     int h = asset.value(QStringLiteral("height")).toInt();
-    const int rotation = asset.value(QStringLiteral("rotationDegrees")).toInt();
+    const int rotation = asset.value(QStringLiteral("effectiveRotation")).toInt();
     if (rotation == 90 || rotation == 270)
         std::swap(w, h);
     if (w > 0 && h > 0) {
@@ -11846,6 +11983,185 @@ void AppController::setClipRotationSnap(int trackIndex, int clipIndex, double de
     clip.rotation.setKeyframe(0, snapped);
     pushProjectEdit(before, tr("Rotation snapped"));
     finishEdit(tr("Rotation set to %1°").arg(snapped, 0, 'f', 0));
+}
+
+void AppController::setClipOrientation(int trackIndex, int clipIndex, int degrees)
+{
+    if (trackIndex < 0 || trackIndex >= m_project.tracks().size())
+        return;
+
+    drift::Track &track = m_project.tracks()[trackIndex];
+    if (clipIndex < 0 || clipIndex >= track.clips.size())
+        return;
+
+    drift::Clip &clip = track.clips[clipIndex];
+    // Images and text/shape clips do not carry a source display-matrix rotation to correct — only
+    // a decoded video frame does.
+    if (clip.type != drift::ClipType::Video)
+        return;
+
+    int normalized = ((degrees % 360) + 360) % 360;
+    normalized = ((normalized + 45) / 90 * 90) % 360;
+
+    const drift::MediaAsset *asset = m_project.asset(clip.assetId);
+    const int oldRotation = clip.rotationOverride >= 0
+        ? clip.rotationOverride
+        : (asset ? drift::effectiveRotation(*asset) : 0);
+    if (oldRotation == normalized)
+        return;
+
+    const drift::Project before = m_project;
+
+    // Only the aspect category (portrait-swapped vs not) needs the box to change — going from,
+    // say, 90 to 270 spins the same content inside the same box. Transposing whatever box the
+    // clip currently has (not re-deriving one from the source media) preserves any manual
+    // resize/reposition the user already made, and needs no canvas or media-size lookup at all.
+    const bool oldSwapped = (oldRotation == 90 || oldRotation == 270);
+    const bool newSwapped = (normalized == 90 || normalized == 270);
+    if (oldSwapped != newSwapped) {
+        // setClipLayoutPixels would collapse every track to one key sampled at time 0, destroying
+        // any existing position/size animation. Width and height instead trade places outright —
+        // new width is exactly the old height track and vice versa, so swapping the two
+        // KeyframeTrack objects wholesale carries every keyframe's time, tangents, hold flag and
+        // the track's enabled/disabled state across losslessly; nothing is resampled and nothing
+        // is lost, even for a disabled track holding keyframes past its frozen first one.
+        const drift::KeyframeTrack<double> oldW = clip.transformW;
+        const drift::KeyframeTrack<double> oldH = clip.transformH;
+        std::swap(clip.transformW, clip.transformH);
+
+        // X/Y need their *values* recomputed (the box's center has to stay put under the new,
+        // transposed size) by (old width - old height)/2 (or the mirror for Y).
+        QSet<drift::TimeUs> sizeTimes;
+        for (auto it = oldW.keyframes().constBegin(); it != oldW.keyframes().constEnd(); ++it)
+            sizeTimes.insert(it.key());
+        for (auto it = oldH.keyframes().constBegin(); it != oldH.keyframes().constEnd(); ++it)
+            sizeTimes.insert(it.key());
+        // More than one keyframe on *either* track means width/height are independently animated,
+        // so the offset is itself a curve, not a constant. (Checking the union's size instead
+        // would be a false positive whenever width and height each hold just one keyframe, but at
+        // two different times — neither is actually animated, yet the union would have two.)
+        const bool sizeIsAnimated = oldW.keyframes().size() > 1 || oldH.keyframes().size() > 1;
+
+        auto retimeAxis = [&](drift::KeyframeTrack<double> &axis, bool axisIsX) {
+            if (axis.isEmpty())
+                return;
+            const QMap<drift::TimeUs, drift::Keyframe<double>> originalKeys = axis.keyframes();
+            auto offsetAt = [&](drift::TimeUs t) {
+                const double w = oldW.isEmpty() ? double(m_project.width()) : oldW.evaluateAt(t);
+                const double h = oldH.isEmpty() ? double(m_project.height()) : oldH.evaluateAt(t);
+                return axisIsX ? (w - h) * 0.5 : (h - w) * 0.5;
+            };
+
+            drift::KeyframeTrack<double> rebuilt;
+            if (!sizeIsAnimated) {
+                // The offset is one constant for the whole clip (even if width/height each hold a
+                // single, never-changing keyframe), so shifting every existing keyframe's value
+                // by it is exact — tangents, hold flags and the enabled/disabled state all carry
+                // over completely unchanged, whether this axis was enabled or not.
+                const double offset = offsetAt(0);
+                for (auto it = originalKeys.constBegin(); it != originalKeys.constEnd(); ++it) {
+                    drift::Keyframe<double> key = it.value();
+                    key.value += offset;
+                    rebuilt.setKeyframe(it.key(), key);
+                }
+                rebuilt.setEnabled(axis.enabled());
+                axis = rebuilt;
+                return;
+            }
+
+            // Width/height are genuinely animated, so the correction is a curve, not a constant —
+            // which a disabled axis (frozen at its first key regardless of time, by definition)
+            // cannot represent at all, whatever its own enabled state was: freezing it at one
+            // corrected value would hold that value right through the rest of the clip while the
+            // box keeps changing size underneath it, drifting off-center exactly as if no
+            // correction had been applied past that first instant. Getting the visible box right
+            // for the whole clip needs this axis to actually track the correction over time, so it
+            // has to become active — the same as an already-enabled axis needs to.
+            //
+            // Sample at every keyframe instant from this axis and from width/height's own tracks
+            // first — mandatory, not optional, since a fixed sample rate can step right over a
+            // short-lived spike between two close keyframes and miss it entirely (e.g. a width
+            // animated 100→200→100 across two 50ms segments, sampled only every 100ms, would see
+            // nothing but the unchanged endpoints). Extra samples are only inserted to fill long
+            // gaps between sparse keyframes, evenly spaced so the piecewise-linear approximation
+            // there does not get too coarse.
+            QSet<drift::TimeUs> mandatorySet = sizeTimes;
+            for (auto it = originalKeys.constBegin(); it != originalKeys.constEnd(); ++it)
+                mandatorySet.insert(it.key());
+            QList<drift::TimeUs> mandatory(mandatorySet.constBegin(), mandatorySet.constEnd());
+            std::sort(mandatory.begin(), mandatory.end());
+
+            // Whether `track` is provably unchanging from `t` up to whichever mandatory time
+            // comes next — either because it never changes at all (0 or 1 keyframe total) or
+            // because its governing keyframe at-or-before `t` is itself a hold. Since no track
+            // has a keyframe strictly between two adjacent mandatory times (if it did, that time
+            // would itself be mandatory), "constant at t" means constant for the whole segment.
+            auto isConstantFrom = [](const drift::KeyframeTrack<double> &track, drift::TimeUs t) {
+                const auto &keys = track.keyframes();
+                if (keys.size() <= 1)
+                    return true;
+                auto it = keys.upperBound(t);
+                if (it == keys.constBegin())
+                    return true; // t is before this track's first key — evaluateAt clamps flat
+                --it;
+                return it->hold;
+            };
+            // A sample only freezes the *combined* value if every contributor to it — this
+            // axis's own motion as much as width/height — is itself unchanging across the same
+            // span; a hold on just one of them must not suppress whichever of the others is still
+            // genuinely moving in that span.
+            auto sample = [&](drift::TimeUs t) {
+                drift::Keyframe<double> key;
+                key.value = axis.evaluateAt(t) + offsetAt(t);
+                key.hold = isConstantFrom(axis, t) && isConstantFrom(oldW, t) && isConstantFrom(oldH, t);
+                rebuilt.setKeyframe(t, key);
+            };
+
+            constexpr drift::TimeUs kMaxGapUs = 200'000; // 200ms
+            for (int i = 0; i < mandatory.size(); ++i) {
+                sample(mandatory.at(i));
+                if (i + 1 >= mandatory.size())
+                    continue;
+                const drift::TimeUs gap = mandatory.at(i + 1) - mandatory.at(i);
+                if (gap <= kMaxGapUs)
+                    continue;
+                const int steps = static_cast<int>(gap / kMaxGapUs);
+                for (int s = 1; s < steps; ++s)
+                    sample(mandatory.at(i) + s * (gap / steps));
+            }
+
+            // A mandatory point can be reached by one component jumping (held, then landing a
+            // new value right there) while another keeps moving continuously through the same
+            // instant — segmentIsConstant above correctly leaves that whole span un-held (since
+            // it is not *all* frozen), but plain linear interpolation between the span's start
+            // and this point then smears the jump backward across the entire span instead of
+            // holding it to the single instant it belongs to. Whenever the value actually
+            // discontinues at a mandatory point, insert one more sample a microsecond before it
+            // carrying the correct left-hand limit (the continuous part's value, still combined
+            // with whatever was frozen right up to the jump) — that isolates the jump to the
+            // last microsecond and lets the continuous portion interpolate correctly on its own.
+            for (int i = 1; i < mandatory.size(); ++i) {
+                const drift::TimeUs t = mandatory.at(i);
+                const drift::TimeUs before = t - 1;
+                if (before <= mandatory.at(i - 1))
+                    continue; // no room for a separate instant this close to the previous sample
+                const double atT = axis.evaluateAt(t) + offsetAt(t);
+                const double justBefore = axis.evaluateAt(before) + offsetAt(before);
+                if (qFuzzyCompare(atT + 1.0, justBefore + 1.0))
+                    continue;
+                rebuilt.setKeyframe(before, justBefore);
+            }
+
+            rebuilt.setEnabled(true);
+            axis = rebuilt;
+        };
+        retimeAxis(clip.transformX, true);
+        retimeAxis(clip.transformY, false);
+    }
+
+    clip.rotationOverride = normalized;
+    pushProjectEdit(before, tr("Orientation changed"));
+    finishEdit(tr("Clip orientation set to %1°").arg(normalized));
 }
 
 bool AppController::canMergeSelection() const
@@ -15042,6 +15358,10 @@ void AppController::pasteAttributes(const QVariantMap &options)
             targetClip.blendMode = sourceClip.blendMode;
             targetClip.flipH = sourceClip.flipH;
             targetClip.flipV = sourceClip.flipV;
+            // Keeps the pasted box paired with the orientation it was fit for; irrelevant to
+            // non-video targets, whose decode never consults it.
+            if (targetClip.type == drift::ClipType::Video)
+                targetClip.rotationOverride = sourceClip.rotationOverride;
             // Pinning a mask mints a lane, which inserts a track and invalidates `track` and
             // `targetClip`. Queued by id and applied once the loop is done.
             pendingMasks.append(qMakePair(targetClip.id, sourceItem.masks));

--- a/src/models/AppController.cpp
+++ b/src/models/AppController.cpp
@@ -711,15 +711,6 @@ AppController::AppController(AssetLibrary *assetLibrary, QObject *parent)
     if (m_assetLibrary) {
         connect(m_assetLibrary, &AssetLibrary::assetMetadataChanged, this,
                 &AppController::editCapabilitiesChanged);
-        // AssetLibrary has no AppController back-reference, so a bin-level edit that never goes
-        // through pushProjectEdit (setAssetRotation/setAssetTrim, called directly from QML) would
-        // otherwise leave m_dirty false — the project could be closed without a save prompt and
-        // the edit silently lost. assetUserEdited (not the broader assetMetadataChanged, which
-        // also covers a thumbnail/filmstrip landing or an audio-presence probe) fires only for
-        // those two actual user edits, so opening a project with missing cached thumbnails, or
-        // saving while one happens to regenerate, does not spuriously mark the project dirty.
-        connect(m_assetLibrary, &AssetLibrary::assetUserEdited, this,
-                [this]() { setDirty(true); });
     }
 
     connect(&m_filmstripTiles, &FilmstripTileCache::tileReady, this,
@@ -2218,13 +2209,13 @@ void applyAssetLayout(drift::Clip &clip, const QVariantMap &asset, int canvasW, 
     int mediaW = asset.value(QStringLiteral("width")).toInt();
     int mediaH = asset.value(QStringLiteral("height")).toInt();
     // "effectiveRotation" folds in any bin-preview override over the probed rotationDegrees
-    // (AssetLibrary::assetAt) — baking it onto the clip keeps the placed clip's orientation
-    // correct even if the bin asset's override changes later.
+    // (AssetLibrary::assetAt). The clip carries the bin's correction as its own from here on, so
+    // its orientation stays put even if the bin asset's override changes later.
     const int rotation = asset.value(QStringLiteral("effectiveRotation")).toInt();
     if (rotation == 90 || rotation == 270)
         std::swap(mediaW, mediaH);
     fitClipLayoutToCanvas(clip, mediaW, mediaH, canvasW, canvasH);
-    clip.rotationOverride = rotation;
+    clip.rotationCorrection = asset.value(QStringLiteral("rotationCorrection")).toInt();
 
     // A bin-preview trim is non-destructive (AssetLibrary::setAssetTrim never touches the file),
     // so a freshly placed clip has to start at that saved range itself rather than the caller's
@@ -2890,9 +2881,11 @@ QVariantMap AppController::clipToMap(const drift::Clip &clip, const drift::Clip 
         {QStringLiteral("reverse"), clip.reverse},
         {QStringLiteral("flipH"), clip.flipH},
         {QStringLiteral("flipV"), clip.flipV},
-        // Discrete lossless orientation correction, distinct from the free "rotation" keyframe
-        // track below — -1 means inherit the source file's own probed rotation.
-        {QStringLiteral("rotationOverride"), clip.rotationOverride},
+        // Discrete lossless orientation fix, distinct from the free "rotation" keyframe track
+        // below. "orientation" is the absolute result (what the inspector shows), the correction
+        // is what is stored — see drift::Clip::rotationCorrection.
+        {QStringLiteral("rotationCorrection"), clip.rotationCorrection},
+        {QStringLiteral("orientation"), clipOrientation(clip)},
         // Same redirect as the effect stacks above: a media clip's mask lives on the adjustment
         // pinned to it, but the inspector and the MCP tools still ask the clip for "its" mask.
         {QStringLiteral("mask"), maskToMap(maskHost ? maskHost->mask : clip.mask,
@@ -3133,6 +3126,19 @@ bool AppController::renameAsset(int assetIndex, const QString &name)
 
     pushProjectEdit(before, tr("Rename media"));
     finishEdit(tr("Media renamed"));
+    return true;
+}
+
+bool AppController::setAssetRotation(int assetIndex, int degrees)
+{
+    if (!m_assetLibrary)
+        return false;
+
+    const drift::Project before = m_project;
+    if (!m_assetLibrary->setAssetRotation(assetIndex, degrees))
+        return false;
+
+    pushProjectEdit(before, tr("Media rotated"));
     return true;
 }
 
@@ -3546,12 +3552,14 @@ bool AppController::saveAssetEdit(int assetIndex, double inSeconds, double outSe
     if (cropIsFull) {
         const drift::TimeUs trimIn = drift::secondsToUs(qMax(0.0, inSeconds));
         const drift::TimeUs trimOut = outSeconds < 0.0 ? -1 : drift::secondsToUs(outSeconds);
+        const drift::Project before = m_project;
         if (!m_assetLibrary->setAssetTrim(assetIndex, trimIn, trimOut)) {
             // Nothing actually changed (e.g. the range already matches what is stored) — that is
             // still a successful, no-op save from the dialog's point of view.
             emit assetEditFinished(true, QString());
             return true;
         }
+        pushProjectEdit(before, tr("Media trimmed"));
         setLastMessage(tr("Trim saved"));
         emit assetEditFinished(true, tr("Trim saved"));
         return true;
@@ -3702,9 +3710,8 @@ void AppController::finalizeAssetReplace(const QString &assetId, const drift::Me
     replacement.name = newName;
     replacement.sourceUri = replacementSourceUri;
     // Captured before applyProbedSource overwrites `current` in place — rebindClipsToAsset needs
-    // to know what the asset's rotation *was* to rebase each clip's override by how much it
-    // actually changed, not just overwrite it outright.
-    const int oldEffectiveRotation = drift::effectiveRotation(*current);
+    // to know what the bin's correction *was* to rebase each clip's own by how much it changed.
+    const int oldBinCorrection = drift::rotationCorrectionOf(*current);
     if (!m_assetLibrary->applyProbedSource(assetId, replacement)) {
         const QString message = tr("That media is no longer in this project.");
         finishEditJob(false, message);
@@ -3713,7 +3720,7 @@ void AppController::finalizeAssetReplace(const QString &assetId, const drift::Me
         return;
     }
 
-    const int adjusted = rebindClipsToAsset(assetId, replacement, oldEffectiveRotation);
+    const int adjusted = rebindClipsToAsset(assetId, replacement, oldBinCorrection);
     pushProjectEdit(before, fromEdit ? tr("Media edited") : tr("Media replaced"));
     finishEdit(fromEdit ? tr("Media edited") : tr("Media replaced"));
     finishEditJob(true, newName);
@@ -3722,9 +3729,9 @@ void AppController::finalizeAssetReplace(const QString &assetId, const drift::Me
 }
 
 int AppController::rebindClipsToAsset(const QString &assetId, const drift::MediaAsset &asset,
-                                      int oldEffectiveRotation)
+                                      int oldBinCorrection)
 {
-    const int newEffectiveRotation = drift::effectiveRotation(asset);
+    const int newBinCorrection = drift::rotationCorrectionOf(asset);
     int adjusted = 0;
     for (drift::Track &track : m_project.tracks()) {
         for (drift::Clip &clip : track.clips) {
@@ -3737,30 +3744,13 @@ int AppController::rebindClipsToAsset(const QString &assetId, const drift::Media
             clip.path = asset.path;
             clip.thumbnailPath = asset.thumbnailPath;
             clip.filmstripPath = asset.filmstripPath;
-            // An explicit override was baked in from whatever the asset's rotation was at add
-            // time (see applyAssetLayout), but may have since been corrected further and
-            // independently via the timeline's own "Fix orientation" control — overwriting it
-            // outright would discard that. Rebase by how much the asset's *own* rotation actually
-            // changed instead: most pointedly, a crop-save bakes any bin rotation correction into
-            // the re-encoded pixels themselves (the freshly probed `asset` here already has
-            // effectiveRotation 0/-1), and every clip's override has to drop that exact same
-            // amount too, or it applies the correction a second time on top of already-upright
-            // pixels — while a clip that was *additionally* corrected on the timeline keeps that
-            // extra correction relative to the asset's new baseline.
-            //
-            // -1 (inherit) is different in kind, not just value, and is left untouched rather
-            // than folded into the same delta: it means "whatever the file this clip now points
-            // at says its own rotation is" — a clip only ever reaches -1 by pre-dating this
-            // feature entirely (any inspector correction sets an explicit value and never goes
-            // back), so it was never coupled to the *bin's* rotation to begin with. clip.path is
-            // rewritten to `asset.path` below regardless, so leaving -1 alone already makes it
-            // read the replacement file's own tag — correct for a crop-save (which bakes rotation
-            // into pixels and leaves the output file's tag at 0, matching upright pixels exactly)
-            // and just as correct for a plain replace with an unrelated file of its own rotation.
-            if (clip.rotationOverride >= 0) {
-                const int extraCorrection = ((clip.rotationOverride - oldEffectiveRotation) % 360 + 360) % 360;
-                clip.rotationOverride = (newEffectiveRotation + extraCorrection) % 360;
-            }
+            // The clip's correction started as the bin's (applyAssetLayout) and may have been
+            // turned further on the timeline since. Keep that extra part and swap the bin's old
+            // share for its new one — most pointedly, a crop-save bakes the bin's correction into
+            // the re-encoded pixels, so the freshly probed `asset` has none left and every clip
+            // has to drop that same amount or it turns already-upright pixels a second time.
+            clip.rotationCorrection =
+                ((clip.rotationCorrection - oldBinCorrection + newBinCorrection) % 360 + 360) % 360;
             // Landmarks are baked against the old pixels. Left in place they would keep the face
             // warps tracking a face the new footage never had, and render without erroring.
             clip.faceTrackPath.clear();
@@ -4530,11 +4520,13 @@ QString AppController::filmstripFrameUrl(const QString &path, int frame, int cou
     return imageUrl(path) + QStringLiteral("?frame=%1&count=%2").arg(frame).arg(count);
 }
 
-QString AppController::filmstripTileUrl(const QString &path, int level, double index) const
+QString AppController::filmstripTileUrl(const QString &path, int level, double index,
+                                        int rotationCorrection) const
 {
     if (path.isEmpty())
         return {};
-    const QString tile = m_filmstripTiles.tile(path, level, static_cast<qint64>(index));
+    const QString tile =
+        m_filmstripTiles.tile(path, level, static_cast<qint64>(index), rotationCorrection);
     return tile.isEmpty() ? QString() : imageUrl(tile);
 }
 
@@ -6783,6 +6775,7 @@ void AppController::refreshMulticamTiles()
         QString path;
         quint64 streamId = 0;
         drift::TimeUs sourceUs = 0;
+        int rotationCorrection = 0;
     };
 
     QList<AngleRead> reads;
@@ -6796,7 +6789,7 @@ void AppController::refreshMulticamTiles()
         }
         reads.append(AngleRead{i, clip.path,
                                kMulticamStreamSalt ^ ClipReaderPool::streamIdForClip(clip.id),
-                               clip.timelineToSourceUs(m_playheadUs)});
+                               clip.timelineToSourceUs(m_playheadUs), clip.rotationCorrection});
     }
 
     // Angles with nothing under the playhead clear immediately; there is no decode to wait for.
@@ -6813,7 +6806,7 @@ void AppController::refreshMulticamTiles()
     requests.reserve(reads.size());
     for (const AngleRead &read : reads)
         requests.append(ClipReaderPool::VideoRequest{read.path, read.streamId, read.sourceUs,
-                                                     maxWidth, maxHeight});
+                                                     maxWidth, maxHeight, read.rotationCorrection});
 
     m_multicamRefreshing = true;
     const int generation = ++m_multicamGeneration;
@@ -6828,7 +6821,8 @@ void AppController::refreshMulticamTiles()
         for (const AngleRead &read : reads) {
             tiles.append(qMakePair(read.angle,
                                    ClipReaderPool::instance().readVideoFrame(
-                                       read.path, read.streamId, read.sourceUs, maxWidth, maxHeight)));
+                                       read.path, read.streamId, read.sourceUs, maxWidth, maxHeight,
+                                       QString(), 15, false, read.rotationCorrection)));
         }
 
         QMetaObject::invokeMethod(this, [this, tiles, generation]() {
@@ -6882,7 +6876,7 @@ void AppController::beginAssetPreview(int assetIndex)
     clip.srcOut = asset->durationUs;
     clip.timelineStart = 0;
     clip.timelineDuration = asset->durationUs;
-    clip.rotationOverride = asset->rotationOverride;
+    clip.rotationCorrection = drift::rotationCorrectionOf(*asset);
 
     m_assetPreviewIndex = assetIndex;
     m_assetPreviewActive = true;
@@ -7705,9 +7699,12 @@ void AppController::setSegmentationFrame(double seconds)
 
     // The model pass is the expensive half (seconds per frame for the SAM2 encoder on a CPU
     // provider), so it runs off the GUI thread. Decodes after this are milliseconds and stay inline.
-    (void)QtConcurrent::run([this, path, sourceUs, canvasW, canvasH, generation, rvm, quality]() {
-        const QImage frame = ClipReaderPool::instance().readVideoFrame(path, kSegmentEncodeStreamId,
-                                                                       sourceUs, canvasW, canvasH);
+    const int rotationCorrection = clip.rotationCorrection;
+    (void)QtConcurrent::run([this, path, sourceUs, canvasW, canvasH, generation, rvm, quality,
+                             rotationCorrection]() {
+        const QImage frame = ClipReaderPool::instance().readVideoFrame(
+            path, kSegmentEncodeStreamId, sourceUs, canvasW, canvasH, QString(), 15, false,
+            rotationCorrection);
         drift::Sam2Embedding embedding;
         QImage mask;
         QString error;
@@ -7941,8 +7938,11 @@ void AppController::segmentClip(int trackIndex, int clipIndex, const QVariantLis
     // runs, and stale indices would apply the matte to the wrong clip.
     const QString clipId = clip.id;
 
+    // Masks are traced against the frames the compositor shows, so they must decode at the same
+    // orientation or the matte lands transposed.
+    const int rotationCorrection = clip.rotationCorrection;
     (void)QtConcurrent::run([this, path, srcIn, srcOut, fps, canvasW, canvasH, normalized, mode,
-                             clipId, rvm, rvmQuality]() {
+                             clipId, rvm, rvmQuality, rotationCorrection]() {
         auto setProgress = [this](double fraction, const QString &status) {
             QMetaObject::invokeMethod(
                 this,
@@ -8064,7 +8064,8 @@ void AppController::segmentClip(int trackIndex, int clipIndex, const QVariantLis
 
             const drift::TimeUs sourceUs = srcIn + drift::TimeUs(i) * step;
             const QImage frame = ClipReaderPool::instance().readVideoFrame(
-                path, kCutoutRenderStreamId, sourceUs, canvasW, canvasH);
+                path, kCutoutRenderStreamId, sourceUs, canvasW, canvasH, QString(), 15, false,
+                rotationCorrection);
             if (frame.isNull()) {
                 abortAll();
                 finish(false, tr("Could not decode frame %1").arg(i), {});
@@ -8753,7 +8754,10 @@ void AppController::detectFacesForClip(int trackIndex, int clipIndex)
     // runs, and stale indices would attach the track to the wrong clip.
     const QString clipId = clip.id;
 
-    (void)QtConcurrent::run([this, path, srcIn, srcOut, fps, canvasW, canvasH, clipId]() {
+    // Landmarks are in frame pixels, so detect on frames oriented the way the compositor shows them.
+    const int rotationCorrection = clip.rotationCorrection;
+    (void)QtConcurrent::run([this, path, srcIn, srcOut, fps, canvasW, canvasH, clipId,
+                             rotationCorrection]() {
         auto setProgress = [this](double fraction, const QString &status) {
             QMetaObject::invokeMethod(
                 this,
@@ -8820,7 +8824,8 @@ void AppController::detectFacesForClip(int trackIndex, int clipIndex)
 
             const drift::TimeUs sourceUs = srcIn + drift::TimeUs(i) * step;
             const QImage frame = ClipReaderPool::instance().readVideoFrame(
-                path, kFaceDetectStreamId, sourceUs, canvasW, canvasH);
+                path, kFaceDetectStreamId, sourceUs, canvasW, canvasH, QString(), 15, false,
+                rotationCorrection);
             if (frame.isNull()) {
                 finish(false, tr("Could not decode frame %1").arg(i), {});
                 return;
@@ -9039,12 +9044,13 @@ QVariantList sceneRowsFromAnalysis(const drift::SceneAnalysis &analysis)
 } // namespace
 
 void AppController::applySceneAnalysis(const drift::SceneAnalysis &analysis, const QString &clipId,
-                                      const QString &clipPath)
+                                      const QString &clipPath, int rotationCorrection)
 {
     const QVariantList rows = sceneRowsFromAnalysis(analysis);
     m_scenes = rows;
     m_sceneClipId = clipId;
     m_sceneClipPath = clipPath;
+    m_sceneClipRotationCorrection = rotationCorrection;
     emit scenesChanged();
 }
 
@@ -9054,6 +9060,7 @@ drift::SceneDetectRequest AppController::sceneRequestFor(const drift::Clip &clip
 {
     drift::SceneDetectRequest request;
     request.path = clip.path;
+    request.rotationCorrection = clip.rotationCorrection;
     request.sourceIn = clip.srcIn;
     request.sourceOut = clip.srcOut;
     request.options.threshold = sceneThreshold();
@@ -9094,7 +9101,7 @@ void AppController::detectScenesForClip(int trackIndex, int clipIndex, bool with
     drift::SceneAnalysis cached;
     if (drift::loadCachedAnalysis(request, &cached)
         && (!withObjects || cached.objectsScanned)) {
-        applySceneAnalysis(cached, clip.id, clip.path);
+        applySceneAnalysis(cached, clip.id, clip.path, clip.rotationCorrection);
         setLastMessage(tr("Found %n scene(s)", nullptr, int(cached.scenes.size())));
         emit sceneDetectionFinished(true, QString());
         return;
@@ -9117,9 +9124,10 @@ void AppController::detectScenesForClip(int trackIndex, int clipIndex, bool with
     // job runs, and a stale index would attach the analysis to the wrong clip.
     const QString clipId = clip.id;
     const QString clipPath = clip.path;
+    const int rotationCorrection = clip.rotationCorrection;
     const quint64 generation = ++m_sceneGeneration;
 
-    (void)QtConcurrent::run([this, request, clipId, clipPath, generation]() {
+    (void)QtConcurrent::run([this, request, clipId, clipPath, rotationCorrection, generation]() {
         auto setProgress = [this, generation](double fraction, const QString &status) {
             QMetaObject::invokeMethod(
                 this,
@@ -9136,11 +9144,11 @@ void AppController::detectScenesForClip(int trackIndex, int clipIndex, bool with
                 Qt::QueuedConnection);
         };
 
-        auto finish = [this, clipId, clipPath, generation](bool ok, const QString &message,
-                                                          const drift::SceneAnalysis &analysis) {
+        auto finish = [this, clipId, clipPath, rotationCorrection, generation](
+                          bool ok, const QString &message, const drift::SceneAnalysis &analysis) {
             QMetaObject::invokeMethod(
                 this,
-                [this, ok, message, analysis, clipId, clipPath, generation]() {
+                [this, ok, message, analysis, clipId, clipPath, rotationCorrection, generation]() {
                     if (generation != m_sceneGeneration)
                         return; // superseded by a newer scan; this result is for nobody
                     m_sceneDetecting = false;
@@ -9155,7 +9163,7 @@ void AppController::detectScenesForClip(int trackIndex, int clipIndex, bool with
                         emit sceneDetectionFinished(false, message);
                         return;
                     }
-                    applySceneAnalysis(analysis, clipId, clipPath);
+                    applySceneAnalysis(analysis, clipId, clipPath, rotationCorrection);
                     setLastMessage(tr("Found %n scene(s)", nullptr, int(analysis.scenes.size())));
                     emit sceneDetectionFinished(true, QString());
                 },
@@ -11985,6 +11993,20 @@ void AppController::setClipRotationSnap(int trackIndex, int clipIndex, double de
     finishEdit(tr("Rotation set to %1°").arg(snapped, 0, 'f', 0));
 }
 
+int AppController::clipOrientation(const drift::Clip &clip) const
+{
+    const drift::MediaAsset *asset = m_project.asset(clip.assetId);
+    const int probed = asset ? asset->rotationDegrees : 0;
+    return ((probed + clip.rotationCorrection) % 360 + 360) % 360;
+}
+
+void AppController::setClipOrientationTo(drift::Clip &clip, int degrees)
+{
+    const drift::MediaAsset *asset = m_project.asset(clip.assetId);
+    const int probed = asset ? asset->rotationDegrees : 0;
+    clip.rotationCorrection = ((degrees - probed) % 360 + 360) % 360;
+}
+
 void AppController::setClipOrientation(int trackIndex, int clipIndex, int degrees)
 {
     if (trackIndex < 0 || trackIndex >= m_project.tracks().size())
@@ -12003,10 +12025,7 @@ void AppController::setClipOrientation(int trackIndex, int clipIndex, int degree
     int normalized = ((degrees % 360) + 360) % 360;
     normalized = ((normalized + 45) / 90 * 90) % 360;
 
-    const drift::MediaAsset *asset = m_project.asset(clip.assetId);
-    const int oldRotation = clip.rotationOverride >= 0
-        ? clip.rotationOverride
-        : (asset ? drift::effectiveRotation(*asset) : 0);
+    const int oldRotation = clipOrientation(clip);
     if (oldRotation == normalized)
         return;
 
@@ -12022,144 +12041,43 @@ void AppController::setClipOrientation(int trackIndex, int clipIndex, int degree
         // setClipLayoutPixels would collapse every track to one key sampled at time 0, destroying
         // any existing position/size animation. Width and height instead trade places outright —
         // new width is exactly the old height track and vice versa, so swapping the two
-        // KeyframeTrack objects wholesale carries every keyframe's time, tangents, hold flag and
-        // the track's enabled/disabled state across losslessly; nothing is resampled and nothing
-        // is lost, even for a disabled track holding keyframes past its frozen first one.
+        // KeyframeTrack objects wholesale carries every keyframe across untouched.
         const drift::KeyframeTrack<double> oldW = clip.transformW;
         const drift::KeyframeTrack<double> oldH = clip.transformH;
         std::swap(clip.transformW, clip.transformH);
 
-        // X/Y need their *values* recomputed (the box's center has to stay put under the new,
-        // transposed size) by (old width - old height)/2 (or the mirror for Y).
-        QSet<drift::TimeUs> sizeTimes;
-        for (auto it = oldW.keyframes().constBegin(); it != oldW.keyframes().constEnd(); ++it)
-            sizeTimes.insert(it.key());
-        for (auto it = oldH.keyframes().constBegin(); it != oldH.keyframes().constEnd(); ++it)
-            sizeTimes.insert(it.key());
-        // More than one keyframe on *either* track means width/height are independently animated,
-        // so the offset is itself a curve, not a constant. (Checking the union's size instead
-        // would be a false positive whenever width and height each hold just one keyframe, but at
-        // two different times — neither is actually animated, yet the union would have two.)
+        // X/Y shift so the box's centre stays put under the transposed size: by (w - h)/2 for X,
+        // the mirror for Y. Each existing key moves by the offset at its own time, which keeps
+        // its tangents, hold flag and the track's enabled state exactly as they were. When the
+        // size itself animates the offset is a curve, so keys are also added at width/height's
+        // key times to pin it there; between keys it is only approximated, which is the trade
+        // for not resampling the user's curve into something they no longer recognise.
         const bool sizeIsAnimated = oldW.keyframes().size() > 1 || oldH.keyframes().size() > 1;
-
-        auto retimeAxis = [&](drift::KeyframeTrack<double> &axis, bool axisIsX) {
+        auto offsetAt = [&](drift::TimeUs t, bool axisIsX) {
+            const double w = oldW.isEmpty() ? double(m_project.width()) : oldW.evaluateAt(t);
+            const double h = oldH.isEmpty() ? double(m_project.height()) : oldH.evaluateAt(t);
+            return axisIsX ? (w - h) * 0.5 : (h - w) * 0.5;
+        };
+        auto shiftAxis = [&](drift::KeyframeTrack<double> &axis, bool axisIsX) {
             if (axis.isEmpty())
                 return;
-            const QMap<drift::TimeUs, drift::Keyframe<double>> originalKeys = axis.keyframes();
-            auto offsetAt = [&](drift::TimeUs t) {
-                const double w = oldW.isEmpty() ? double(m_project.width()) : oldW.evaluateAt(t);
-                const double h = oldH.isEmpty() ? double(m_project.height()) : oldH.evaluateAt(t);
-                return axisIsX ? (w - h) * 0.5 : (h - w) * 0.5;
-            };
-
-            drift::KeyframeTrack<double> rebuilt;
-            if (!sizeIsAnimated) {
-                // The offset is one constant for the whole clip (even if width/height each hold a
-                // single, never-changing keyframe), so shifting every existing keyframe's value
-                // by it is exact — tangents, hold flags and the enabled/disabled state all carry
-                // over completely unchanged, whether this axis was enabled or not.
-                const double offset = offsetAt(0);
-                for (auto it = originalKeys.constBegin(); it != originalKeys.constEnd(); ++it) {
-                    drift::Keyframe<double> key = it.value();
-                    key.value += offset;
-                    rebuilt.setKeyframe(it.key(), key);
-                }
-                rebuilt.setEnabled(axis.enabled());
-                axis = rebuilt;
-                return;
+            const drift::KeyframeTrack<double> original = axis;
+            if (sizeIsAnimated && axis.enabled()) {
+                for (auto it = oldW.keyframes().constBegin(); it != oldW.keyframes().constEnd(); ++it)
+                    if (!original.keyframes().contains(it.key()))
+                        axis.setKeyframe(it.key(), original.evaluateAt(it.key()));
+                for (auto it = oldH.keyframes().constBegin(); it != oldH.keyframes().constEnd(); ++it)
+                    if (!original.keyframes().contains(it.key()))
+                        axis.setKeyframe(it.key(), original.evaluateAt(it.key()));
             }
-
-            // Width/height are genuinely animated, so the correction is a curve, not a constant —
-            // which a disabled axis (frozen at its first key regardless of time, by definition)
-            // cannot represent at all, whatever its own enabled state was: freezing it at one
-            // corrected value would hold that value right through the rest of the clip while the
-            // box keeps changing size underneath it, drifting off-center exactly as if no
-            // correction had been applied past that first instant. Getting the visible box right
-            // for the whole clip needs this axis to actually track the correction over time, so it
-            // has to become active — the same as an already-enabled axis needs to.
-            //
-            // Sample at every keyframe instant from this axis and from width/height's own tracks
-            // first — mandatory, not optional, since a fixed sample rate can step right over a
-            // short-lived spike between two close keyframes and miss it entirely (e.g. a width
-            // animated 100→200→100 across two 50ms segments, sampled only every 100ms, would see
-            // nothing but the unchanged endpoints). Extra samples are only inserted to fill long
-            // gaps between sparse keyframes, evenly spaced so the piecewise-linear approximation
-            // there does not get too coarse.
-            QSet<drift::TimeUs> mandatorySet = sizeTimes;
-            for (auto it = originalKeys.constBegin(); it != originalKeys.constEnd(); ++it)
-                mandatorySet.insert(it.key());
-            QList<drift::TimeUs> mandatory(mandatorySet.constBegin(), mandatorySet.constEnd());
-            std::sort(mandatory.begin(), mandatory.end());
-
-            // Whether `track` is provably unchanging from `t` up to whichever mandatory time
-            // comes next — either because it never changes at all (0 or 1 keyframe total) or
-            // because its governing keyframe at-or-before `t` is itself a hold. Since no track
-            // has a keyframe strictly between two adjacent mandatory times (if it did, that time
-            // would itself be mandatory), "constant at t" means constant for the whole segment.
-            auto isConstantFrom = [](const drift::KeyframeTrack<double> &track, drift::TimeUs t) {
-                const auto &keys = track.keyframes();
-                if (keys.size() <= 1)
-                    return true;
-                auto it = keys.upperBound(t);
-                if (it == keys.constBegin())
-                    return true; // t is before this track's first key — evaluateAt clamps flat
-                --it;
-                return it->hold;
-            };
-            // A sample only freezes the *combined* value if every contributor to it — this
-            // axis's own motion as much as width/height — is itself unchanging across the same
-            // span; a hold on just one of them must not suppress whichever of the others is still
-            // genuinely moving in that span.
-            auto sample = [&](drift::TimeUs t) {
-                drift::Keyframe<double> key;
-                key.value = axis.evaluateAt(t) + offsetAt(t);
-                key.hold = isConstantFrom(axis, t) && isConstantFrom(oldW, t) && isConstantFrom(oldH, t);
-                rebuilt.setKeyframe(t, key);
-            };
-
-            constexpr drift::TimeUs kMaxGapUs = 200'000; // 200ms
-            for (int i = 0; i < mandatory.size(); ++i) {
-                sample(mandatory.at(i));
-                if (i + 1 >= mandatory.size())
-                    continue;
-                const drift::TimeUs gap = mandatory.at(i + 1) - mandatory.at(i);
-                if (gap <= kMaxGapUs)
-                    continue;
-                const int steps = static_cast<int>(gap / kMaxGapUs);
-                for (int s = 1; s < steps; ++s)
-                    sample(mandatory.at(i) + s * (gap / steps));
-            }
-
-            // A mandatory point can be reached by one component jumping (held, then landing a
-            // new value right there) while another keeps moving continuously through the same
-            // instant — segmentIsConstant above correctly leaves that whole span un-held (since
-            // it is not *all* frozen), but plain linear interpolation between the span's start
-            // and this point then smears the jump backward across the entire span instead of
-            // holding it to the single instant it belongs to. Whenever the value actually
-            // discontinues at a mandatory point, insert one more sample a microsecond before it
-            // carrying the correct left-hand limit (the continuous part's value, still combined
-            // with whatever was frozen right up to the jump) — that isolates the jump to the
-            // last microsecond and lets the continuous portion interpolate correctly on its own.
-            for (int i = 1; i < mandatory.size(); ++i) {
-                const drift::TimeUs t = mandatory.at(i);
-                const drift::TimeUs before = t - 1;
-                if (before <= mandatory.at(i - 1))
-                    continue; // no room for a separate instant this close to the previous sample
-                const double atT = axis.evaluateAt(t) + offsetAt(t);
-                const double justBefore = axis.evaluateAt(before) + offsetAt(before);
-                if (qFuzzyCompare(atT + 1.0, justBefore + 1.0))
-                    continue;
-                rebuilt.setKeyframe(before, justBefore);
-            }
-
-            rebuilt.setEnabled(true);
-            axis = rebuilt;
+            for (const drift::TimeUs t : axis.keyframes().keys())
+                axis.keyframeRef(t)->value += offsetAt(t, axisIsX);
         };
-        retimeAxis(clip.transformX, true);
-        retimeAxis(clip.transformY, false);
+        shiftAxis(clip.transformX, true);
+        shiftAxis(clip.transformY, false);
     }
 
-    clip.rotationOverride = normalized;
+    setClipOrientationTo(clip, normalized);
     pushProjectEdit(before, tr("Orientation changed"));
     finishEdit(tr("Clip orientation set to %1°").arg(normalized));
 }
@@ -15358,10 +15276,10 @@ void AppController::pasteAttributes(const QVariantMap &options)
             targetClip.blendMode = sourceClip.blendMode;
             targetClip.flipH = sourceClip.flipH;
             targetClip.flipV = sourceClip.flipV;
-            // Keeps the pasted box paired with the orientation it was fit for; irrelevant to
-            // non-video targets, whose decode never consults it.
+            // Keeps the pasted box paired with the orientation it was fit for. The stored value
+            // is relative to each clip's own file, so match the visible result, not the number.
             if (targetClip.type == drift::ClipType::Video)
-                targetClip.rotationOverride = sourceClip.rotationOverride;
+                setClipOrientationTo(targetClip, clipOrientation(sourceClip));
             // Pinning a mask mints a lane, which inserts a track and invalidates `track` and
             // `targetClip`. Queued by id and applied once the loop is done.
             pendingMasks.append(qMakePair(targetClip.id, sourceItem.masks));
@@ -20209,7 +20127,7 @@ QJsonObject AppController::mcpDetectScenes(int trackIndex, int clipIndex, double
     // can carry straight on to list_scenes.
     drift::SceneAnalysis cached;
     if (drift::loadCachedAnalysis(request, &cached) && (!withObjects || cached.objectsScanned)) {
-        applySceneAnalysis(cached, clip.id, clip.path);
+        applySceneAnalysis(cached, clip.id, clip.path, clip.rotationCorrection);
         return ok({{QStringLiteral("cached"), true},
                    {QStringLiteral("clip"), clip.id},
                    {QStringLiteral("scenes"), int(cached.scenes.size())},
@@ -20891,6 +20809,7 @@ struct FrameSource
 {
     std::shared_ptr<const drift::Project> project;
     QString path;          // source mode when non-empty
+    int rotationCorrection = 0;
     bool source() const { return !path.isEmpty(); }
     int longEdge() const { return qMax(project->width(), project->height()); }
 
@@ -20898,7 +20817,8 @@ struct FrameSource
     {
         const drift::TimeUs us = qMax<drift::TimeUs>(0, drift::secondsToUs(seconds));
         if (source())
-            return ClipReaderPool::instance().readVideoFrame(path, kFrameSheetStreamId, us, maxW, maxH);
+            return ClipReaderPool::instance().readVideoFrame(path, kFrameSheetStreamId, us, maxW, maxH,
+                                                             QString(), 15, false, rotationCorrection);
         FrameCompositor::RenderOptions options;
         options.previewScale =
             qBound(kMinPreviewScale, double(maxW) / double(longEdge()), 1.0);
@@ -20977,6 +20897,7 @@ QJsonObject AppController::mcpFrameSheet(const McpFrameSheetRequest &request)
         if (clip.path.isEmpty() || clip.type != drift::ClipType::Video)
             return err("type_mismatch", QStringLiteral("clip has no video file; omit clip to render the composition"));
         src.path = clip.path;
+        src.rotationCorrection = clip.rotationCorrection;
     } else if (src.project->durationUs() <= 0) {
         return err("not_found", QStringLiteral("Timeline is empty"));
     }
@@ -21223,6 +21144,7 @@ QJsonObject AppController::mcpActivity(const McpActivityRequest &request)
         if (clip.path.isEmpty() || clip.type != drift::ClipType::Video)
             return err("type_mismatch", QStringLiteral("clip has no video file; omit clip to profile the composition"));
         src.path = clip.path;
+        src.rotationCorrection = clip.rotationCorrection;
     } else if (src.project->durationUs() <= 0) {
         return err("not_found", QStringLiteral("Timeline is empty"));
     }

--- a/src/models/AppController.h
+++ b/src/models/AppController.h
@@ -275,6 +275,7 @@ class AppController : public QObject
     Q_PROPERTY(QString sceneClipId READ sceneClipId NOTIFY scenesChanged)
     // Source file the live analysis describes, so the panel can ask for thumbnails.
     Q_PROPERTY(QString sceneClipPath READ sceneClipPath NOTIFY scenesChanged)
+    Q_PROPERTY(int sceneClipRotationCorrection READ sceneClipRotationCorrection NOTIFY scenesChanged)
     Q_PROPERTY(bool sceneDetecting READ sceneDetecting NOTIFY sceneDetectingChanged)
     Q_PROPERTY(double sceneDetectProgress READ sceneDetectProgress NOTIFY sceneDetectProgressChanged)
     Q_PROPERTY(QString sceneDetectStatus READ sceneDetectStatus NOTIFY sceneDetectStatusChanged)
@@ -425,6 +426,7 @@ public:
     QVariantList scenes() const { return m_scenes; }
     QString sceneClipId() const { return m_sceneClipId; }
     QString sceneClipPath() const { return m_sceneClipPath; }
+    int sceneClipRotationCorrection() const { return m_sceneClipRotationCorrection; }
     bool sceneDetecting() const { return m_sceneDetecting; }
     double sceneDetectProgress() const { return m_sceneDetectProgress; }
     QString sceneDetectStatus() const { return m_sceneDetectStatus; }
@@ -675,6 +677,9 @@ public:
     Q_INVOKABLE int removeAssetsAndClips(const QStringList &assetIds);
     // Bin label only — does not rename the file on disk or rewrite clip names.
     Q_INVOKABLE bool renameAsset(int assetIndex, const QString &name);
+    // Bin-preview orientation for a video asset (absolute 0/90/180/270; -1 = the file's own tag),
+    // as one undoable edit — AssetLibrary::setAssetRotation on its own leaves no undo entry.
+    Q_INVOKABLE bool setAssetRotation(int assetIndex, int degrees);
     // Bin folder CRUD. parentId empty = bin root; nesting is arbitrary depth.
     Q_INVOKABLE QString createBinFolder(const QString &name, const QString &parentId);
     Q_INVOKABLE bool renameBinFolder(const QString &folderId, const QString &name);
@@ -1044,9 +1049,9 @@ public:
     Q_INVOKABLE void previewSetClipPan(int trackIndex, int clipIndex, double pan);
     Q_INVOKABLE void setClipPan(int trackIndex, int clipIndex, double pan);
     Q_INVOKABLE void setClipRotationSnap(int trackIndex, int clipIndex, double degrees);
-    // Discrete, lossless orientation correction (0/90/180/270) — distinct from the free decorative
-    // "Angle" above. Re-fits the clip's box for the new orientation and decodes losslessly; see
-    // drift::Clip::rotationOverride.
+    // Discrete, lossless orientation fix (absolute 0/90/180/270, as the inspector shows it) —
+    // distinct from the free decorative "Angle" above. Re-fits the clip's box for the new
+    // orientation and decodes losslessly; see drift::Clip::rotationCorrection.
     Q_INVOKABLE void setClipOrientation(int trackIndex, int clipIndex, int degrees);
     Q_INVOKABLE bool canMergeSelection() const;
     Q_INVOKABLE void mergeSelectedClips();
@@ -1450,7 +1455,8 @@ public:
     Q_INVOKABLE QString filmstripFrameUrl(const QString &path, int frame, int count) const;
     // Sharp on-demand frame for one filmstrip tile — see FilmstripTileCache. Empty until the
     // decode lands, at which point filmstripTileReady() fires for that source.
-    Q_INVOKABLE QString filmstripTileUrl(const QString &path, int level, double index) const;
+    Q_INVOKABLE QString filmstripTileUrl(const QString &path, int level, double index,
+                                         int rotationCorrection = 0) const;
 
 signals:
     // A text clip was added with no text; the preview should open its inline
@@ -1628,7 +1634,7 @@ protected:
     void finalizeAssetReplace(const QString &assetId, const drift::MediaAsset &filled, bool ok);
     // Moves every clip bound to `assetId` onto the replacement media. Returns how many had a
     // source range that no longer fitted and had to be pulled back to it.
-    int rebindClipsToAsset(const QString &assetId, const drift::MediaAsset &asset, int oldEffectiveRotation);
+    int rebindClipsToAsset(const QString &assetId, const drift::MediaAsset &asset, int oldBinCorrection);
     // Keeps the keyframe strip's index-addressed hidden series in sync after an effect is removed.
     void dropKeyframeGraphPropertiesForEffect(int removedIndex);
     // Same idea after a reorder: fx.N.* indices move with the effect.
@@ -1683,7 +1689,7 @@ protected:
                                               double minSceneSeconds) const;
     // Publishes a finished scene analysis into m_scenes, shaped for QML.
     void applySceneAnalysis(const drift::SceneAnalysis &analysis, const QString &clipId,
-                            const QString &clipPath);
+                            const QString &clipPath, int rotationCorrection);
     // Completes a segmentation job: pins the matte to the clip as a Mask adjustment on its own
     // lane. `outputMode` is kept only so the older "clips"/"mask" spellings stay accepted; all
     // three now produce the same mask layer.
@@ -1788,6 +1794,11 @@ protected:
     void restoreSelectionByTrackId(const QList<QPair<QString, int>> &captured);
     int assetIndexForClip(const drift::Clip &clip) const;
     drift::TimeUs clipDurationForAssetIndex(int assetIndex) const;
+    // The absolute orientation (0/90/180/270) a video clip's frames come out at: its file's own
+    // tag plus its rotationCorrection. setClipOrientationTo stores the correction that lands on
+    // `degrees`.
+    int clipOrientation(const drift::Clip &clip) const;
+    void setClipOrientationTo(drift::Clip &clip, int degrees);
     drift::TimeUs sourceDurationForClip(const drift::Clip &clip) const;
     void startReverseRender(const QString &sourcePath, drift::TimeUs coverInUs,
                             drift::TimeUs coverOutUs);
@@ -2021,6 +2032,7 @@ protected:
     QVariantList m_scenes;
     QString m_sceneClipId;
     QString m_sceneClipPath;
+    int m_sceneClipRotationCorrection = 0;
     bool m_sceneDetecting = false;
     double m_sceneDetectProgress = 0.0;
     QString m_sceneDetectStatus;

--- a/src/models/AppController.h
+++ b/src/models/AppController.h
@@ -315,6 +315,10 @@ class AppController : public QObject
     // corrupt-project open rendered as a neutral info toast.
     Q_PROPERTY(QString lastMessageSeverity READ lastMessageSeverity NOTIFY lastMessageChanged)
     Q_PROPERTY(int draggingAssetIndex READ draggingAssetIndex WRITE setDraggingAssetIndex NOTIFY draggingAssetIndexChanged)
+    // Set by MediaPreviewWindow.qml/AndroidMediaPreview.qml while open, so the bin grid can defer
+    // rebuilding its delegate array (and the scroll-position flicker that causes) until the
+    // window closes rather than on every metadata change (rotate, trim, a probe landing) it emits.
+    Q_PROPERTY(bool assetPreviewWindowOpen READ assetPreviewWindowOpen WRITE setAssetPreviewWindowOpen NOTIFY assetPreviewWindowOpenChanged)
     Q_PROPERTY(bool hasUnsavedChanges READ hasUnsavedChanges NOTIFY dirtyChanged)
     Q_PROPERTY(QString currentProjectPath READ currentProjectPath NOTIFY currentProjectPathChanged)
     Q_PROPERTY(bool recoveryAvailable READ recoveryAvailable NOTIFY recoveryChanged)
@@ -448,6 +452,8 @@ public:
     QString lastMessageSeverity() const { return m_lastMessageSeverity; }
     int draggingAssetIndex() const { return m_draggingAssetIndex; }
     void setDraggingAssetIndex(int index);
+    bool assetPreviewWindowOpen() const { return m_assetPreviewWindowOpen; }
+    void setAssetPreviewWindowOpen(bool open);
     bool hasUnsavedChanges() const { return m_dirty; }
     QString currentProjectPath() const { return m_currentProjectPath; }
     bool recoveryAvailable() const { return m_recoveryAvailable; }
@@ -1038,6 +1044,10 @@ public:
     Q_INVOKABLE void previewSetClipPan(int trackIndex, int clipIndex, double pan);
     Q_INVOKABLE void setClipPan(int trackIndex, int clipIndex, double pan);
     Q_INVOKABLE void setClipRotationSnap(int trackIndex, int clipIndex, double degrees);
+    // Discrete, lossless orientation correction (0/90/180/270) — distinct from the free decorative
+    // "Angle" above. Re-fits the clip's box for the new orientation and decodes losslessly; see
+    // drift::Clip::rotationOverride.
+    Q_INVOKABLE void setClipOrientation(int trackIndex, int clipIndex, int degrees);
     Q_INVOKABLE bool canMergeSelection() const;
     Q_INVOKABLE void mergeSelectedClips();
     Q_INVOKABLE bool canSeparateAudioSelection() const;
@@ -1553,6 +1563,7 @@ signals:
     void missingAddons(const QVariantList &addons);
     void lastMessageChanged();
     void draggingAssetIndexChanged();
+    void assetPreviewWindowOpenChanged();
     void exportFinished(bool success);
     void projectMutated();
     void waveformReady(const QString &path);
@@ -1617,7 +1628,7 @@ protected:
     void finalizeAssetReplace(const QString &assetId, const drift::MediaAsset &filled, bool ok);
     // Moves every clip bound to `assetId` onto the replacement media. Returns how many had a
     // source range that no longer fitted and had to be pulled back to it.
-    int rebindClipsToAsset(const QString &assetId, const drift::MediaAsset &asset);
+    int rebindClipsToAsset(const QString &assetId, const drift::MediaAsset &asset, int oldEffectiveRotation);
     // Keeps the keyframe strip's index-addressed hidden series in sync after an effect is removed.
     void dropKeyframeGraphPropertiesForEffect(int removedIndex);
     // Same idea after a reorder: fx.N.* indices move with the effect.
@@ -2051,6 +2062,7 @@ protected:
     QHash<QString, QString> m_shortcuts;
     QHash<QString, QSet<QString>> m_assetFavorites;
     int m_draggingAssetIndex = -1;
+    bool m_assetPreviewWindowOpen = false;
     QString m_lastMessage;
     QString m_lastMessageSeverity = QStringLiteral("info");
     bool m_inlineTextEditing = false;

--- a/src/models/AssetLibrary.cpp
+++ b/src/models/AssetLibrary.cpp
@@ -229,6 +229,26 @@ QString formatDuration(drift::TimeUs durationUs)
         .arg(seconds, 2, 10, QChar('0'));
 }
 
+// The card's duration text: the file's full length, with the length a bin-preview trim actually
+// places on the timeline in parentheses when one is set.
+// What a bin-preview trim leaves of the file — the length a clip placed from this asset gets
+// (AppController::applyAssetLayout). The full duration when there is no trim.
+drift::TimeUs placedDurationUs(const drift::MediaAsset &asset)
+{
+    const drift::TimeUs trimOut = asset.trimOutUs < 0 ? asset.durationUs : asset.trimOutUs;
+    return trimOut - qBound<drift::TimeUs>(0, asset.trimInUs, trimOut);
+}
+
+// The card's duration text: the file's full length, with the placed length in parentheses when
+// a trim is set.
+QString durationLabelFor(const drift::MediaAsset &asset)
+{
+    const bool trimmed = asset.trimInUs > 0 || asset.trimOutUs >= 0;
+    if (asset.durationLabel.isEmpty() || !trimmed)
+        return asset.durationLabel;
+    return QStringLiteral("%1 (%2)").arg(asset.durationLabel, formatDuration(placedDurationUs(asset)));
+}
+
 // MediaAsset carries one sampleRate/channels pair for the whole file, so a multi-stream source
 // has to pick one. It describes the *first* audio stream, matching Clip::audioStreamIndex's
 // default of 0 and ensureAudioPresence(), which also breaks on the first. This used to keep
@@ -421,11 +441,30 @@ QList<QString> AssetLibrary::currentFolderIds() const
     return folderIds;
 }
 
+QList<QString> AssetLibrary::currentEdits() const
+{
+    if (!m_project)
+        return {};
+
+    QList<QString> edits;
+    edits.reserve(m_project->assetOrder().size());
+    for (const QString &id : m_project->assetOrder()) {
+        const drift::MediaAsset *asset = m_project->asset(id);
+        edits.append(asset ? QStringLiteral("%1|%2|%3")
+                                 .arg(asset->rotationOverride)
+                                 .arg(asset->trimInUs)
+                                 .arg(asset->trimOutUs)
+                           : QString{});
+    }
+    return edits;
+}
+
 void AssetLibrary::snapshotAssets()
 {
     m_syncedOrder = m_project ? m_project->assetOrder() : QList<QString>{};
     m_syncedPaths = currentPaths();
     m_syncedFolderIds = currentFolderIds();
+    m_syncedEdits = currentEdits();
 }
 
 void AssetLibrary::syncToProject()
@@ -447,26 +486,39 @@ void AssetLibrary::syncToProject()
     // data. Only the rows that actually changed are re-read.
     const QList<QString> paths = currentPaths();
     const QList<QString> folderIds = currentFolderIds();
-    if (paths == m_syncedPaths && folderIds == m_syncedFolderIds)
+    const QList<QString> edits = currentEdits();
+    if (paths == m_syncedPaths && folderIds == m_syncedFolderIds && edits == m_syncedEdits)
         return;
 
     for (int i = 0; i < paths.size(); ++i) {
         const bool pathChanged = i >= m_syncedPaths.size() || m_syncedPaths.at(i) != paths.at(i);
         const bool folderChanged =
             i >= m_syncedFolderIds.size() || m_syncedFolderIds.at(i) != folderIds.at(i);
-        if (!pathChanged && !folderChanged)
+        const bool editChanged = i >= m_syncedEdits.size() || m_syncedEdits.at(i) != edits.at(i);
+        if (!pathChanged && !folderChanged && !editChanged)
             continue;
         // Empty roles: every role may have moved with the file. A folder-only change only
         // touches FolderIdRole.
-        emitAssetRowChanged(i, pathChanged ? QList<int>{} : QList<int>{FolderIdRole});
-        if (pathChanged) {
-            const QString assetId = m_project->assetIdAt(i);
+        emitAssetRowChanged(i, pathChanged ? QList<int>{}
+                               : folderChanged ? QList<int>{FolderIdRole}
+                                               : QList<int>{DurationRole, ThumbnailPathRole, FilmstripPathRole});
+        const QString assetId = m_project->assetIdAt(i);
+        if (pathChanged || editChanged) {
             emit assetMetadataChanged(assetId);
             emit assetCardChanged(assetId);
+        }
+        // The snapshot an undo/redo restored was taken with the thumbnail for that rotation/trim
+        // still being generated (setAssetRotation/setAssetTrim clear it and kick a job), so it
+        // may well hold an empty path — nothing else will fill it in.
+        if (editChanged) {
+            const drift::MediaAsset *asset = m_project->asset(assetId);
+            if (asset && (asset->thumbnailPath.isEmpty() || asset->filmstripPath.isEmpty()))
+                startThumbJob(assetId);
         }
     }
     m_syncedPaths = paths;
     m_syncedFolderIds = folderIds;
+    m_syncedEdits = edits;
 }
 
 void AssetLibrary::setProject(drift::Project *project)
@@ -514,7 +566,7 @@ QVariant AssetLibrary::data(const QModelIndex &index, int role) const
     case KindRole:
         return drift::mediaKindToString(asset->kind);
     case DurationRole:
-        return asset->durationLabel;
+        return durationLabelFor(*asset);
     case DurationSecondsRole:
         return drift::usToSeconds(asset->durationUs);
     case PathRole:
@@ -525,8 +577,6 @@ QVariant AssetLibrary::data(const QModelIndex &index, int role) const
         return asset->filmstripPath;
     case FolderIdRole:
         return asset->folderId;
-    case RotationRole:
-        return drift::effectiveRotation(*asset);
     default:
         return {};
     }
@@ -544,7 +594,6 @@ QHash<int, QByteArray> AssetLibrary::roleNames() const
         {ThumbnailPathRole, "thumbnailPath"},
         {FilmstripPathRole, "filmstripPath"},
         {FolderIdRole, "folderId"},
-        {RotationRole, "rotation"},
     };
 }
 
@@ -839,8 +888,9 @@ QVariantMap AssetLibrary::assetAt(int index) const
         {QStringLiteral("id"), asset->id},
         {QStringLiteral("name"), asset->name},
         {QStringLiteral("kind"), drift::mediaKindToString(asset->kind)},
-        {QStringLiteral("duration"), asset->durationLabel},
+        {QStringLiteral("duration"), durationLabelFor(*asset)},
         {QStringLiteral("durationSeconds"), drift::usToSeconds(asset->durationUs)},
+        {QStringLiteral("placedDurationSeconds"), drift::usToSeconds(placedDurationUs(*asset))},
         {QStringLiteral("path"), asset->path},
         {QStringLiteral("width"), asset->width},
         {QStringLiteral("height"), asset->height},
@@ -848,6 +898,7 @@ QVariantMap AssetLibrary::assetAt(int index) const
         {QStringLiteral("rotationDegrees"), asset->rotationDegrees},
         {QStringLiteral("rotationOverride"), asset->rotationOverride},
         {QStringLiteral("effectiveRotation"), drift::effectiveRotation(*asset)},
+        {QStringLiteral("rotationCorrection"), drift::rotationCorrectionOf(*asset)},
         {QStringLiteral("trimInSeconds"), drift::usToSeconds(asset->trimInUs)},
         {QStringLiteral("trimOutSeconds"), asset->trimOutUs < 0 ? -1.0 : drift::usToSeconds(asset->trimOutUs)},
         {QStringLiteral("thumbnailPath"), asset->thumbnailPath},
@@ -1004,9 +1055,8 @@ bool AssetLibrary::setAssetRotation(int index, int degrees)
     // previous files simply stay on disk unreferenced — only the pointers need clearing here.
     asset->thumbnailPath.clear();
     asset->filmstripPath.clear();
-    emitAssetRowChanged(index, {RotationRole, ThumbnailPathRole, FilmstripPathRole});
+    emitAssetRowChanged(index, {ThumbnailPathRole, FilmstripPathRole});
     emit assetMetadataChanged(asset->id);
-    emit assetUserEdited(asset->id);
     startThumbJob(asset->id);
     snapshotAssets();
     return true;
@@ -1048,13 +1098,14 @@ bool AssetLibrary::setAssetTrim(int index, qint64 trimInUs, qint64 trimOutUs)
     // cover thumbnail is the frame at the trim's "Set In" point, which just moved.
     if (inPointMoved) {
         asset->thumbnailPath.clear();
-        emitAssetRowChanged(index, {ThumbnailPathRole});
+        emitAssetRowChanged(index, {ThumbnailPathRole, DurationRole});
         startThumbJob(asset->id);
     } else {
-        emitAssetRowChanged(index, {});
+        emitAssetRowChanged(index, {DurationRole});
     }
     emit assetMetadataChanged(asset->id);
-    emit assetUserEdited(asset->id);
+    // The card's duration text carries the trimmed length, so the grid's snapshot is stale.
+    emit assetCardChanged(asset->id);
     snapshotAssets();
     return true;
 }

--- a/src/models/AssetLibrary.cpp
+++ b/src/models/AssetLibrary.cpp
@@ -459,8 +459,11 @@ void AssetLibrary::syncToProject()
         // Empty roles: every role may have moved with the file. A folder-only change only
         // touches FolderIdRole.
         emitAssetRowChanged(i, pathChanged ? QList<int>{} : QList<int>{FolderIdRole});
-        if (pathChanged)
-            emit assetMetadataChanged(m_project->assetIdAt(i));
+        if (pathChanged) {
+            const QString assetId = m_project->assetIdAt(i);
+            emit assetMetadataChanged(assetId);
+            emit assetCardChanged(assetId);
+        }
     }
     m_syncedPaths = paths;
     m_syncedFolderIds = folderIds;
@@ -522,6 +525,8 @@ QVariant AssetLibrary::data(const QModelIndex &index, int role) const
         return asset->filmstripPath;
     case FolderIdRole:
         return asset->folderId;
+    case RotationRole:
+        return drift::effectiveRotation(*asset);
     default:
         return {};
     }
@@ -539,6 +544,7 @@ QHash<int, QByteArray> AssetLibrary::roleNames() const
         {ThumbnailPathRole, "thumbnailPath"},
         {FilmstripPathRole, "filmstripPath"},
         {FolderIdRole, "folderId"},
+        {RotationRole, "rotation"},
     };
 }
 
@@ -585,8 +591,17 @@ void AssetLibrary::emitAssetRowChanged(int index, const QList<int> &roles)
 
 void AssetLibrary::startThumbJob(const QString &assetId)
 {
-    if (!m_project || assetId.isEmpty() || m_thumbPending.contains(assetId))
+    if (!m_project || assetId.isEmpty())
         return;
+    if (m_thumbPending.contains(assetId)) {
+        // A rotation/trim change landed while the previous job for this asset was still running.
+        // That job was scheduled against the old settings, so its result (about to be accepted in
+        // applyThumbResult purely because the source path still matches) would otherwise become a
+        // permanently stale thumbnail with nothing left to trigger a redo. Remember to redo it
+        // the moment the in-flight job lands instead of just dropping this request.
+        m_thumbStale.insert(assetId);
+        return;
+    }
 
     drift::MediaAsset *asset = m_project->asset(assetId);
     if (!asset)
@@ -607,15 +622,19 @@ void AssetLibrary::startThumbJob(const QString &assetId)
     m_thumbPending.insert(assetId);
     const QString path = asset->path;
     const drift::MediaKind kind = asset->kind;
+    const int rotationOverride = asset->rotationOverride;
+    // The bin's cover thumbnail is the frame at a trim's "Set In" point, not always frame 0.
+    const qint64 trimInUs = asset->trimInUs;
 
-    (void)QtConcurrent::run(&m_jobs, [this, assetId, path, kind, needThumb, needStrip]() {
+    (void)QtConcurrent::run(&m_jobs, [this, assetId, path, kind, needThumb, needStrip, rotationOverride,
+                                      trimInUs]() {
         const QString kindString = drift::mediaKindToString(kind);
         QString thumb;
         QString strip;
         if (needThumb)
-            thumb = MediaThumbnail::generate(path, kindString);
+            thumb = MediaThumbnail::generate(path, kindString, rotationOverride, trimInUs);
         if (needStrip)
-            strip = MediaThumbnail::generateFilmstrip(path, kindString);
+            strip = MediaThumbnail::generateFilmstrip(path, kindString, rotationOverride);
         else if (!thumb.isEmpty() && kind != drift::MediaKind::Video)
             strip = thumb;
 
@@ -630,14 +649,28 @@ void AssetLibrary::applyThumbResult(const QString &assetId, const QString &sourc
                                     const QString &thumb, const QString &strip)
 {
     m_thumbPending.remove(assetId);
-    if (!m_project)
+    // A rotation/trim change arrived while this job was in flight, so this result reflects
+    // settings that are no longer current — apply it anyway (better than staying blank/stale a
+    // moment longer) but immediately redo it against whatever the asset's settings are now.
+    const bool wasStale = m_thumbStale.remove(assetId);
+
+    if (!m_project) {
         return;
+    }
 
     drift::MediaAsset *asset = m_project->asset(assetId);
     // The source was replaced while this job ran, so these frames are of a file the row no
     // longer points at.
-    if (!asset || asset->path != sourcePath)
+    if (!asset || asset->path != sourcePath) {
         return;
+    }
+
+    // Discard rather than apply-then-immediately-redo: this result was generated against
+    // settings that are already outdated, and briefly showing it would just be a flash.
+    if (wasStale) {
+        startThumbJob(assetId);
+        return;
+    }
 
     bool changed = false;
     if (!thumb.isEmpty() && asset->thumbnailPath != thumb) {
@@ -743,6 +776,7 @@ bool AssetLibrary::applyProbedSource(const QString &assetId, const drift::MediaA
                         {NameRole, KindRole, DurationRole, DurationSecondsRole, PathRole,
                          ThumbnailPathRole, FilmstripPathRole});
     emit assetMetadataChanged(assetId);
+    emit assetCardChanged(assetId);
     return true;
 }
 
@@ -792,6 +826,7 @@ void AssetLibrary::applyImportResult(const QString &assetId, const drift::MediaA
                         {NameRole, KindRole, DurationRole, DurationSecondsRole, PathRole,
                          ThumbnailPathRole, FilmstripPathRole});
     emit assetMetadataChanged(assetId);
+    emit assetCardChanged(assetId);
 }
 
 QVariantMap AssetLibrary::assetAt(int index) const
@@ -811,6 +846,10 @@ QVariantMap AssetLibrary::assetAt(int index) const
         {QStringLiteral("height"), asset->height},
         {QStringLiteral("fps"), asset->fps},
         {QStringLiteral("rotationDegrees"), asset->rotationDegrees},
+        {QStringLiteral("rotationOverride"), asset->rotationOverride},
+        {QStringLiteral("effectiveRotation"), drift::effectiveRotation(*asset)},
+        {QStringLiteral("trimInSeconds"), drift::usToSeconds(asset->trimInUs)},
+        {QStringLiteral("trimOutSeconds"), asset->trimOutUs < 0 ? -1.0 : drift::usToSeconds(asset->trimOutUs)},
         {QStringLiteral("thumbnailPath"), asset->thumbnailPath},
         {QStringLiteral("filmstripPath"), asset->filmstripPath},
         {QStringLiteral("assetIndex"), index},
@@ -943,6 +982,83 @@ bool AssetLibrary::setAssetName(int index, const QString &name)
     return true;
 }
 
+bool AssetLibrary::setAssetRotation(int index, int degrees)
+{
+    drift::MediaAsset *asset = assetAtIndex(index);
+    if (!asset)
+        return false;
+
+    // -1 resets to the file's own probed rotation; anything else snaps to the nearest
+    // quarter-turn, matching how the source display-matrix tag is normalized.
+    int normalized = -1;
+    if (degrees >= 0) {
+        normalized = (((degrees + 45) / 90) * 90) % 360;
+        if (normalized < 0)
+            normalized += 360;
+    }
+    if (asset->rotationOverride == normalized)
+        return false;
+
+    asset->rotationOverride = normalized;
+    // The cached thumbnail/filmstrip are keyed by rotation (see MediaThumbnail::generate), so the
+    // previous files simply stay on disk unreferenced — only the pointers need clearing here.
+    asset->thumbnailPath.clear();
+    asset->filmstripPath.clear();
+    emitAssetRowChanged(index, {RotationRole, ThumbnailPathRole, FilmstripPathRole});
+    emit assetMetadataChanged(asset->id);
+    emit assetUserEdited(asset->id);
+    startThumbJob(asset->id);
+    snapshotAssets();
+    return true;
+}
+
+bool AssetLibrary::setAssetTrim(int index, qint64 trimInUs, qint64 trimOutUs)
+{
+    drift::MediaAsset *asset = assetAtIndex(index);
+    if (!asset)
+        return false;
+
+    const drift::TimeUs wantedIn = static_cast<drift::TimeUs>(trimInUs);
+    const drift::TimeUs wantedOut = static_cast<drift::TimeUs>(trimOutUs);
+    drift::TimeUs normalizedIn =
+        qBound<drift::TimeUs>(static_cast<drift::TimeUs>(0), wantedIn, asset->durationUs);
+    // -1, or an out point spanning to (or past) the end of the file, is the "no explicit out"
+    // sentinel — "trim from normalizedIn to the end" is exactly what that means, and it must
+    // keep whatever in point was asked for (only a truly empty/degenerate selection collapses
+    // the in point too, below).
+    drift::TimeUs normalizedOut = wantedOut;
+    if (normalizedOut < 0 || normalizedOut >= asset->durationUs)
+        normalizedOut = -1;
+    else
+        normalizedOut = qBound<drift::TimeUs>(normalizedIn, normalizedOut, asset->durationUs);
+    // A degenerate (zero-length) selection is "no trim" at all — reset both to the defaults so a
+    // later re-open reads back a clean, unambiguous baseline.
+    if (normalizedOut >= 0 && normalizedOut <= normalizedIn) {
+        normalizedIn = 0;
+        normalizedOut = -1;
+    }
+
+    if (asset->trimInUs == normalizedIn && asset->trimOutUs == normalizedOut)
+        return false;
+
+    const bool inPointMoved = asset->trimInUs != normalizedIn;
+    asset->trimInUs = normalizedIn;
+    asset->trimOutUs = normalizedOut;
+    // The source file is untouched by a plain trim, so no re-encode is needed — but the bin's
+    // cover thumbnail is the frame at the trim's "Set In" point, which just moved.
+    if (inPointMoved) {
+        asset->thumbnailPath.clear();
+        emitAssetRowChanged(index, {ThumbnailPathRole});
+        startThumbJob(asset->id);
+    } else {
+        emitAssetRowChanged(index, {});
+    }
+    emit assetMetadataChanged(asset->id);
+    emit assetUserEdited(asset->id);
+    snapshotAssets();
+    return true;
+}
+
 bool AssetLibrary::moveAssetToFolder(int index, const QString &folderId)
 {
     drift::MediaAsset *asset = assetAtIndex(index);
@@ -1048,6 +1164,9 @@ QJsonArray AssetLibrary::toJsonArray() const
             {QStringLiteral("height"), asset->height},
             {QStringLiteral("fps"), asset->fps},
             {QStringLiteral("rotationDegrees"), asset->rotationDegrees},
+            {QStringLiteral("rotationOverride"), asset->rotationOverride},
+            {QStringLiteral("trimInUs"), static_cast<double>(asset->trimInUs)},
+            {QStringLiteral("trimOutUs"), static_cast<double>(asset->trimOutUs)},
             {QStringLiteral("sampleRate"), asset->sampleRate},
             {QStringLiteral("channels"), asset->channels},
             {QStringLiteral("codecName"), asset->codecName},
@@ -1090,6 +1209,9 @@ void AssetLibrary::loadFromJsonArray(const QJsonArray &assets)
         asset.height = object.value(QStringLiteral("height")).toInt();
         asset.fps = object.value(QStringLiteral("fps")).toDouble();
         asset.rotationDegrees = object.value(QStringLiteral("rotationDegrees")).toInt();
+        asset.rotationOverride = object.value(QStringLiteral("rotationOverride")).toInt(-1);
+        asset.trimInUs = static_cast<drift::TimeUs>(object.value(QStringLiteral("trimInUs")).toDouble(0));
+        asset.trimOutUs = static_cast<drift::TimeUs>(object.value(QStringLiteral("trimOutUs")).toDouble(-1));
         asset.sampleRate = object.value(QStringLiteral("sampleRate")).toInt();
         asset.channels = object.value(QStringLiteral("channels")).toInt();
         asset.codecName = object.value(QStringLiteral("codecName")).toString();

--- a/src/models/AssetLibrary.h
+++ b/src/models/AssetLibrary.h
@@ -40,6 +40,7 @@ public:
         ThumbnailPathRole,
         FilmstripPathRole,
         FolderIdRole,
+        RotationRole,
     };
     Q_ENUM(Role)
 
@@ -93,6 +94,13 @@ public:
     Q_INVOKABLE void sortByKind();
     // Display name in the media bin. Does not rename the file on disk.
     Q_INVOKABLE bool setAssetName(int index, const QString &name);
+    // Bin-preview rotation correction, snapped to the nearest 90°; -1 resets to the file's own
+    // probed rotation. Forces the cached thumbnail/filmstrip to regenerate against it.
+    Q_INVOKABLE bool setAssetRotation(int index, int degrees);
+    // Non-destructive bin-preview trim (microseconds); trimOutUs < 0 resets to the full duration.
+    // Never touches the source file — applied to a clip's srcIn/srcOut when placed on the
+    // timeline (see AppController::applyAssetLayout).
+    Q_INVOKABLE bool setAssetTrim(int index, qint64 trimInUs, qint64 trimOutUs);
     int indexOfPath(const QString &path) const;
     // Drops the row from the project's asset table. Callers own the undo
     // snapshot and the in-use check; this only touches the bin.
@@ -129,6 +137,17 @@ signals:
     void importFinished(int materialized, int failed);
     // Fired when probe/thumb/audio metadata lands so unlink affordances can refresh.
     void assetMetadataChanged(const QString &assetId);
+    // Narrower than assetMetadataChanged: only for a change to a *card-level* field the bin grid
+    // snapshots (name/kind/duration/path — see MediaAssetsTab.qml's combinedItems), so its
+    // listener knows a real rebuild is warranted. A thumbnail-only change (rotate, a thumbnail
+    // regenerating) does not emit this — those refresh their own delegate's image in place.
+    void assetCardChanged(const QString &assetId);
+    // Fired only by an actual user-initiated bin edit (setAssetRotation, setAssetTrim) — never by
+    // a passive background update (a thumbnail/filmstrip landing, an audio-presence probe). The
+    // project's dirty flag listens to this one, not assetMetadataChanged: opening a project with
+    // missing cached thumbnails, or saving while one happens to regenerate, must not by itself
+    // produce an unsaved-changes prompt.
+    void assetUserEdited(const QString &assetId);
     // Result of startReplaceProbe. Nothing has been applied yet; the caller decides whether the
     // probed media is an acceptable stand-in and calls applyProbedSource if so.
     void assetSourceProbed(const QString &assetId, const drift::MediaAsset &filled, bool ok);
@@ -176,6 +195,10 @@ private:
     QString m_importFolderId;
     QSet<QString> m_importPending;
     QSet<QString> m_thumbPending;
+    // Asset ids whose settings (rotation/trim) changed again while a thumbnail job for them was
+    // already in flight — the in-flight job's result is stale the moment it lands, so its landing
+    // immediately kicks a fresh job rather than silently keeping the outdated image.
+    QSet<QString> m_thumbStale;
     QSet<QString> m_audioProbePending;
     // Probe and thumbnail jobs run here rather than on the global pool, because the destructor
     // has to be able to wait for them: each captures `this` and posts its result back with

--- a/src/models/AssetLibrary.h
+++ b/src/models/AssetLibrary.h
@@ -40,7 +40,6 @@ public:
         ThumbnailPathRole,
         FilmstripPathRole,
         FolderIdRole,
-        RotationRole,
     };
     Q_ENUM(Role)
 
@@ -95,12 +94,14 @@ public:
     // Display name in the media bin. Does not rename the file on disk.
     Q_INVOKABLE bool setAssetName(int index, const QString &name);
     // Bin-preview rotation correction, snapped to the nearest 90°; -1 resets to the file's own
-    // probed rotation. Forces the cached thumbnail/filmstrip to regenerate against it.
-    Q_INVOKABLE bool setAssetRotation(int index, int degrees);
+    // probed rotation. Forces the cached thumbnail/filmstrip to regenerate against it. Not
+    // invokable from QML on purpose: like setAssetName, the caller owns the undo snapshot
+    // (AppController::setAssetRotation).
+    bool setAssetRotation(int index, int degrees);
     // Non-destructive bin-preview trim (microseconds); trimOutUs < 0 resets to the full duration.
     // Never touches the source file — applied to a clip's srcIn/srcOut when placed on the
-    // timeline (see AppController::applyAssetLayout).
-    Q_INVOKABLE bool setAssetTrim(int index, qint64 trimInUs, qint64 trimOutUs);
+    // timeline (see AppController::applyAssetLayout). Undo snapshot is the caller's, as above.
+    bool setAssetTrim(int index, qint64 trimInUs, qint64 trimOutUs);
     int indexOfPath(const QString &path) const;
     // Drops the row from the project's asset table. Callers own the undo
     // snapshot and the in-use check; this only touches the bin.
@@ -142,12 +143,6 @@ signals:
     // listener knows a real rebuild is warranted. A thumbnail-only change (rotate, a thumbnail
     // regenerating) does not emit this — those refresh their own delegate's image in place.
     void assetCardChanged(const QString &assetId);
-    // Fired only by an actual user-initiated bin edit (setAssetRotation, setAssetTrim) — never by
-    // a passive background update (a thumbnail/filmstrip landing, an audio-presence probe). The
-    // project's dirty flag listens to this one, not assetMetadataChanged: opening a project with
-    // missing cached thumbnails, or saving while one happens to regenerate, must not by itself
-    // produce an unsaved-changes prompt.
-    void assetUserEdited(const QString &assetId);
     // Result of startReplaceProbe. Nothing has been applied yet; the caller decides whether the
     // probed media is an acceptable stand-in and calls applyProbedSource if so.
     void assetSourceProbed(const QString &assetId, const drift::MediaAsset &filled, bool ok);
@@ -181,6 +176,7 @@ private:
     void snapshotAssets();
     QList<QString> currentPaths() const;
     QList<QString> currentFolderIds() const;
+    QList<QString> currentEdits() const;
     const drift::MediaAsset *assetAtIndex(int index) const;
     drift::MediaAsset *assetAtIndex(int index);
 
@@ -192,6 +188,9 @@ private:
     QList<QString> m_syncedOrder;
     QList<QString> m_syncedPaths;
     QList<QString> m_syncedFolderIds;
+    // Per-row rotation override and trim, for the same reason: an undone bin rotate/trim leaves
+    // order, path and folder alone, and the card (thumbnail, duration text) has to follow it.
+    QList<QString> m_syncedEdits;
     QString m_importFolderId;
     QSet<QString> m_importPending;
     QSet<QString> m_thumbPending;

--- a/src/playback/ClipPreviewPlayer.cpp
+++ b/src/playback/ClipPreviewPlayer.cpp
@@ -23,13 +23,14 @@ constexpr quint64 kPreviewStreamSalt = 0x9E3779B97F4A7C15ull;
 } // namespace
 
 void ClipPreviewFrameWorker::decode(const QString &path, quint64 streamId, qint64 sourceUs,
-                                    int maxWidth, int maxHeight, quint64 token)
+                                    int maxWidth, int maxHeight, quint64 token, int rotationOverride)
 {
     if (token < latestToken.load(std::memory_order_acquire))
         return; // a newer position arrived while this sat in the queue
 
     const QImage image = ClipReaderPool::instance().readVideoFrame(
-        path, streamId, static_cast<drift::TimeUs>(sourceUs), maxWidth, maxHeight);
+        path, streamId, static_cast<drift::TimeUs>(sourceUs), maxWidth, maxHeight,
+        QString(), 15, false, rotationOverride);
     if (!image.isNull())
         emit decoded(image, token);
 }
@@ -234,6 +235,7 @@ void ClipPreviewPlayer::requestFrame(drift::TimeUs position)
     QString path;
     drift::TimeUs sourceUs = 0;
     quint64 streamId = 0;
+    int rotationOverride = -1;
     {
         QMutexLocker lock(&m_clipMutex);
         if (m_clip.type == drift::ClipType::Audio || m_clip.path.isEmpty())
@@ -242,6 +244,7 @@ void ClipPreviewPlayer::requestFrame(drift::TimeUs position)
         path = read.path;
         sourceUs = read.sourceUs;
         streamId = kPreviewStreamSalt ^ ClipReaderPool::streamIdForClip(m_clip.id);
+        rotationOverride = m_clip.rotationOverride;
     }
 
     const quint64 token = ++m_frameToken;
@@ -249,7 +252,7 @@ void ClipPreviewPlayer::requestFrame(drift::TimeUs position)
     QMetaObject::invokeMethod(m_frameWorker, "decode", Qt::QueuedConnection, Q_ARG(QString, path),
                               Q_ARG(quint64, streamId), Q_ARG(qint64, static_cast<qint64>(sourceUs)),
                               Q_ARG(int, kFrameMaxWidth), Q_ARG(int, kFrameMaxHeight),
-                              Q_ARG(quint64, token));
+                              Q_ARG(quint64, token), Q_ARG(int, rotationOverride));
 }
 
 void ClipPreviewPlayer::onDecoded(const QImage &image, quint64 token)

--- a/src/playback/ClipPreviewPlayer.cpp
+++ b/src/playback/ClipPreviewPlayer.cpp
@@ -23,14 +23,14 @@ constexpr quint64 kPreviewStreamSalt = 0x9E3779B97F4A7C15ull;
 } // namespace
 
 void ClipPreviewFrameWorker::decode(const QString &path, quint64 streamId, qint64 sourceUs,
-                                    int maxWidth, int maxHeight, quint64 token, int rotationOverride)
+                                    int maxWidth, int maxHeight, quint64 token, int rotationCorrection)
 {
     if (token < latestToken.load(std::memory_order_acquire))
         return; // a newer position arrived while this sat in the queue
 
     const QImage image = ClipReaderPool::instance().readVideoFrame(
         path, streamId, static_cast<drift::TimeUs>(sourceUs), maxWidth, maxHeight,
-        QString(), 15, false, rotationOverride);
+        QString(), 15, false, rotationCorrection);
     if (!image.isNull())
         emit decoded(image, token);
 }
@@ -235,7 +235,7 @@ void ClipPreviewPlayer::requestFrame(drift::TimeUs position)
     QString path;
     drift::TimeUs sourceUs = 0;
     quint64 streamId = 0;
-    int rotationOverride = -1;
+    int rotationCorrection = 0;
     {
         QMutexLocker lock(&m_clipMutex);
         if (m_clip.type == drift::ClipType::Audio || m_clip.path.isEmpty())
@@ -244,7 +244,7 @@ void ClipPreviewPlayer::requestFrame(drift::TimeUs position)
         path = read.path;
         sourceUs = read.sourceUs;
         streamId = kPreviewStreamSalt ^ ClipReaderPool::streamIdForClip(m_clip.id);
-        rotationOverride = m_clip.rotationOverride;
+        rotationCorrection = m_clip.rotationCorrection;
     }
 
     const quint64 token = ++m_frameToken;
@@ -252,7 +252,7 @@ void ClipPreviewPlayer::requestFrame(drift::TimeUs position)
     QMetaObject::invokeMethod(m_frameWorker, "decode", Qt::QueuedConnection, Q_ARG(QString, path),
                               Q_ARG(quint64, streamId), Q_ARG(qint64, static_cast<qint64>(sourceUs)),
                               Q_ARG(int, kFrameMaxWidth), Q_ARG(int, kFrameMaxHeight),
-                              Q_ARG(quint64, token), Q_ARG(int, rotationOverride));
+                              Q_ARG(quint64, token), Q_ARG(int, rotationCorrection));
 }
 
 void ClipPreviewPlayer::onDecoded(const QImage &image, quint64 token)

--- a/src/playback/ClipPreviewPlayer.h
+++ b/src/playback/ClipPreviewPlayer.h
@@ -28,7 +28,7 @@ public:
 
 public slots:
     void decode(const QString &path, quint64 streamId, qint64 sourceUs, int maxWidth, int maxHeight,
-                quint64 token);
+                quint64 token, int rotationOverride = -1);
 
 signals:
     void decoded(const QImage &image, quint64 token);

--- a/src/playback/ClipPreviewPlayer.h
+++ b/src/playback/ClipPreviewPlayer.h
@@ -28,7 +28,7 @@ public:
 
 public slots:
     void decode(const QString &path, quint64 streamId, qint64 sourceUs, int maxWidth, int maxHeight,
-                quint64 token, int rotationOverride = -1);
+                quint64 token, int rotationCorrection = 0);
 
 signals:
     void decoded(const QImage &image, quint64 token);

--- a/src/qml/AndroidMediaPreview.qml
+++ b/src/qml/AndroidMediaPreview.qml
@@ -108,17 +108,26 @@ Item {
     }
 
     // Steps the bin's rotation correction by 90° and reopens the preview session so the player's
-    // decoder picks up the new rotationOverride. Video only: image/audio clips have no lossless
+    // decoder picks up the new correction. Video only: image/audio clips have no lossless
     // pixel-rotation path on the timeline (see AppController::applyAssetLayout).
     function rotate90() {
         if (root.assetIndex < 0 || !root.isVideo)
             return
+        EditorState.setAssetRotation(root.assetIndex, (root.effectiveRotation + 90) % 360)
+    }
+
+    // Picks up a rotation change from wherever it came from (the button above, or an undo) and
+    // reopens the preview session at the same spot so the decoder applies it.
+    function applyRotationFromAsset(asset) {
+        const nextOverride = (asset.rotationOverride === undefined || asset.rotationOverride === null)
+                              ? -1 : asset.rotationOverride
+        const next = (asset.effectiveRotation === undefined || asset.effectiveRotation === null)
+                      ? root.rotationDegrees : asset.effectiveRotation
+        if (nextOverride === root.rotationOverride && next === root.effectiveRotation)
+            return
         const wasPlaying = EditorState.assetPreviewPlaying
         const at = root.position
-        const next = (root.effectiveRotation + 90) % 360
-        if (!AssetLibrary.setAssetRotation(root.assetIndex, next))
-            return
-        root.rotationOverride = next
+        root.rotationOverride = nextOverride
         root.effectiveRotation = next
         EditorState.beginAssetPreview(root.assetIndex)
         root.seekTo(at)
@@ -205,6 +214,9 @@ Item {
             if (assetId !== root.assetId)
                 return
             root.filmstripPath = AssetLibrary.filmstripAt(root.assetIndex)
+            const asset = AssetLibrary.assetAt(root.assetIndex)
+            if (asset && asset.id === root.assetId)
+                root.applyRotationFromAsset(asset)
         }
     }
 
@@ -671,6 +683,7 @@ Item {
                     filmstripPath: root.filmstripPath
                     frameWidth: Math.max(1, width / frameCount)
                     sourcePath: root.sourcePath
+                    rotationCorrection: (root.effectiveRotation - root.rotationDegrees + 360) % 360
                     inPoint: 0
                     outPoint: root.durationSeconds
                     sourceDuration: root.durationSeconds

--- a/src/qml/AndroidMediaPreview.qml
+++ b/src/qml/AndroidMediaPreview.qml
@@ -29,7 +29,11 @@ Item {
     property real durationSeconds: 0
     property int sourceWidth: 0
     property int sourceHeight: 0
+    // Native: the file's own probed display-matrix rotation. Override: the bin-preview
+    // correction, -1 when none. Effective is whichever of the two actually applies.
     property int rotationDegrees: 0
+    property int rotationOverride: -1
+    property int effectiveRotation: 0
 
     property real inSeconds: 0
     property real outSeconds: 0
@@ -37,6 +41,12 @@ Item {
     property real cropY: 0
     property real cropW: 1
     property real cropH: 1
+
+    // The trim already saved non-destructively on the asset (AssetLibrary::setAssetTrim) — the
+    // baseline "no edit yet" reverts to, since a plain trim never re-encodes the file and so is
+    // never reflected in durationSeconds the way an old encode-based save used to be.
+    property real persistedInSeconds: 0
+    property real persistedOutSeconds: 0
 
     // "trim" | "crop". Crop starts off: the handles used to be live over the picture the
     // moment the screen opened, with nothing saying what they were.
@@ -50,19 +60,19 @@ Item {
     readonly property bool canPlay: !isImage
 
     readonly property int displayW: {
-        const rot = Math.abs(root.rotationDegrees)
+        const rot = Math.abs(root.effectiveRotation)
         return (rot === 90 || rot === 270) ? root.sourceHeight : root.sourceWidth
     }
     readonly property int displayH: {
-        const rot = Math.abs(root.rotationDegrees)
+        const rot = Math.abs(root.effectiveRotation)
         return (rot === 90 || rot === 270) ? root.sourceWidth : root.sourceHeight
     }
 
     readonly property bool cropDirty: cropX > 0.001 || cropY > 0.001
                                       || cropW < 0.999 || cropH < 0.999
     readonly property bool trimDirty: canTrim
-                                      && (inSeconds > 0.02
-                                          || outSeconds < durationSeconds - 0.02)
+                                      && (Math.abs(inSeconds - persistedInSeconds) > 0.02
+                                          || Math.abs(outSeconds - persistedOutSeconds) > 0.02)
     readonly property bool dirty: cropDirty || trimDirty
     readonly property bool saving: EditorState.editingAsset
     readonly property real position: EditorState.assetPreviewPosition
@@ -73,6 +83,7 @@ Item {
             root.closed()
             return
         }
+        EditorState.assetPreviewWindowOpen = true
         root.assetIndex = index
         root.assetId = asset.id || ""
         root.kind = asset.kind || ""
@@ -83,21 +94,49 @@ Item {
         root.sourceWidth = asset.width || 0
         root.sourceHeight = asset.height || 0
         root.rotationDegrees = asset.rotationDegrees || 0
+        root.rotationOverride = (asset.rotationOverride === undefined || asset.rotationOverride === null)
+                                 ? -1 : asset.rotationOverride
+        root.effectiveRotation = (asset.effectiveRotation === undefined || asset.effectiveRotation === null)
+                                  ? root.rotationDegrees : asset.effectiveRotation
+        root.persistedInSeconds = asset.trimInSeconds || 0
+        root.persistedOutSeconds = (asset.trimOutSeconds === undefined || asset.trimOutSeconds === null
+                                     || asset.trimOutSeconds < 0)
+                                    ? root.durationSeconds : asset.trimOutSeconds
         root.mode = "trim"
         resetEdits()
         EditorState.beginAssetPreview(index)
+    }
+
+    // Steps the bin's rotation correction by 90° and reopens the preview session so the player's
+    // decoder picks up the new rotationOverride. Video only: image/audio clips have no lossless
+    // pixel-rotation path on the timeline (see AppController::applyAssetLayout).
+    function rotate90() {
+        if (root.assetIndex < 0 || !root.isVideo)
+            return
+        const wasPlaying = EditorState.assetPreviewPlaying
+        const at = root.position
+        const next = (root.effectiveRotation + 90) % 360
+        if (!AssetLibrary.setAssetRotation(root.assetIndex, next))
+            return
+        root.rotationOverride = next
+        root.effectiveRotation = next
+        EditorState.beginAssetPreview(root.assetIndex)
+        root.seekTo(at)
+        if (wasPlaying)
+            EditorState.playAssetPreview()
     }
 
     function close() {
         EditorState.pauseAssetPreview()
         EditorState.endAssetPreview()
         root.assetIndex = -1
+        EditorState.assetPreviewWindowOpen = false
         root.closed()
     }
 
     function resetEdits() {
-        root.inSeconds = 0
-        root.outSeconds = Math.max(0, root.durationSeconds)
+        root.inSeconds = root.persistedInSeconds
+        root.outSeconds = root.persistedOutSeconds
         root.cropX = 0
         root.cropY = 0
         root.cropW = 1
@@ -155,6 +194,17 @@ Item {
         }
         function onProjectReset() {
             root.close()
+        }
+    }
+
+    // The rotated thumbnail/filmstrip regenerate on a background job (MediaThumbnail::generate),
+    // so the strip below needs to pick up the new file once it lands.
+    Connections {
+        target: AssetLibrary
+        function onAssetMetadataChanged(assetId) {
+            if (assetId !== root.assetId)
+                return
+            root.filmstripPath = AssetLibrary.filmstripAt(root.assetIndex)
         }
     }
 
@@ -572,6 +622,16 @@ Item {
             }
         }
 
+        ThemedButton {
+            width: parent.width
+            height: Theme.controlHeight
+            visible: root.isVideo
+            variant: "secondary"
+            text: qsTr("Rotate")
+            enabled: !root.saving
+            onClicked: root.rotate90()
+        }
+
         // ----- Trim -------------------------------------------------------------------------
         Column {
             width: parent.width
@@ -753,9 +813,9 @@ Item {
                     text: qsTr("Undo trim")
                     enabled: root.trimDirty && !root.saving
                     onClicked: {
-                        root.inSeconds = 0
-                        root.outSeconds = Math.max(0, root.durationSeconds)
-                        root.seekTo(0)
+                        root.inSeconds = root.persistedInSeconds
+                        root.outSeconds = root.persistedOutSeconds
+                        root.seekTo(root.inSeconds)
                     }
                 }
             }

--- a/src/qml/AndroidTimeline.qml
+++ b/src/qml/AndroidTimeline.qml
@@ -487,7 +487,8 @@ Item {
             return 5.0
         if (asset.kind === "image" || !(asset.durationSeconds > 0))
             return 5.0
-        return asset.durationSeconds
+        // A bin-preview trim shortens what actually lands, so the landing preview matches it.
+        return asset.placedDurationSeconds
     }
 
     function timelineHasClips() {

--- a/src/qml/MediaPreviewWindow.qml
+++ b/src/qml/MediaPreviewWindow.qml
@@ -19,7 +19,15 @@ Window {
     property real durationSeconds: 0
     property int sourceWidth: 0
     property int sourceHeight: 0
+    // Native: the file's own probed display-matrix rotation. Override: the bin-preview
+    // correction, -1 when none. Effective is whichever of the two actually applies.
     property int rotationDegrees: 0
+    property int rotationOverride: -1
+    property int effectiveRotation: 0
+
+    // See openFor()/onMediaStatusChanged: the play/pause "first frame" kick must run exactly once
+    // per loaded source, not on every mediaStatus transition an ordinary seek can also cause.
+    property bool _kickedForCurrentSource: false
 
     property real inSeconds: 0
     property real outSeconds: 0
@@ -28,6 +36,12 @@ Window {
     property real cropW: 1
     property real cropH: 1
 
+    // The trim already saved non-destructively on the asset (AssetLibrary::setAssetTrim) — the
+    // baseline "no edit yet" reverts to, since a plain trim never re-encodes the file and so is
+    // never reflected in durationSeconds the way an old encode-based save used to be.
+    property real persistedInSeconds: 0
+    property real persistedOutSeconds: 0
+
     readonly property bool isImage: kind === "image"
     readonly property bool isAudio: kind === "audio"
     readonly property bool isVideo: kind === "video"
@@ -35,19 +49,19 @@ Window {
     readonly property bool canTrim: !isImage && durationSeconds > 0.05
 
     readonly property int displayW: {
-        const rot = Math.abs(root.rotationDegrees)
+        const rot = Math.abs(root.effectiveRotation)
         return (rot === 90 || rot === 270) ? root.sourceHeight : root.sourceWidth
     }
     readonly property int displayH: {
-        const rot = Math.abs(root.rotationDegrees)
+        const rot = Math.abs(root.effectiveRotation)
         return (rot === 90 || rot === 270) ? root.sourceWidth : root.sourceHeight
     }
 
     readonly property bool cropDirty: cropX > 0.001 || cropY > 0.001
                                       || cropW < 0.999 || cropH < 0.999
     readonly property bool trimDirty: canTrim
-                                      && (inSeconds > 0.02
-                                          || outSeconds < durationSeconds - 0.02)
+                                      && (Math.abs(inSeconds - persistedInSeconds) > 0.02
+                                          || Math.abs(outSeconds - persistedOutSeconds) > 0.02)
     readonly property bool dirty: cropDirty || trimDirty
     readonly property bool saving: EditorState.editingAsset
 
@@ -62,7 +76,20 @@ Window {
         const asset = AssetLibrary.assetAt(index)
         if (!asset || Object.keys(asset).length === 0)
             return
+        EditorState.assetPreviewWindowOpen = true
         player.stop()
+        // QMediaPlayer::setSource() is a silent no-op when the new source compares equal to the
+        // one it already has (confirmed against Qt 6.8.3), so reopening the same file below would
+        // never re-fire mediaStatusChanged — and with it, never rerun the play/pause kick that
+        // forces this backend to actually push a first frame. Clearing it first guarantees a real
+        // source transition every time, same file or not.
+        player.source = ""
+        // Rearms the one-shot play/pause kick below for this newly loaded file. Without this,
+        // an ordinary seek (dragging the strip, "Set In"/"Set Out") can cycle mediaStatus back
+        // through Buffering/Buffered on its own, and the kick firing again on that would call
+        // seekTo(root.inSeconds) a second time — snapping the position back to the start on every
+        // seek instead of holding wherever the user put it.
+        root._kickedForCurrentSource = false
         root.assetIndex = index
         root.assetId = asset.id || ""
         root.kind = asset.kind || ""
@@ -73,6 +100,14 @@ Window {
         root.sourceWidth = asset.width || 0
         root.sourceHeight = asset.height || 0
         root.rotationDegrees = asset.rotationDegrees || 0
+        root.rotationOverride = (asset.rotationOverride === undefined || asset.rotationOverride === null)
+                                 ? -1 : asset.rotationOverride
+        root.effectiveRotation = (asset.effectiveRotation === undefined || asset.effectiveRotation === null)
+                                  ? root.rotationDegrees : asset.effectiveRotation
+        root.persistedInSeconds = asset.trimInSeconds || 0
+        root.persistedOutSeconds = (asset.trimOutSeconds === undefined || asset.trimOutSeconds === null
+                                     || asset.trimOutSeconds < 0)
+                                    ? root.durationSeconds : asset.trimOutSeconds
         resetEdits()
         root.show()
         root.raise()
@@ -81,9 +116,22 @@ Window {
             player.source = EditorState.fileUrl(root.sourcePath)
     }
 
+    // Steps the bin's rotation correction by 90° and keeps it — independent of crop/trim, which
+    // still need Save. Kept only for video: image/audio clips have no lossless pixel-rotation
+    // path on the timeline (see AppController::applyAssetLayout / ClipReader::rotationOverride).
+    function rotate90() {
+        if (root.assetIndex < 0 || !root.isVideo)
+            return
+        const next = (root.effectiveRotation + 90) % 360
+        if (AssetLibrary.setAssetRotation(root.assetIndex, next)) {
+            root.rotationOverride = next
+            root.effectiveRotation = next
+        }
+    }
+
     function resetEdits() {
-        root.inSeconds = 0
-        root.outSeconds = Math.max(0, root.durationSeconds)
+        root.inSeconds = root.persistedInSeconds
+        root.outSeconds = root.persistedOutSeconds
         root.cropX = 0
         root.cropY = 0
         root.cropW = 1
@@ -107,10 +155,28 @@ Window {
         root.outSeconds = Math.max(root.inSeconds + minSpan, Math.min(root.outSeconds, dur))
     }
 
+    // Guards against a genuine crash: the nudge below deliberately writes `position` twice, and
+    // each write fires onPositionChanged synchronously — which, whenever playback is (or still
+    // reports as) active and lands at/past outSeconds, calls back into seekTo to loop to the
+    // start. With no guard that is unbounded recursion (each level's own nudge re-enters again)
+    // and a "Maximum call stack size exceeded" crash, not just a harmless ping-pong. A seek that
+    // happens to re-enter while already seeking is our own nudge, never a real playback position
+    // worth reacting to, so just dropping it here is correct, not merely safe.
+    property bool _seeking: false
+
     function seekTo(seconds) {
-        if (root.isImage)
+        if (root.isImage || root._seeking)
             return
-        player.position = Math.round(Math.max(0, seconds) * 1000)
+        root._seeking = true
+        const target = Math.round(Math.max(0, seconds) * 1000)
+        // Assigning the position it already reports is a no-op in Qt Multimedia — no seek is
+        // actually issued, so a freshly loaded player (position 0) asked to show frame 0 never
+        // decodes anything and the video output stays blank until some other, real seek happens.
+        // Nudge off the target first so this always forces an actual seek.
+        if (player.position === target)
+            player.position = target > 0 ? target - 1 : target + 1
+        player.position = target
+        root._seeking = false
     }
 
     function togglePlay() {
@@ -130,6 +196,7 @@ Window {
         player.stop()
         if (root.saving)
             EditorState.cancelAssetEdit()
+        EditorState.assetPreviewWindowOpen = false
     }
 
     Connections {
@@ -146,14 +213,37 @@ Window {
         }
     }
 
+    // The rotated thumbnail/filmstrip regenerate on a background job (MediaThumbnail::generate),
+    // so the strip below needs to pick up the new file once it lands.
+    Connections {
+        target: AssetLibrary
+        function onAssetMetadataChanged(assetId) {
+            if (assetId !== root.assetId)
+                return
+            root.filmstripPath = AssetLibrary.filmstripAt(root.assetIndex)
+        }
+    }
+
     MediaPlayer {
         id: player
         audioOutput: AudioOutput {}
         videoOutput: videoOut
         onMediaStatusChanged: {
-            if (mediaStatus === MediaPlayer.LoadedMedia
-                    || mediaStatus === MediaPlayer.BufferedMedia)
-                root.seekTo(root.inSeconds)
+            if (mediaStatus !== MediaPlayer.LoadedMedia && mediaStatus !== MediaPlayer.BufferedMedia)
+                return
+            if (root._kickedForCurrentSource)
+                return
+            root._kickedForCurrentSource = true
+            // This backend only actually decodes/pushes a frame to the video sink once playback
+            // has started at least once — seeking alone, while stopped, leaves it showing nothing.
+            // A play/pause kick forces that first frame, then the real seek lands on the right one.
+            // Guarded to run once per source: an ordinary seek can cycle mediaStatus back through
+            // Buffering/Buffered on its own, and re-running this on that would call
+            // seekTo(root.inSeconds) again — snapping the position back to the start on every
+            // seek instead of holding wherever the user put it.
+            player.play()
+            player.pause()
+            root.seekTo(root.inSeconds)
         }
         onPositionChanged: {
             if (root.isImage || player.playbackState !== MediaPlayer.PlayingState)
@@ -219,8 +309,11 @@ Window {
             height: {
                 let h = parent.height - hintLabel.height - Theme.spacingLg
                 h -= transport.height + Theme.spacingLg
+                // stripBlock, not strip: the ruler above the filmstrip strip is part of the same
+                // visible block now and has to come out of this budget too, or its extra height
+                // overflows into the transport row above and the footer below.
                 if (root.canTrim)
-                    h -= strip.height + Theme.spacingLg
+                    h -= stripBlock.height + Theme.spacingLg
                 return Math.max(80, h)
             }
             radius: Theme.radiusMd
@@ -249,8 +342,20 @@ Window {
             VideoOutput {
                 id: videoOut
                 visible: root.isVideo
-                anchors.fill: parent
                 fillMode: VideoOutput.PreserveAspectFit
+
+                // QtMultimedia auto-rotates per the file's own tag (rotationDegrees) regardless of
+                // our override, so the delta between the two is applied here on top of that. A
+                // 90/270 delta also swaps which of stage.fit's box dimensions is this item's own
+                // pre-rotation footprint, so the rotated result still lands exactly on stage.fit
+                // instead of just spinning in place inside its original (wrong-aspect) box.
+                readonly property int rotationDelta: (root.effectiveRotation - root.rotationDegrees + 360) % 360
+                readonly property bool swapped: rotationDelta === 90 || rotationDelta === 270
+                width: swapped ? stage.fit.h : stage.fit.w
+                height: swapped ? stage.fit.w : stage.fit.h
+                x: stage.fit.x + stage.fit.w / 2 - width / 2
+                y: stage.fit.y + stage.fit.h / 2 - height / 2
+                rotation: rotationDelta
             }
 
             Column {
@@ -506,6 +611,15 @@ Window {
             }
 
             ThemedButton {
+                visible: root.isVideo
+                width: visible ? implicitWidth : 0
+                variant: "ghost"
+                text: qsTr("Rotate")
+                enabled: !root.saving
+                onClicked: root.rotate90()
+            }
+
+            ThemedButton {
                 variant: "ghost"
                 text: qsTr("Reset")
                 enabled: root.dirty && !root.saving
@@ -513,61 +627,150 @@ Window {
             }
         }
 
-        Rectangle {
-            id: strip
+        Column {
+            id: stripBlock
             visible: root.canTrim
             width: parent.width
-            height: visible ? 64 : 0
-            radius: Theme.radiusSm
-            color: Theme.panelBackground
-            border.width: Theme.borderWidth
-            border.color: Theme.panelBorder
-            clip: true
-
-            ClipFilmstrip {
-                anchors.fill: parent
-                anchors.margins: Theme.borderWidth
-                visible: root.filmstripPath.length > 0
-                filmstripPath: root.filmstripPath
-                frameWidth: Math.max(1, width / frameCount)
-                sourcePath: root.sourcePath
-                inPoint: 0
-                outPoint: root.durationSeconds
-                sourceDuration: root.durationSeconds
-            }
+            spacing: 2
 
             readonly property real dur: Math.max(0.001, root.durationSeconds)
-            readonly property real inX: (root.inSeconds / dur) * width
-            readonly property real outX: (root.outSeconds / dur) * width
-            readonly property real playX: ((player.position / 1000) / dur) * width
+            readonly property real pxPerSecond: width / dur
+            readonly property real playX: (player.position / 1000) * pxPerSecond
+
+            // Ticks stay legible regardless of the clip's length: the smallest "nice" step from
+            // this list whose label spacing is still wide enough not to overlap the next one —
+            // the same idea TimelinePanel's ruler uses for its zoom-adaptive ticks, simplified
+            // here since this strip has a fixed width for the whole clip and never zooms/pans.
+            readonly property var tickSteps: [0.1, 0.2, 0.5, 1, 2, 5, 10, 15, 30, 60, 120, 300,
+                                              600, 900, 1800, 3600]
+            readonly property real tickStep: {
+                const minLabelPx = 56
+                for (const s of stripBlock.tickSteps) {
+                    if (s * stripBlock.pxPerSecond >= minLabelPx)
+                        return s
+                }
+                return stripBlock.tickSteps[stripBlock.tickSteps.length - 1]
+            }
+
+            function formatTick(seconds) {
+                const s = Math.max(0, seconds)
+                const total = Math.floor(s)
+                const h = Math.floor(total / 3600)
+                const m = Math.floor((total % 3600) / 60)
+                const sec = total % 60
+                function pad(n) { return n.toString().padStart(2, "0") }
+                let text = pad(h) + ":" + pad(m) + ":" + pad(sec)
+                if (stripBlock.tickStep < 1)
+                    text += "." + pad(Math.floor((s - total) * 100))
+                return text
+            }
+
+            // Time ruler — ticks/timestamps across the clip's full duration, same idea as the
+            // main timeline's ruler, plus a playhead handle so the strip below reads as scrubbing
+            // a timeline rather than just a static filmstrip.
+            Item {
+                id: timeRuler
+                width: parent.width
+                height: 20
+                clip: true
+
+                Repeater {
+                    model: Math.floor(stripBlock.dur / stripBlock.tickStep) + 1
+                    Item {
+                        required property int index
+                        readonly property real tSeconds: index * stripBlock.tickStep
+                        x: tSeconds * stripBlock.pxPerSecond
+                        width: 1
+                        height: parent.height
+
+                        Rectangle {
+                            anchors.bottom: parent.bottom
+                            width: 1
+                            height: 6
+                            color: Theme.mutedForeground
+                            opacity: 0.35
+                        }
+                        Text {
+                            anchors.bottom: parent.bottom
+                            anchors.bottomMargin: 8
+                            anchors.left: parent.left
+                            anchors.leftMargin: 2
+                            text: stripBlock.formatTick(tSeconds)
+                            font.family: Theme.monoFontFamily
+                            font.pixelSize: Theme.fontSizeTick
+                            color: Theme.mutedForeground
+                        }
+                    }
+                }
+
+                // Playhead handle: a small flag at the top of the line that continues down
+                // through the strip below, matching the timeline's playhead silhouette.
+                Item {
+                    x: stripBlock.playX - width / 2
+                    y: 6
+                    width: 10
+                    height: 10
+                    Rectangle {
+                        anchors.fill: parent
+                        radius: 2
+                        color: Theme.primary
+                    }
+                }
+            }
 
             Rectangle {
-                width: strip.inX
-                height: parent.height
-                color: Theme.scrimStrong
-            }
-            Rectangle {
-                x: strip.outX
-                width: Math.max(0, parent.width - x)
-                height: parent.height
-                color: Theme.scrimStrong
-            }
-            Rectangle {
-                x: strip.inX
-                width: Math.max(2, strip.outX - strip.inX)
-                height: parent.height
-                color: "transparent"
+                id: strip
+                width: parent.width
+                height: 64
+                radius: Theme.radiusSm
+                color: Theme.panelBackground
                 border.width: Theme.borderWidth
-                border.color: Theme.primary
-            }
-            Rectangle {
-                x: strip.playX - 1
-                width: 2
-                height: parent.height
-                color: Theme.onMedia
-            }
+                border.color: Theme.panelBorder
+                clip: true
 
-            MouseArea {
+                ClipFilmstrip {
+                    anchors.fill: parent
+                    anchors.margins: Theme.borderWidth
+                    visible: root.filmstripPath.length > 0
+                    filmstripPath: root.filmstripPath
+                    frameWidth: Math.max(1, width / frameCount)
+                    sourcePath: root.sourcePath
+                    inPoint: 0
+                    outPoint: root.durationSeconds
+                    sourceDuration: root.durationSeconds
+                }
+
+                readonly property real inX: (root.inSeconds / stripBlock.dur) * width
+                readonly property real outX: (root.outSeconds / stripBlock.dur) * width
+
+                Rectangle {
+                    width: strip.inX
+                    height: parent.height
+                    color: Theme.scrimStrong
+                }
+                Rectangle {
+                    x: strip.outX
+                    width: Math.max(0, parent.width - x)
+                    height: parent.height
+                    color: Theme.scrimStrong
+                }
+                Rectangle {
+                    x: strip.inX
+                    width: Math.max(2, strip.outX - strip.inX)
+                    height: parent.height
+                    color: "transparent"
+                    border.width: Theme.borderWidth
+                    border.color: Theme.primary
+                }
+                Rectangle {
+                    x: stripBlock.playX - 1
+                    width: 2
+                    height: parent.height
+                    color: Theme.primary
+                    z: 3
+                }
+
+                MouseArea {
                 anchors.fill: parent
                 enabled: !root.saving
                 cursorShape: Qt.PointingHandCursor
@@ -619,6 +822,7 @@ Window {
                     }
                 }
             }
+        }
         }
     }
 

--- a/src/qml/MediaPreviewWindow.qml
+++ b/src/qml/MediaPreviewWindow.qml
@@ -118,12 +118,12 @@ Window {
 
     // Steps the bin's rotation correction by 90° and keeps it — independent of crop/trim, which
     // still need Save. Kept only for video: image/audio clips have no lossless pixel-rotation
-    // path on the timeline (see AppController::applyAssetLayout / ClipReader::rotationOverride).
+    // path on the timeline (see AppController::applyAssetLayout / Clip::rotationCorrection).
     function rotate90() {
         if (root.assetIndex < 0 || !root.isVideo)
             return
         const next = (root.effectiveRotation + 90) % 360
-        if (AssetLibrary.setAssetRotation(root.assetIndex, next)) {
+        if (EditorState.setAssetRotation(root.assetIndex, next)) {
             root.rotationOverride = next
             root.effectiveRotation = next
         }
@@ -214,13 +214,19 @@ Window {
     }
 
     // The rotated thumbnail/filmstrip regenerate on a background job (MediaThumbnail::generate),
-    // so the strip below needs to pick up the new file once it lands.
+    // so the strip below needs to pick up the new file once it lands. The rotation itself is
+    // re-read too: an undo of the rotate while this window is open lands here as well.
     Connections {
         target: AssetLibrary
         function onAssetMetadataChanged(assetId) {
             if (assetId !== root.assetId)
                 return
             root.filmstripPath = AssetLibrary.filmstripAt(root.assetIndex)
+            const asset = AssetLibrary.assetAt(root.assetIndex)
+            if (!asset || asset.id !== root.assetId)
+                return
+            root.rotationOverride = asset.rotationOverride
+            root.effectiveRotation = asset.effectiveRotation
         }
     }
 
@@ -735,6 +741,7 @@ Window {
                     filmstripPath: root.filmstripPath
                     frameWidth: Math.max(1, width / frameCount)
                     sourcePath: root.sourcePath
+                    rotationCorrection: (root.effectiveRotation - root.rotationDegrees + 360) % 360
                     inPoint: 0
                     outPoint: root.durationSeconds
                     sourceDuration: root.durationSeconds

--- a/src/qml/TimelinePanel.qml
+++ b/src/qml/TimelinePanel.qml
@@ -348,7 +348,8 @@ PanelFrame {
             return 5.0
         if (asset.kind === "image" || !(asset.durationSeconds > 0))
             return 5.0
-        return asset.durationSeconds
+        // A bin-preview trim shortens what actually lands, so the landing preview matches it.
+        return asset.placedDurationSeconds
     }
 
     // Snap a clip's desired start against timeline targets, testing both edges.

--- a/src/qml/components/ClipFilmstrip.qml
+++ b/src/qml/components/ClipFilmstrip.qml
@@ -18,6 +18,9 @@ Item {
     // Media file behind the strip. Set for video clips only; when present each tile also
     // requests its real frame on demand and fades it in over the coarse strip frame.
     property string sourcePath: ""
+    // The clip's lossless orientation fix (Clip::rotationCorrection), so on-demand tiles come
+    // out the way the preview shows the clip.
+    property int rotationCorrection: 0
 
     // Source window this clip covers, in seconds, plus the full source length. When set, each
     // tile maps to the source time it represents so the strip shows correct-timestamp frames and
@@ -124,7 +127,8 @@ Item {
         if (srcSec < 0 || srcSec >= sourceDuration)
             return ""
         var interval = Math.pow(2, tileLevel)
-        return EditorState.filmstripTileUrl(sourcePath, tileLevel, Math.floor(srcSec / interval))
+        return EditorState.filmstripTileUrl(sourcePath, tileLevel, Math.floor(srcSec / interval),
+                                            rotationCorrection)
     }
 
     function coarseUrlForTile(tileIndex) {

--- a/src/qml/components/assets/MediaAssetsTab.qml
+++ b/src/qml/components/assets/MediaAssetsTab.qml
@@ -210,18 +210,53 @@ Item {
     // down and rebuilt once per signal — quadratic work, and a chance of destroying a delegate
     // out from under a card that owns an active drag or has its context menu open.
     property int _refreshTick: 0
+    // Set instead of restarting the timer while a preview window has a metadata edit in flight
+    // (rotate, trim) — nothing behind that modal-ish window needs to reflect the change until it
+    // closes, and rebuilding while it's open is a visible, pointless flicker for the user.
+    property bool _refreshPending: false
     Timer {
         id: refreshCoalesceTimer
         interval: 100
-        onTriggered: root._refreshTick++
+        onTriggered: {
+            // Reassigning a freshly-built array to `model:` below is exactly the "different
+            // model, not an in-place update" case GridView/ListView cannot tell apart from a
+            // real reset, so it snaps contentY back to the top on every coalesced rebuild —
+            // disruptive when a metadata edit (rotate, trim, a probe landing) fires while the
+            // user is scrolled down. Save/restore across it instead of trying to avoid the
+            // rebuild; the restore is deferred a couple of turns so it runs after the view has
+            // actually relaid out its delegates against the new model.
+            const gridY = grid.contentY
+            const listY = listColumn.contentY
+            root._refreshTick++
+            Qt.callLater(() => Qt.callLater(() => {
+                grid.contentY = Math.min(gridY, Math.max(0, grid.contentHeight - grid.height))
+                listColumn.contentY =
+                    Math.min(listY, Math.max(0, listColumn.contentHeight - listColumn.height))
+            }))
+        }
+    }
+    function _requestRefresh() {
+        if (EditorState.assetPreviewWindowOpen)
+            root._refreshPending = true
+        else
+            refreshCoalesceTimer.restart()
     }
     Connections {
         target: EditorState
-        function onUndoStackChanged() { refreshCoalesceTimer.restart() }
+        function onUndoStackChanged() { root._requestRefresh() }
+        function onAssetPreviewWindowOpenChanged() {
+            if (!EditorState.assetPreviewWindowOpen && root._refreshPending) {
+                root._refreshPending = false
+                refreshCoalesceTimer.restart()
+            }
+        }
     }
     Connections {
         target: AssetLibrary
-        function onAssetMetadataChanged(assetId) { refreshCoalesceTimer.restart() }
+        // Only a card-level field (name/kind/duration/path) warrants rebuilding combinedItems;
+        // a thumbnail-only change (rotate, a thumbnail regenerating) refreshes its own delegate
+        // directly instead (see cardRoot/listRow's own Connections below) with no rebuild at all.
+        function onAssetCardChanged(assetId) { root._requestRefresh() }
     }
 
     // Tree view's flattened rows: the current folder's contents, with each open folder's
@@ -429,6 +464,20 @@ Item {
 
             readonly property bool selected: !isFolder && root.isAssetSelected(assetId)
 
+            // Bound to the model snapshot by default, but re-readable in place: a rotate/trim
+            // edit only ever changes this one card's thumbnail, so refreshing it directly here
+            // avoids MediaAssetsTab's full combinedItems rebuild (and the scroll-position
+            // flicker that comes with reassigning a GridView's whole model) for what is really a
+            // single-image update.
+            property string _liveThumbnailPath: thumbnailPath
+            Connections {
+                target: AssetLibrary
+                function onAssetMetadataChanged(assetId) {
+                    if (!cardRoot.isFolder && assetId === cardRoot.assetId)
+                        cardRoot._liveThumbnailPath = AssetLibrary.thumbnailAt(cardRoot.assetIndex)
+                }
+            }
+
             // Lift on grab: dims and grows slightly, so the card reads as
             // picked up rather than just sitting there while a ghost moves.
             opacity: assetDrag.active ? 0.85 : 1
@@ -506,15 +555,16 @@ Item {
                 SkeletonBox {
                     anchors.fill: parent
                     radius: parent.radius
-                    visible: !cardRoot.isFolder && thumbnailPath.length > 0
+                    visible: !cardRoot.isFolder && cardRoot._liveThumbnailPath.length > 0
                                 && gridThumb.status === Image.Loading
                 }
 
                 Image {
                     id: gridThumb
                     anchors.fill: parent
-                    visible: !cardRoot.isFolder && thumbnailPath.length > 0 && status === Image.Ready
-                    source: !cardRoot.isFolder && thumbnailPath.length > 0 ? EditorState.imageUrl(thumbnailPath) : ""
+                    visible: !cardRoot.isFolder && cardRoot._liveThumbnailPath.length > 0 && status === Image.Ready
+                    source: !cardRoot.isFolder && cardRoot._liveThumbnailPath.length > 0
+                            ? EditorState.imageUrl(cardRoot._liveThumbnailPath) : ""
                     fillMode: Image.PreserveAspectFit
                     asynchronous: true
                     // Fades in rather than popping at full opacity.
@@ -531,7 +581,7 @@ Item {
                     // thumbnail file falls back to the kind icon
                     // instead of staying blank forever.
                     visible: !cardRoot.isFolder
-                             && (thumbnailPath.length === 0 || gridThumb.status === Image.Error)
+                             && (cardRoot._liveThumbnailPath.length === 0 || gridThumb.status === Image.Error)
                     glyph: kind === "audio" ? Theme.icons.music
                             : kind === "image" ? Theme.icons.image
                             : Theme.icons.film
@@ -857,6 +907,17 @@ Item {
                 && EditorState.replacingAssetId === AssetLibrary.assetIdAt(assetIndex)
             readonly property bool selected: !isFolder && root.isAssetSelected(assetId)
 
+            // See the matching property on gridDelegate's cardRoot: lets a rotate/trim edit
+            // refresh just this row's thumbnail without MediaAssetsTab rebuilding the whole list.
+            property string _liveThumbnailPath: thumbnailPath
+            Connections {
+                target: AssetLibrary
+                function onAssetMetadataChanged(assetId) {
+                    if (!listRow.isFolder && assetId === listRow.assetId)
+                        listRow._liveThumbnailPath = AssetLibrary.thumbnailAt(listRow.assetIndex)
+                }
+            }
+
             Drag.active: !isFolder && rowDrag.active
             Drag.dragType: Drag.Automatic
             Drag.supportedActions: Qt.CopyAction
@@ -889,15 +950,16 @@ Item {
                     SkeletonBox {
                         anchors.fill: parent
                         radius: parent.radius
-                        visible: !listRow.isFolder && thumbnailPath.length > 0
+                        visible: !listRow.isFolder && listRow._liveThumbnailPath.length > 0
                                     && listThumb.status === Image.Loading
                     }
 
                     Image {
                         id: listThumb
                         anchors.fill: parent
-                        visible: !listRow.isFolder && thumbnailPath.length > 0 && status === Image.Ready
-                        source: !listRow.isFolder && thumbnailPath.length > 0 ? EditorState.imageUrl(thumbnailPath) : ""
+                        visible: !listRow.isFolder && listRow._liveThumbnailPath.length > 0 && status === Image.Ready
+                        source: !listRow.isFolder && listRow._liveThumbnailPath.length > 0
+                                ? EditorState.imageUrl(listRow._liveThumbnailPath) : ""
                         fillMode: Image.PreserveAspectFit
                         // Was missing, so list thumbnails decoded
                         // on the UI thread and stalled scrolling.
@@ -907,7 +969,7 @@ Item {
                     IconGlyph {
                         anchors.centerIn: parent
                         visible: listRow.isFolder
-                                    || thumbnailPath.length === 0 || listThumb.status === Image.Error
+                                    || listRow._liveThumbnailPath.length === 0 || listThumb.status === Image.Error
                         glyph: listRow.isFolder ? Theme.icons.folder
                                : (kind === "audio" ? Theme.icons.music : Theme.icons.film)
                         iconSize: Theme.iconSizeBase

--- a/src/qml/components/assets/ScenesTab.qml
+++ b/src/qml/components/assets/ScenesTab.qml
@@ -276,7 +276,8 @@ Item {
                                 ? ""
                                 : EditorState.filmstripTileUrl(
                                       EditorState.sceneClipPath, 0,
-                                      Math.floor(row.modelData.thumbnailSeconds))
+                                      Math.floor(row.modelData.thumbnailSeconds),
+                                      EditorState.sceneClipRotationCorrection)
                         }
                     }
                 }

--- a/src/qml/components/properties/TransformInspector.qml
+++ b/src/qml/components/properties/TransformInspector.qml
@@ -188,6 +188,45 @@ Item {
             }
 
             Text {
+                visible: root.clipKind === "video"
+                text: qsTr("Fix orientation")
+                color: Theme.mutedForeground
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeXs
+                font.weight: Font.Medium
+            }
+
+            Text {
+                visible: root.clipKind === "video"
+                width: parent.width
+                wrapMode: Text.WordWrap
+                text: qsTr("Corrects the source's own rotation losslessly — unlike Angle above, this changes decoding, not just the on-screen box.")
+                color: Theme.mutedForeground
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeXs
+            }
+
+            Flow {
+                visible: root.clipKind === "video"
+                width: parent.width
+                spacing: 6
+                Repeater {
+                    model: [0, 90, 180, 270]
+                    delegate: ThemedChip {
+                        required property int modelData
+                        text: modelData + "°"
+                        selected: {
+                            void root.clipDataRevision
+                            return Number(root.clipData.rotationOverride) === modelData
+                        }
+                        onClicked: EditorState.setClipOrientation(
+                                       EditorState.selectedTrack, EditorState.selectedClip,
+                                       modelData)
+                    }
+                }
+            }
+
+            Text {
                 text: qsTr("Flip")
                 color: Theme.mutedForeground
                 font.family: Theme.fontFamily

--- a/src/qml/components/properties/TransformInspector.qml
+++ b/src/qml/components/properties/TransformInspector.qml
@@ -217,7 +217,7 @@ Item {
                         text: modelData + "°"
                         selected: {
                             void root.clipDataRevision
-                            return Number(root.clipData.rotationOverride) === modelData
+                            return Number(root.clipData.orientation) === modelData
                         }
                         onClicked: EditorState.setClipOrientation(
                                        EditorState.selectedTrack, EditorState.selectedClip,

--- a/src/qml/components/timeline/TimelineClipItem.qml
+++ b/src/qml/components/timeline/TimelineClipItem.qml
@@ -511,6 +511,7 @@ Item {
             // Video only: on-demand tiles need a decodable video stream, and images/shapes
             // have a single poster frame that the strip already covers exactly.
             sourcePath: clipItem.clipData.kind === "video" ? (clipItem.clipData.path || "") : ""
+            rotationCorrection: clipItem.clipData.rotationCorrection || 0
             inPoint: clipItem.clipData.inPoint
             outPoint: clipItem.clipData.outPoint
             sourceDuration: clipItem.clipData.sourceDuration


### PR DESCRIPTION
- Bin preview: rotate a video asset in 90° steps (no re-encode); the chosen orientation carries over when it's added to the timeline.
- Timeline: new "Fix orientation" control re-orients an already-placed clip losslessly, separate from the free "Angle" effect, correctly rebasing box position/size — including animated ones, discontinuities and disabled tracks — instead of flattening them to one keyframe.
- Bin preview: a plain trim (Set In/Set Out, no crop) now stores a non-destructive srcIn/srcOut range instead of re-encoding, mirroring how a clip already on the timeline trims; placement math (gaps, batch cursor) accounts for the trimmed length. The cover thumbnail regenerates at the trim's Set In point.
- Crop-save now bakes the bin's rotation correction into the encoder output and rebases affected clips' overrides accordingly, instead of double-rotating or losing independent per-clip corrections.
- Preview window: added a time ruler and playhead to the trim strip; fixed a black first frame (this backend needs a play/pause kick to render at all, and reopening the same file needs a forced reload), a position that reset to 0 on every seek, a crash from unbounded seek recursion, and the media bin rebuilding/scrolling to top on every rotate or trim edit.
- Asset rotation/trim edits now correctly mark the project dirty without flagging on unrelated background thumbnail/probe updates.