### PR TITLE
Fix the five failing tests in the Windows CI job

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Windows checkouts default to core.autocrlf=true, which rewrites every text file's line endings
+# on the way out of git. Two kinds of file here are byte-compared against what a tool writes, and
+# those tools emit LF on every platform:
+#
+#   * i18n/*.ts — the Translations test runs lupdate and compares the result against the
+#     checkout. lupdate opens the catalog without QIODevice::Text, so it writes LF on Windows
+#     too, which made every catalog look stale there however recently it had been regenerated.
+#   * tests/data/** — fixtures matched against literals containing "\n"; tst_vector patches
+#     slide.json by searching for one, and silently found nothing to replace.
+#
+# Nothing in this tree wants CRLF, so normalise all of it rather than listing the tripwires.
+# No tracked text file carries a CR today, so this changes no committed bytes, and text=auto
+# leaves git's binary detection in charge of the fixtures that must not be rewritten at all.
+* text=auto eol=lf

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -438,8 +438,16 @@ jobs:
       # elevation on Windows. Roughly 16 tests QSKIP as a result; the rest is what this covers.
       #
       # Serial, not ctest -j: the suites share QStandardPaths::AppDataLocation test-mode state.
+      #
+      # QT_FORCE_STDERR_LOGGING is what makes a failure here legible at all. QPlainTestLogger
+      # diverts its whole stream to OutputDebugString when it is writing to stdout and stderr has
+      # no console attached (qplaintestlogger.cpp) — which is exactly ctest's pipe. Without it a
+      # failing suite reports only "***Failed" with not one FAIL! line to say which case or why,
+      # and qWarning/qFatal go the same way, so even a fatal startup error is invisible.
       - name: Test
         shell: pwsh
+        env:
+          QT_FORCE_STDERR_LOGGING: 1
         run: |
           $env:PATH = "${{ github.workspace }}\.deps\ffmpeg\bin;${{ env.QT_ROOT_DIR }}\bin;$env:PATH"
           ctest --test-dir build -C Release --output-on-failure

--- a/tests/tst_addonpackage.cpp
+++ b/tests/tst_addonpackage.cpp
@@ -97,6 +97,9 @@ void TestAddonPackage::installsAndVerifies()
     QFile family(dest + QStringLiteral("/fonts/testfamily/family.json"));
     QVERIFY(family.open(QIODevice::ReadOnly));
     QCOMPARE(family.readAll(), QByteArray(R"({"id":"testfamily","family":"Test Family"})"));
+    // Closed before reinstalling: Windows refuses to unlink an open file, so holding this handle
+    // failed the reinstall below in removeRecursively() rather than in anything it means to test.
+    family.close();
 
     // Installing again over an existing directory must succeed, not trip over the leftovers.
     QVERIFY2(install(m_fixture, dest, {}, &info, &error), qPrintable(error));

--- a/tests/tst_engine.cpp
+++ b/tests/tst_engine.cpp
@@ -3530,6 +3530,9 @@ void EngineTest::clipReaderAudioSequential()
 
 void EngineTest::compositorDefaultRenderStaysFullResolution()
 {
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
+
     drift::Project project;
     project.setResolution(192, 108);
     project.tracks().clear();
@@ -3553,6 +3556,9 @@ void EngineTest::compositorDefaultRenderStaysFullResolution()
 
 void EngineTest::compositorPreviewScaleRendersLowerResolution()
 {
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
+
     drift::Project project;
     project.setResolution(192, 108);
     project.tracks().clear();
@@ -3582,6 +3588,9 @@ void EngineTest::compositorPreviewScaleRendersLowerResolution()
 
 void EngineTest::compositorPreviewScaleMapsProjectPixelLayout()
 {
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
+
     // Project-pixel layout must be scaled onto the preview canvas so WYSIWYG
     // handles (which map project px → widget) stay aligned with the frame.
     drift::Project project;
@@ -3622,6 +3631,9 @@ void EngineTest::compositorPreviewScaleMapsProjectPixelLayout()
 // compositor, which is what the preview uses.
 void EngineTest::compositorAppliesFaceWarpFromBakedTrack()
 {
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
+
     QTemporaryDir dir;
     QVERIFY(dir.isValid());
 
@@ -3713,6 +3725,9 @@ void EngineTest::compositorAppliesFaceWarpFromBakedTrack()
 
 void EngineTest::compositorAppliesMultiplyBlendMode()
 {
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
+
     QTemporaryDir dir;
     QVERIFY(dir.isValid());
 
@@ -3815,6 +3830,9 @@ void EngineTest::compositorAnimatesKeyedEffectParam()
 
 void EngineTest::compositorRendersShapeClip()
 {
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
+
     drift::Project project;
     project.setResolution(128, 128);
     project.tracks().clear();
@@ -3847,6 +3865,9 @@ void EngineTest::compositorRendersShapeClip()
 // editing on the preview, where the QML editor stands in for the baked raster.
 void EngineTest::compositorSkipsClipBeingEdited()
 {
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
+
     drift::Project project;
     project.setResolution(128, 128);
     project.tracks().clear();
@@ -4299,6 +4320,9 @@ void EngineTest::rgbSplitZeroAmountPassthrough()
 
 void EngineTest::rgbSplitShiftsColorChannels()
 {
+    if (!GpuEffectExecutor::instance().isAvailable())
+        QSKIP("GPU effect executor unavailable");
+
     const QImage image = makeRedBlueSplitTestImage();
 
     drift::Effect effect;
@@ -4369,6 +4393,9 @@ void EngineTest::blockGlitchDeterministicForSameTimeAndSeed()
 
 void EngineTest::blockGlitchChangesWithTimelineTime()
 {
+    if (!GpuEffectExecutor::instance().isAvailable())
+        QSKIP("GPU effect executor unavailable");
+
     const QImage image = makeBlockGlitchTestImage();
     const drift::Effect effect = makeBlockGlitchEffect();
 
@@ -4429,6 +4456,9 @@ void EngineTest::scanlineGlitchDeterministicAtFixedTime()
 
 void EngineTest::scanlineGlitchVisualChangeAtNonzeroSettings()
 {
+    if (!GpuEffectExecutor::instance().isAvailable())
+        QSKIP("GPU effect executor unavailable");
+
     const QImage image = makeBlockGlitchTestImage();
     const drift::Effect effect = makeScanlineGlitchEffect();
 
@@ -4482,6 +4512,9 @@ void EngineTest::vhsCrtZeroSettingsPassthrough()
 
 void EngineTest::vhsCrtNonzeroModifiesOutput()
 {
+    if (!GpuEffectExecutor::instance().isAvailable())
+        QSKIP("GPU effect executor unavailable");
+
     const QImage image = makeVhsCrtTestImage();
     const drift::Effect effect = makeVhsCrtEffect();
 
@@ -4496,6 +4529,9 @@ void EngineTest::vhsCrtNonzeroModifiesOutput()
 
 void EngineTest::vhsCrtDeterministicAtFixedTime()
 {
+    if (!GpuEffectExecutor::instance().isAvailable())
+        QSKIP("GPU effect executor unavailable");
+
     const QImage image = makeVhsCrtTestImage();
     const drift::Effect effect = makeVhsCrtEffect();
     constexpr drift::TimeUs timeUs = 420'000;
@@ -4609,6 +4645,9 @@ void EngineTest::rippleWaterZeroAmplitudePassthrough()
 
 void EngineTest::rippleWaterNonzeroDisplacementChangesOutput()
 {
+    if (!GpuEffectExecutor::instance().isAvailable())
+        QSKIP("GPU effect executor unavailable");
+
     const QImage image = makeBlockGlitchTestImage();
     const drift::Effect effect = makeRippleWaterEffect();
 
@@ -4659,6 +4698,9 @@ void EngineTest::edgeNeonZeroIntensityUnchanged()
 
 void EngineTest::edgeNeonHighContrastRectangleGlow()
 {
+    if (!GpuEffectExecutor::instance().isAvailable())
+        QSKIP("GPU effect executor unavailable");
+
     const QImage image = makeHighContrastRectangleImage();
     const drift::Effect effect = makeEdgeNeonEffect();
 
@@ -4707,6 +4749,9 @@ void EngineTest::digitalGlitchZeroIntensityUnchanged()
 
 void EngineTest::digitalGlitchDeterministicForFixedTimeAndSeed()
 {
+    if (!GpuEffectExecutor::instance().isAvailable())
+        QSKIP("GPU effect executor unavailable");
+
     const QImage image = makeBlockGlitchTestImage();
     const drift::Effect effect = makeDigitalGlitchEffect();
     constexpr drift::TimeUs timeUs = 620'000;
@@ -4753,6 +4798,9 @@ void EngineTest::filmBurnZeroIntensityUnchanged()
 
 void EngineTest::filmBurnAddsWarmLeakContribution()
 {
+    if (!GpuEffectExecutor::instance().isAvailable())
+        QSKIP("GPU effect executor unavailable");
+
     QImage image(64, 64, QImage::Format_RGBA8888);
     image.fill(QColor(20, 22, 35));
 
@@ -4830,6 +4878,9 @@ static drift::Effect makeTimeEchoEffect(const QString &blendMode = QStringLitera
 
 void EngineTest::timeEchoDeterministicAtFixedTimelineTime()
 {
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
+
     QTemporaryDir dir;
     QVERIFY(dir.isValid());
     const QString path = makeColorSegmentsVideo(dir);
@@ -4863,6 +4914,9 @@ void EngineTest::timeEchoDeterministicAtFixedTimelineTime()
 
 void EngineTest::timeEchoBlendsPriorVideoFrames()
 {
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
+
     QTemporaryDir dir;
     QVERIFY(dir.isValid());
     const QString path = makeColorSegmentsVideo(dir);
@@ -4930,6 +4984,9 @@ void EngineTest::shockwavePulseZeroStrengthPassthrough()
 
 void EngineTest::shockwavePulseChangesPixelsNearWavefront()
 {
+    if (!GpuEffectExecutor::instance().isAvailable())
+        QSKIP("GPU effect executor unavailable");
+
     const QImage image = makeBlockGlitchTestImage();
     const drift::Effect effect = makeShockwavePulseEffect();
 
@@ -4950,6 +5007,9 @@ void EngineTest::shockwavePulseChangesPixelsNearWavefront()
 
 void EngineTest::compositorCrossfadeBetweenShapeClips()
 {
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
+
     drift::Project project;
     project.setResolution(128, 128);
     project.tracks().clear();
@@ -5034,6 +5094,9 @@ static void appendRedBlueShapeTransition(drift::Project &project, const QString 
 
 void EngineTest::compositorDipToBlackMidpointIsBlack()
 {
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
+
     drift::Project project;
     appendRedBlueShapeTransition(project, QStringLiteral("dip"));
 
@@ -5050,6 +5113,9 @@ void EngineTest::compositorDipToBlackMidpointIsBlack()
 
 void EngineTest::compositorWipeRightRevealsIncomingClip()
 {
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
+
     drift::Project project;
     appendRedBlueShapeTransition(project, QStringLiteral("wipe_right"));
 
@@ -5132,6 +5198,9 @@ void EngineTest::gpuTransitionBindsBothSources()
 // A broken shader must fall back to a CPU crossfade, never to a black frame or to clip A alone.
 void EngineTest::brokenTransitionShaderFallsBackToCrossfade()
 {
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
+
     QTemporaryDir dir;
     QVERIFY(dir.isValid());
     const QString pkg = QDir(dir.path()).filePath(QStringLiteral("broken"));
@@ -5170,6 +5239,9 @@ void EngineTest::brokenTransitionShaderFallsBackToCrossfade()
 // Rendering each side into its own full-canvas layer routes text through the normal path.
 void EngineTest::textClipRendersInsideTransition()
 {
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
+
     drift::Project project;
     project.setResolution(128, 128);
     project.tracks().clear();
@@ -5759,6 +5831,9 @@ void EngineTest::textAnimationFadesAndSlides()
 
 void EngineTest::clipBodyAnimationFadeRampsOpacity()
 {
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
+
     drift::Project project;
     project.setResolution(128, 128);
     project.tracks().clear();
@@ -6157,6 +6232,11 @@ void EngineTest::aVideoEffectsAdjustmentKeepsItsOwnMask()
 
 void EngineTest::exporterProducesPlayableFileWithBackground()
 {
+    // The exporter composites every frame it writes, so with no GPU compositor this
+    // produces a file of identical blank frames rather than anything worth asserting on.
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
+
     QTemporaryDir dir;
     QVERIFY(dir.isValid());
 
@@ -6962,6 +7042,11 @@ void EngineTest::exporterSupportsNtscFrameRates()
 // export is exactly the ceiling and 240 fps is past it.
 void EngineTest::exporterFrameRateAddsRealDetailToSlowedClips()
 {
+    // The exporter composites every frame it writes, so with no GPU compositor this
+    // produces a file of identical blank frames rather than anything worth asserting on.
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
+
     QTemporaryDir dir;
     QVERIFY(dir.isValid());
     const QString source = makeHighRateVideo(dir);

--- a/tests/tst_mcp.cpp
+++ b/tests/tst_mcp.cpp
@@ -29,6 +29,7 @@
 #include "mcp/McpProtocol.h"
 #include "mcp/McpSession.h"
 #include "mcp/McpStdio.h"
+#include "engine/GpuCompositor.h"
 #include "engine/ObjectDetector.h"
 #include "models/AppController.h"
 #include "TestZip.h"
@@ -3345,6 +3346,11 @@ void McpTest::framesUniformReturnsN()
 
 void McpTest::framesChangesDedupesFourShotClip()
 {
+    // The isError guard below is not enough here: a compositor that cannot draw still answers,
+    // with the same blank frame at every sample, and the changes sampler dedupes those down to
+    // the single frame this used to fail on. Nothing about dedupe is observable without one.
+    if (!GpuCompositor::isAvailable())
+        QSKIP("No GPU compositor available");
     if (ffmpegPath().isEmpty())
         QSKIP("ffmpeg not available to generate a test clip");
     QTemporaryDir dir;

--- a/tests/tst_vector.cpp
+++ b/tests/tst_vector.cpp
@@ -19,7 +19,11 @@ QByteArray fixture(const QString &name)
     QFile file(QStringLiteral(DRIFT_TEST_DATA_DIR "/vector/") + name);
     if (!file.open(QIODevice::ReadOnly))
         return {};
-    return file.readAll();
+    // Normalised rather than raw: inspectReportsExpressions patches the document by searching for
+    // a literal that spans a newline, and a CRLF working tree turns that into a silent no-op.
+    // .gitattributes pins these fixtures to LF now; this keeps the test honest in a checkout that
+    // predates it.
+    return file.readAll().replace("\r\n", "\n");
 }
 
 VectorSource slideSource()


### PR DESCRIPTION
Fixes the five failing test suites in the Windows packaging job. Three causes:

**Line endings** (`Translations`, `Vector`) — the tree had no `.gitattributes`, so the Windows runner checked out CRLF. `lupdate` always writes LF, so every `i18n/*.ts` looked stale; `tst_vector` patches `slide.json` with a literal spanning a newline, which then matched nothing. Added `* text=auto eol=lf` — changes no committed bytes.

**No OpenGL on the runner** (`Engine`, `Mcp`) — 28 GPU cases were missing the availability guard their neighbours already use, so they failed instead of skipping. Added `GpuCompositor::isAvailable()` / `GpuEffectExecutor::instance().isAvailable()`.

**Open file handle** (`AddonPackage`) — `installsAndVerifies` held `family.json` open while reinstalling over its directory, and Windows will not unlink an open file. Closed it first.

Also sets `QT_FORCE_STDERR_LOGGING=1` on the Test step: without it Qt routes all QTest output to `OutputDebugString`, which is why the original log had no `FAIL!` line to work from.

Verified — Windows 14/14 with the whole job green including the installer, Linux 14/14 with the guarded cases still running in full (Engine 11.71s both before and after).